### PR TITLE
implement [OqtaneAssembly] and [OqtaneIgnore] attributes

### DIFF
--- a/Oqtane.Client/Oqtane.Client.csproj
+++ b/Oqtane.Client/Oqtane.Client.csproj
@@ -20,6 +20,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="Oqtane.Shared.OqtaneAssemblyAttribute">    
+    </AssemblyAttribute>
+  </ItemGroup>
+ 
+  <ItemGroup>
     <Compile Remove="Modules\Admin\ModuleCreator\Templates\**" />
     <Content Remove="Modules\Admin\ModuleCreator\Templates\**" />
     <EmbeddedResource Remove="Modules\Admin\ModuleCreator\Templates\**" />

--- a/Oqtane.Client/Services/ServiceBase.cs
+++ b/Oqtane.Client/Services/ServiceBase.cs
@@ -55,6 +55,7 @@ namespace Oqtane.Services
 
         protected async Task<T> GetJsonAsync<T>(string uri)
         {
+            Console.WriteLine($"Get: {uri}");
             var response = await _http.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, CancellationToken.None);
             if (CheckResponse(response) && ValidateJsonContent(response.Content))
             {
@@ -83,7 +84,6 @@ namespace Oqtane.Services
                 var result = await response.Content.ReadFromJsonAsync<TResult>();
                 return result;
             }
-
             return default;
         }
 
@@ -122,6 +122,8 @@ namespace Oqtane.Services
             if (response.StatusCode != HttpStatusCode.NoContent && response.StatusCode != HttpStatusCode.NotFound)
             {
                 //TODO: Log errors here
+                
+                Console.WriteLine($"Request: {response.RequestMessage.RequestUri}");
                 Console.WriteLine($"Response status: {response.StatusCode} {response.ReasonPhrase}");
             }
 

--- a/Oqtane.Server/Extensions/AssemblyExtensions.cs
+++ b/Oqtane.Server/Extensions/AssemblyExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Oqtane.Shared;
 
 // ReSharper disable once CheckNamespace
 namespace System.Reflection
@@ -31,5 +32,23 @@ namespace System.Reflection
             return assembly.GetTypes()
                 .Where(t => t.GetInterfaces().Contains(interfaceType));
         }
+
+        public static bool IsOqtaneAssembly(this Assembly assembly)
+        {
+            return Attribute.IsDefined(assembly, typeof(OqtaneAssemblyAttribute))
+//                || assembly.FullName.Contains(".Views")
+
+                // can be added for backward compatibility                
+//                || assembly.FullName.StartsWith("Oqtane.")
+//                || assembly.FullName.Contains(".Module.")
+//                || assembly.FullName.Contains(".Theme.")
+                ;
+        }
+
+        public static IEnumerable<Assembly> GetOqtaneAssemblies(this AppDomain appDomain)
+        {
+            return appDomain.GetAssemblies().Where(a => a.IsOqtaneAssembly());
+        }
+        
     }
 }

--- a/Oqtane.Server/Extensions/OqtaneMvcBuilderExtensions.cs
+++ b/Oqtane.Server/Extensions/OqtaneMvcBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 
@@ -16,10 +17,11 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             // load MVC application parts from module assemblies
-            foreach (var assembly in OqtaneServiceCollectionExtensions.GetOqtaneModuleAssemblies())
+            var assemblies = AppDomain.CurrentDomain.GetOqtaneAssemblies();
+            foreach (var assembly in assemblies)
             {
                 // check if assembly contains MVC Controllers
-                if (assembly.GetTypes().Where(t => t.IsSubclassOf(typeof(Controller))).ToArray().Length > 0)
+                if (assembly.GetTypes().Any(t => t.IsSubclassOf(typeof(Controller))))
                 {
                     var partFactory = ApplicationPartFactory.GetApplicationPartFactory(assembly);
                     foreach (var part in partFactory.GetApplicationParts(assembly))

--- a/Oqtane.Server/Extensions/StringExtensions.cs
+++ b/Oqtane.Server/Extensions/StringExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Oqtane.Extensions
+{
+    public static class StringExtensions
+    {
+        public static bool StartWithAnyOf(this string s, IEnumerable<string> list)
+        {
+            if (s == null)
+            {
+                return false;
+            }
+            return list.Any(f => s.StartsWith(f));
+        }
+    }
+}

--- a/Oqtane.Server/Oqtane.Server.csproj
+++ b/Oqtane.Server/Oqtane.Server.csproj
@@ -18,6 +18,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="Oqtane.Shared.OqtaneAssemblyAttribute">
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="Modules\HtmlText\Scripts\HtmlText.1.0.0.sql" />
     <EmbeddedResource Include="Modules\HtmlText\Scripts\HtmlText.Uninstall.sql" />
     <EmbeddedResource Include="Scripts\Master.0.9.0.sql" />

--- a/Oqtane.Server/Repository/ModuleDefinitionRepository.cs
+++ b/Oqtane.Server/Repository/ModuleDefinitionRepository.cs
@@ -168,8 +168,7 @@ namespace Oqtane.Repository
         {
             List<ModuleDefinition> moduleDefinitions = new List<ModuleDefinition>();
             // iterate through Oqtane module assemblies
-            Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies()
-                .Where(item => item.FullName.StartsWith("Oqtane.") || item.FullName.Contains(".Module.")).ToArray();
+            var assemblies = AppDomain.CurrentDomain.GetOqtaneAssemblies();
             foreach (Assembly assembly in assemblies)
             {
                 moduleDefinitions = LoadModuleDefinitionsFromAssembly(moduleDefinitions, assembly);
@@ -183,80 +182,82 @@ namespace Oqtane.Repository
             Type[] modulecontroltypes = assembly.GetTypes().Where(item => item.GetInterfaces().Contains(typeof(IModuleControl))).ToArray();
             foreach (Type modulecontroltype in modulecontroltypes)
             {
-                if (modulecontroltype.Name != "ModuleBase" && !modulecontroltype.Namespace.EndsWith(".Controls"))
-                {
-                    string[] typename = modulecontroltype.AssemblyQualifiedName?.Split(',').Select(item => item.Trim()).ToArray();
-                    string[] segments = typename[0].Split('.');
-                    Array.Resize(ref segments, segments.Length - 1);
-                    string moduleType = string.Join(".", segments);
-                    string qualifiedModuleType = moduleType + ", " + typename[1];
+                // Check if type should be ignored
+                if (modulecontroltype.Name == "ModuleBase" 
+                    || modulecontroltype.Namespace.EndsWith(".Controls")
+                    || Attribute.IsDefined(modulecontroltype,typeof(OqtaneIgnoreAttribute))) continue;
+                
+                string[] typename = modulecontroltype.AssemblyQualifiedName?.Split(',').Select(item => item.Trim()).ToArray();
+                string[] segments = typename[0].Split('.');
+                Array.Resize(ref segments, segments.Length - 1);
+                string moduleType = string.Join(".", segments);
+                string qualifiedModuleType = moduleType + ", " + typename[1];
 
-                    int index = moduledefinitions.FindIndex(item => item.ModuleDefinitionName == qualifiedModuleType);
-                    if (index == -1)
+                int index = moduledefinitions.FindIndex(item => item.ModuleDefinitionName == qualifiedModuleType);
+                if (index == -1)
+                {
+                    // determine if this module implements IModule
+                    Type moduletype = assembly
+                        .GetTypes()
+                        .Where(item => item.Namespace != null)
+                        .Where(item => item.Namespace.StartsWith(moduleType))
+                        .FirstOrDefault(item => item.GetInterfaces().Contains(typeof(IModule)));
+                    if (moduletype != null)
                     {
-                        // determine if this module implements IModule
-                        Type moduletype = assembly
-                            .GetTypes()
-                            .Where(item => item.Namespace != null)
-                            .Where(item => item.Namespace.StartsWith(moduleType))
-                            .FirstOrDefault(item => item.GetInterfaces().Contains(typeof(IModule)));
-                        if (moduletype != null)
+                        // get property values from IModule
+                        var moduleobject = Activator.CreateInstance(moduletype);
+                        moduledefinition = (ModuleDefinition)moduletype.GetProperty("ModuleDefinition").GetValue(moduleobject);
+                    }
+                    else
+                    {
+                        // set default property values
+                        moduledefinition = new ModuleDefinition
                         {
-                            // get property values from IModule
-                            var moduleobject = Activator.CreateInstance(moduletype);
-                            moduledefinition = (ModuleDefinition)moduletype.GetProperty("ModuleDefinition").GetValue(moduleobject);
-                        }
-                        else
-                        {
-                            // set default property values
-                            moduledefinition = new ModuleDefinition
-                            {
-                                Name = moduleType.Substring(moduleType.LastIndexOf(".") + 1),
-                                Description = "Manage " + moduleType.Substring(moduleType.LastIndexOf(".") + 1),
-                                Categories = ((qualifiedModuleType.StartsWith("Oqtane.Modules.Admin.")) ? "Admin" : "")
-                            };
-                        }
-                        // set internal properties
-                        moduledefinition.ModuleDefinitionName = qualifiedModuleType;
-                        moduledefinition.Version = ""; // will be populated from database
-                        moduledefinition.ControlTypeTemplate = moduleType + "." + Constants.ActionToken + ", " + typename[1];
-                        moduledefinition.AssemblyName = assembly.GetName().Name;
+                            Name = moduleType.Substring(moduleType.LastIndexOf(".") + 1),
+                            Description = "Manage " + moduleType.Substring(moduleType.LastIndexOf(".") + 1),
+                            Categories = ((qualifiedModuleType.StartsWith("Oqtane.Modules.Admin.")) ? "Admin" : "")
+                        };
+                    }
+                    // set internal properties
+                    moduledefinition.ModuleDefinitionName = qualifiedModuleType;
+                    moduledefinition.Version = ""; // will be populated from database
+                    moduledefinition.ControlTypeTemplate = moduleType + "." + Constants.ActionToken + ", " + typename[1];
+                    moduledefinition.AssemblyName = assembly.GetName().Name;
                         
-                        if (string.IsNullOrEmpty(moduledefinition.Categories))
-                        {
-                            moduledefinition.Categories = "Common";
-                        }
-                        if (moduledefinition.Categories == "Admin")
-                        {
-                            moduledefinition.Permissions = new List<Permission>
-                            {
-                                new Permission(PermissionNames.Utilize, Constants.AdminRole, true)
-                            }.EncodePermissions();
-                        }
-                        else
-                        {
-                            moduledefinition.Permissions = new List<Permission>
-                            {
-                                new Permission(PermissionNames.Utilize, Constants.AdminRole, true),
-                                new Permission(PermissionNames.Utilize, Constants.RegisteredRole, true)
-                            }.EncodePermissions();
-                        }
-                        moduledefinitions.Add(moduledefinition);
-                        index = moduledefinitions.FindIndex(item => item.ModuleDefinitionName == qualifiedModuleType);
-                    }
-                    moduledefinition = moduledefinitions[index];
-                    // actions
-                    var modulecontrolobject = Activator.CreateInstance(modulecontroltype);
-                    string actions = (string)modulecontroltype.GetProperty("Actions")?.GetValue(modulecontrolobject);
-                    if (!string.IsNullOrEmpty(actions))
+                    if (string.IsNullOrEmpty(moduledefinition.Categories))
                     {
-                        foreach (string action in actions.Split(','))
-                        {
-                            moduledefinition.ControlTypeRoutes += (action + "=" + modulecontroltype.FullName + ", " + typename[1] + ";");
-                        }
+                        moduledefinition.Categories = "Common";
                     }
-                    moduledefinitions[index] = moduledefinition;
+                    if (moduledefinition.Categories == "Admin")
+                    {
+                        moduledefinition.Permissions = new List<Permission>
+                        {
+                            new Permission(PermissionNames.Utilize, Constants.AdminRole, true)
+                        }.EncodePermissions();
+                    }
+                    else
+                    {
+                        moduledefinition.Permissions = new List<Permission>
+                        {
+                            new Permission(PermissionNames.Utilize, Constants.AdminRole, true),
+                            new Permission(PermissionNames.Utilize, Constants.RegisteredRole, true)
+                        }.EncodePermissions();
+                    }
+                    moduledefinitions.Add(moduledefinition);
+                    index = moduledefinitions.FindIndex(item => item.ModuleDefinitionName == qualifiedModuleType);
                 }
+                moduledefinition = moduledefinitions[index];
+                // actions
+                var modulecontrolobject = Activator.CreateInstance(modulecontroltype);
+                string actions = (string)modulecontroltype.GetProperty("Actions")?.GetValue(modulecontrolobject);
+                if (!string.IsNullOrEmpty(actions))
+                {
+                    foreach (string action in actions.Split(','))
+                    {
+                        moduledefinition.ControlTypeRoutes += (action + "=" + modulecontroltype.FullName + ", " + typename[1] + ";");
+                    }
+                }
+                moduledefinitions[index] = moduledefinition;
             }
 
             return moduledefinitions;

--- a/Oqtane.Server/Repository/SiteTemplateRepository.cs
+++ b/Oqtane.Server/Repository/SiteTemplateRepository.cs
@@ -22,8 +22,8 @@ namespace Oqtane.Repository
             List<SiteTemplate> siteTemplates = new List<SiteTemplate>();
 
             // iterate through Oqtane site template assemblies
-            Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies()
-                .Where(item => item.FullName.StartsWith("Oqtane.") || item.FullName.Contains(".SiteTemplate.")).ToArray();
+            var assemblies = AppDomain.CurrentDomain.GetOqtaneAssemblies();
+                
             foreach (Assembly assembly in assemblies)
             {
                 siteTemplates = LoadSiteTemplatesFromAssembly(siteTemplates, assembly);

--- a/Oqtane.Server/Repository/ThemeRepository.cs
+++ b/Oqtane.Server/Repository/ThemeRepository.cs
@@ -31,8 +31,7 @@ namespace Oqtane.Repository
             List<Theme> themes = new List<Theme>();
 
             // iterate through Oqtane theme assemblies
-            Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies()
-                .Where(item => item.FullName.StartsWith("Oqtane.") || item.FullName.Contains(".Theme.")).ToArray();
+            var assemblies = AppDomain.CurrentDomain.GetOqtaneAssemblies();
             foreach (Assembly assembly in assemblies)
             {
                 themes = LoadThemesFromAssembly(themes, assembly);

--- a/Oqtane.Server/Startup.cs
+++ b/Oqtane.Server/Startup.cs
@@ -41,7 +41,7 @@ namespace Oqtane
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc().AddNewtonsoftJson();
+            
             services.AddServerSideBlazor();
 
             // setup HttpClient for server side in a client side compatible fashion ( with auth cookie )
@@ -188,16 +188,13 @@ namespace Oqtane
             services.AddTransient<IUpgradeManager, UpgradeManager>();
 
             // load the external assemblies into the app domain
-            services.AddOqtaneModules();
-            services.AddOqtaneThemes();
-            services.AddOqtaneSiteTemplates();
+            services.AddOqtaneParts();
 
             services.AddMvc()
                 .AddOqtaneApplicationParts() // register any Controllers from custom modules
                 .AddNewtonsoftJson();
 
-            services.AddOqtaneServices();
-            services.AddOqtaneHostedServices();
+
 
             services.AddSwaggerGen(c =>
             {

--- a/Oqtane.Shared/Shared/OqtaneAssemblyAttribute.cs
+++ b/Oqtane.Shared/Shared/OqtaneAssemblyAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Oqtane.Shared
+{
+    [AttributeUsage(AttributeTargets.Assembly)]
+    public class OqtaneAssemblyAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    public class OqtaneIgnoreAttribute : Attribute
+    {
+    }
+}


### PR DESCRIPTION
* Breaking change, this should be added to project file in order to load oqtane dynamic parts
```
  <ItemGroup>
    <AssemblyAttribute Include="Oqtane.Shared.OqtaneAssemblyAttribute">
    </AssemblyAttribute>
  </ItemGroup>
```
* Project can contain more Oqtane types (Modules, Themes, SiteTemplates), removed file naming convention for them