### PR TITLE
Fix empty string for default site template.

### DIFF
--- a/Oqtane.Server/Repository/SiteRepository.cs
+++ b/Oqtane.Server/Repository/SiteRepository.cs
@@ -596,7 +596,13 @@ namespace Oqtane.Repository
                 var section = _config.GetSection("Installation:SiteTemplate");
                 if (section.Exists())
                 {
-                    site.SiteTemplateType = section.Value;
+                    if(string.IsNullOrEmpty(section.Value)){
+                        site.SiteTemplateType = Constants.DefaultSiteTemplate;
+                    }
+                    else
+                    {
+                        site.SiteTemplateType = section.Value;
+                    }                    
                 }
                 else
                 {


### PR DESCRIPTION
The fix for #368 prevents the default site template from being used. The site builds, but the default three pages do not show.