### PR TITLE
ModuleCreator: WebAssembly references causes build error in some scenarios. 

### DIFF
--- a/Oqtane.Client/Modules/Admin/ModuleCreator/Templates/External/Client/[Owner].[Module]s.Module.Client.csproj
+++ b/Oqtane.Client/Modules/Admin/ModuleCreator/Templates/External/Client/[Owner].[Module]s.Module.Client.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.0-preview5.20216.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.0-preview5.20216.8" PrivateAssets="all" />
+<!--    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.0-preview5.20216.8" />-->
+<!--    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.0-preview5.20216.8" PrivateAssets="all" />-->
     <PackageReference Include="System.Net.Http.Json" Version="3.2.0-preview5.20210.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Works without them.

error:
Microsoft.NET.Sdk.Razor.StaticWebAssets.targets(195, 5): Duplicate base paths '/' for content root paths .......
https://gitter.im/aspnet/Blazor?at=5e915f6ee24b4d6c44fe1827