### PR TITLE
Fix NavigationUrl unit tests

### DIFF
--- a/Oqtane.Test/Oqtane.Shared.Tests/UtilitiesTests.cs
+++ b/Oqtane.Test/Oqtane.Shared.Tests/UtilitiesTests.cs
@@ -8,13 +8,13 @@ namespace Oqtane.Test.Oqtane.Shared.Tests
         [Theory]
         [InlineData("contoso", "login", "returnUrl=/admin", "/contoso/login?returnUrl=/admin")]
         [InlineData("contoso", "admin", "", "/contoso/admin")]
-        [InlineData("contoso", "", "pageId=4", "/contoso?pageId=4")]
-        [InlineData("contoso", "", "pageId=4&moduleId=10", "/contoso?pageId=4&moduleId=10")]
+        [InlineData("contoso", "", "pageId=4", "/contoso/?pageId=4")]
+        [InlineData("contoso", "", "pageId=4&moduleId=10", "/contoso/?pageId=4&moduleId=10")]
         [InlineData("contoso", "", "", "/contoso/")]
         [InlineData("", "login", "returnUrl=/admin", "/login?returnUrl=/admin")]
         [InlineData("", "admin", "", "/admin")]
-        [InlineData("", "", "pageId=4", "?pageId=4")]
-        [InlineData("", "", "pageId=4&moduleId=10", "?pageId=4&moduleId=10")]
+        [InlineData("", "", "pageId=4", "/?pageId=4")]
+        [InlineData("", "", "pageId=4&moduleId=10", "/?pageId=4&moduleId=10")]
         [InlineData("", "", "", "/")]
         public void NavigateUrlTest(string alias, string path, string parameters, string expectedUrl)
         {


### PR DESCRIPTION
>Please change the unit tests, a "/" is not required before a "?" unless the path = ""

@sbwalker you are right about adding `/` if the path = "", but it's required too for non empty path, you could try to run the unit tests