### PR TITLE
Fixed add profile property

### DIFF
--- a/Oqtane.Client/Modules/Admin/Profiles/Edit.razor
+++ b/Oqtane.Client/Modules/Admin/Profiles/Edit.razor
@@ -144,7 +144,7 @@
             {
                 profile = new Profile();
             }
-            
+
             profile.Name = _name;
             profile.Title = _title;
             profile.Description = _description;
@@ -154,8 +154,14 @@
             profile.DefaultValue = _defaultvalue;
             profile.IsRequired = (_isrequired == null ? false : Boolean.Parse(_isrequired));
             profile.IsPrivate = (_isprivate == null ? false : Boolean.Parse(_isprivate));
-            profile = await ProfileService.UpdateProfileAsync(profile);
-            
+            if (_profileid != -1)
+            {
+                profile = await ProfileService.UpdateProfileAsync(profile);
+            }else
+            {
+                profile = await ProfileService.AddProfileAsync(profile);
+            }
+
             await logger.LogInformation("Profile Saved {Profile}", profile);
             NavigationManager.NavigateTo(NavigateUrl());
         }


### PR DESCRIPTION
Adding a new profile property was going through the UpdateProfile method instead of AddProfile 
 method. Now uses the AddProfile method when there was no pre-existing id as already used earlier in the same function for same destinction