### PR TITLE
Add alias for running in vs-code

### DIFF
--- a/Oqtane.Server/Scripts/Initialize.sql
+++ b/Oqtane.Server/Scripts/Initialize.sql
@@ -165,6 +165,9 @@ VALUES (1, N'localhost:44357', 1, 1)
 GO
 INSERT [dbo].[Alias] ([AliasId], [Name], [TenantId], [SiteId]) 
 VALUES (2, N'localhost:44357/site2', 1, 2)
+Go
+INSERT [dbo].[Alias] ([AliasId], [Name], [TenantId], [SiteId]) 
+values (3, 'localhost:14245', 1, 1)
 GO
 SET IDENTITY_INSERT [dbo].[Alias] OFF
 GO


### PR DESCRIPTION
This enables it to run with VS Code :)
The alias is required because otherwise an endpoint fails to respond