### PR TITLE
Ignore abstract classes at loading

### DIFF
--- a/Oqtane.Server/Repository/ModuleDefinitionRepository.cs
+++ b/Oqtane.Server/Repository/ModuleDefinitionRepository.cs
@@ -194,6 +194,7 @@ namespace Oqtane.Repository
                 // Check if type should be ignored
                 if (modulecontroltype.Name == "ModuleBase"
                     || modulecontroltype.IsGenericType
+                    || modulecontroltype.IsAbstract
                     || Attribute.IsDefined(modulecontroltype, typeof(OqtaneIgnoreAttribute))
                 ) continue;
 


### PR DESCRIPTION
Abstract classes should be filtered, cannot be instantiated.