### PR TITLE
Fix null value for site template.

### DIFF
--- a/Oqtane.Server/Repository/SiteRepository.cs
+++ b/Oqtane.Server/Repository/SiteRepository.cs
@@ -593,7 +593,7 @@ namespace Oqtane.Repository
             // process site template
             if (string.IsNullOrEmpty(site.SiteTemplateType))
             {
-                var section = _config.GetSection("SiteTemplate");
+                var section = _config.GetSection("Installation:SiteTemplate");
                 if (section.Exists())
                 {
                     site.SiteTemplateType = section.Value;


### PR DESCRIPTION
When you add a new site template in the appconfig, the value is null. When adding the section and the value, the installation picks up your new template.