### PR TITLE
Missing nullcheck -> crash when 404

### DIFF
--- a/Oqtane.Client/Shared/SiteRouter.razor
+++ b/Oqtane.Client/Shared/SiteRouter.razor
@@ -196,7 +196,10 @@
             {
                 page = pages.Where(item => item.Path == path).FirstOrDefault();
                 reload = Reload.Page;
-                editmode = page.EditMode;
+                if (page!=null)
+                {
+                    editmode = page.EditMode;
+                }
             }
 
             user = null;


### PR DESCRIPTION
added nulcheck on page. 
when url is changed to nonexistent page exception was raised