### PR TITLE
Alias is unknown at time of installation.

### DIFF
--- a/Oqtane.Client/UI/Installer.razor
+++ b/Oqtane.Client/UI/Installer.razor
@@ -202,7 +202,7 @@
                 user.Password = _hostPassword;
                 user.Email = _hostEmail;
                 user.DisplayName = _hostUsername;
-                user = await UserService.AddUserAsync(user);
+                user = await UserService.AddUserAsync(user, null);
 
                 NavigationManager.NavigateTo("", true);
             }


### PR DESCRIPTION
Use the other overloaded method when initially installing the site.