### PR TITLE
Simplify NavigateUrl using UriBuilder

### DIFF
--- a/Oqtane.Shared/Oqtane.Shared.csproj
+++ b/Oqtane.Shared/Oqtane.Shared.csproj
@@ -18,6 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.Text.Json" Version="4.7.1" />
   </ItemGroup>

--- a/Oqtane.Shared/Oqtane.Shared.csproj
+++ b/Oqtane.Shared/Oqtane.Shared.csproj
@@ -18,7 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.Text.Json" Version="4.7.1" />
   </ItemGroup>

--- a/Oqtane.Shared/Shared/Utilities.cs
+++ b/Oqtane.Shared/Shared/Utilities.cs
@@ -14,30 +14,17 @@ namespace Oqtane.Shared
             var assemblyName = assemblyFullName.Substring(0,  assemblyFullName.IndexOf(",", StringComparison.Ordinal));
             return $"{type.Namespace}, {assemblyName}";
         }
+
         public static string NavigateUrl(string alias, string path, string parameters)
         {
-            string url = "";
-            if (alias != "")
-            {
-                url += alias + "/";
-            }
-            if (path != "" && path != "/")
-            {
-                url += path + "/";
-            }
-            if (url.EndsWith("/"))
-            {
-                url = url.Substring(0, url.Length - 1);
-            }
-            if (!string.IsNullOrEmpty(parameters))
-            {
-                url += "?" + parameters;
-            }
-            if (!url.StartsWith("/"))
-            {
-                url = "/" + url;
-            }
-            return url;
+            var uriBuilder = alias == string.Empty
+                ? new UriBuilder()
+                : new UriBuilder(alias);
+
+            uriBuilder.Path = path;
+            uriBuilder.Query = parameters;
+
+            return uriBuilder.Uri.AbsoluteUri;
         }
 
         public static string EditUrl(string alias, string path, int moduleid, string action, string parameters)

--- a/Oqtane.Shared/Shared/Utilities.cs
+++ b/Oqtane.Shared/Shared/Utilities.cs
@@ -2,6 +2,8 @@
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
 
 namespace Oqtane.Shared
 {
@@ -17,14 +19,29 @@ namespace Oqtane.Shared
 
         public static string NavigateUrl(string alias, string path, string parameters)
         {
-            var uriBuilder = alias == string.Empty
-                ? new UriBuilder()
-                : new UriBuilder(alias);
+            if (!alias.StartsWith("/"))
+            {
+                alias = $"/{alias}";
+            }
 
-            uriBuilder.Path = path;
-            uriBuilder.Query = parameters;
+            if (!path.StartsWith("/"))
+            {
+                path = $"/{path}";
+            }
 
-            return uriBuilder.Uri.AbsoluteUri;
+            var pathPaseValue = alias == string.Empty
+                ? default
+                : new PathString(alias);
+
+            var pathValue = path == string.Empty
+                ? default
+                : new PathString(path);
+
+            var queryStringValue = parameters == string.Empty
+                ? default
+                : new QueryString($"?{parameters}");
+
+            return UriHelper.BuildRelative(pathPaseValue, pathValue, queryStringValue);
         }
 
         public static string EditUrl(string alias, string path, int moduleid, string action, string parameters)

--- a/Oqtane.Shared/Shared/Utilities.cs
+++ b/Oqtane.Shared/Shared/Utilities.cs
@@ -2,8 +2,6 @@
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Extensions;
 
 namespace Oqtane.Shared
 {
@@ -19,29 +17,15 @@ namespace Oqtane.Shared
 
         public static string NavigateUrl(string alias, string path, string parameters)
         {
-            if (!alias.StartsWith("/"))
+            var uriBuilder = new UriBuilder
             {
-                alias = $"/{alias}";
-            }
+                Path = !string.IsNullOrEmpty(alias)
+                ? $"{alias}/{path}"
+                : $"{path}",
+                Query = parameters
+            };
 
-            if (!path.StartsWith("/"))
-            {
-                path = $"/{path}";
-            }
-
-            var pathPaseValue = alias == string.Empty
-                ? default
-                : new PathString(alias);
-
-            var pathValue = path == string.Empty
-                ? default
-                : new PathString(path);
-
-            var queryStringValue = parameters == string.Empty
-                ? default
-                : new QueryString($"?{parameters}");
-
-            return UriHelper.BuildRelative(pathPaseValue, pathValue, queryStringValue);
+            return uriBuilder.Uri.PathAndQuery;
         }
 
         public static string EditUrl(string alias, string path, int moduleid, string action, string parameters)

--- a/Oqtane.Test/Oqtane.Shared.Tests/UtilitiesTests.cs
+++ b/Oqtane.Test/Oqtane.Shared.Tests/UtilitiesTests.cs
@@ -6,22 +6,16 @@ namespace Oqtane.Test.Oqtane.Shared.Tests
     public class UtilitiesTests
     {
         [Theory]
-        [InlineData("contoso", "login", "returnUrl=/admin", "http://contoso/login?returnUrl=/admin")]
-        [InlineData("contoso", "admin", "", "http://contoso/admin")]
-        [InlineData("contoso", "", "pageId=4", "http://contoso/?pageId=4")]
-        [InlineData("contoso", "", "", "http://contoso/")]
-        [InlineData("http://contoso", "login", "returnUrl=/admin", "http://contoso/login?returnUrl=/admin")]
-        [InlineData("http://contoso", "admin", "", "http://contoso/admin")]
-        [InlineData("http://contoso", "", "pageId=4", "http://contoso/?pageId=4")]
-        [InlineData("http://contoso", "", "", "http://contoso/")]
-        [InlineData("https://contoso", "login", "returnUrl=/admin", "https://contoso/login?returnUrl=/admin")]
-        [InlineData("https://contoso", "admin", "", "https://contoso/admin")]
-        [InlineData("https://contoso", "", "pageId=4", "https://contoso/?pageId=4")]
-        [InlineData("https://contoso", "", "", "https://contoso/")]
-        [InlineData("", "login", "returnUrl=/admin", "http://localhost/login?returnUrl=/admin")]
-        [InlineData("", "admin", "", "http://localhost/admin")]
-        [InlineData("", "", "pageId=4", "http://localhost/?pageId=4")]
-        [InlineData("", "", "", "http://localhost/")]
+        [InlineData("contoso", "login", "returnUrl=/admin", "/contoso/login?returnUrl=/admin")]
+        [InlineData("contoso", "admin", "", "/contoso/admin")]
+        [InlineData("contoso", "", "pageId=4", "/contoso/?pageId=4")]
+        [InlineData("contoso", "", "pageId=4&moduleId=10", "/contoso/?pageId=4&moduleId=10")]
+        [InlineData("contoso", "", "", "/contoso/")]
+        [InlineData("", "login", "returnUrl=/admin", "/login?returnUrl=/admin")]
+        [InlineData("", "admin", "", "/admin")]
+        [InlineData("", "", "pageId=4", "/?pageId=4")]
+        [InlineData("", "", "pageId=4&moduleId=10", "/?pageId=4&moduleId=10")]
+        [InlineData("", "", "", "/")]
         public void NavigateUrlTest(string alias, string path, string parameters, string expectedUrl)
         {
             // Arrange

--- a/Oqtane.Test/Oqtane.Shared.Tests/UtilitiesTests.cs
+++ b/Oqtane.Test/Oqtane.Shared.Tests/UtilitiesTests.cs
@@ -8,13 +8,13 @@ namespace Oqtane.Test.Oqtane.Shared.Tests
         [Theory]
         [InlineData("contoso", "login", "returnUrl=/admin", "/contoso/login?returnUrl=/admin")]
         [InlineData("contoso", "admin", "", "/contoso/admin")]
-        [InlineData("contoso", "", "pageId=4", "/contoso/?pageId=4")]
-        [InlineData("contoso", "", "pageId=4&moduleId=10", "/contoso/?pageId=4&moduleId=10")]
+        [InlineData("contoso", "", "pageId=4", "/contoso?pageId=4")]
+        [InlineData("contoso", "", "pageId=4&moduleId=10", "/contoso?pageId=4&moduleId=10")]
         [InlineData("contoso", "", "", "/contoso/")]
         [InlineData("", "login", "returnUrl=/admin", "/login?returnUrl=/admin")]
         [InlineData("", "admin", "", "/admin")]
-        [InlineData("", "", "pageId=4", "/?pageId=4")]
-        [InlineData("", "", "pageId=4&moduleId=10", "/?pageId=4&moduleId=10")]
+        [InlineData("", "", "pageId=4", "?pageId=4")]
+        [InlineData("", "", "pageId=4&moduleId=10", "?pageId=4&moduleId=10")]
         [InlineData("", "", "", "/")]
         public void NavigateUrlTest(string alias, string path, string parameters, string expectedUrl)
         {

--- a/Oqtane.Test/Oqtane.Shared.Tests/UtilitiesTests.cs
+++ b/Oqtane.Test/Oqtane.Shared.Tests/UtilitiesTests.cs
@@ -1,0 +1,37 @@
+﻿using Oqtane.Shared;
+using Xunit;
+
+namespace Oqtane.Test.Oqtane.Shared.Tests
+{
+    public class UtilitiesTests
+    {
+        [Theory]
+        [InlineData("contoso", "login", "returnUrl=/admin", "http://contoso/login?returnUrl=/admin")]
+        [InlineData("contoso", "admin", "", "http://contoso/admin")]
+        [InlineData("contoso", "", "pageId=4", "http://contoso/?pageId=4")]
+        [InlineData("contoso", "", "", "http://contoso/")]
+        [InlineData("http://contoso", "login", "returnUrl=/admin", "http://contoso/login?returnUrl=/admin")]
+        [InlineData("http://contoso", "admin", "", "http://contoso/admin")]
+        [InlineData("http://contoso", "", "pageId=4", "http://contoso/?pageId=4")]
+        [InlineData("http://contoso", "", "", "http://contoso/")]
+        [InlineData("https://contoso", "login", "returnUrl=/admin", "https://contoso/login?returnUrl=/admin")]
+        [InlineData("https://contoso", "admin", "", "https://contoso/admin")]
+        [InlineData("https://contoso", "", "pageId=4", "https://contoso/?pageId=4")]
+        [InlineData("https://contoso", "", "", "https://contoso/")]
+        [InlineData("", "login", "returnUrl=/admin", "http://localhost/login?returnUrl=/admin")]
+        [InlineData("", "admin", "", "http://localhost/admin")]
+        [InlineData("", "", "pageId=4", "http://localhost/?pageId=4")]
+        [InlineData("", "", "", "http://localhost/")]
+        public void NavigateUrlTest(string alias, string path, string parameters, string expectedUrl)
+        {
+            // Arrange
+            var navigatedUrl = string.Empty;
+
+            // Act
+            navigatedUrl = Utilities.NavigateUrl(alias, path, parameters);
+
+            // Assert
+            Assert.Equal(expectedUrl, navigatedUrl);
+        }
+    }
+}


### PR DESCRIPTION
FYI I found a little tiny bug with the old implementation when we have url like `https://contoso?pageId=4` it should be `https://contoso/?pageId=4` to meet the standard