### PR TITLE
Add File and Path rules

### DIFF
--- a/Oqtane.Server/Controllers/FolderController.cs
+++ b/Oqtane.Server/Controllers/FolderController.cs
@@ -32,7 +32,7 @@ namespace Oqtane.Controllers
         public IEnumerable<Folder> Get(string siteid)
         {
             List<Folder> folders = new List<Folder>();
-            foreach(Folder folder in _folders.GetFolders(int.Parse(siteid)))
+            foreach (Folder folder in _folders.GetFolders(int.Parse(siteid)))
             {
                 if (_userPermissions.IsAuthorized(User, PermissionNames.Browse, folder.Permissions))
                 {
@@ -84,7 +84,7 @@ namespace Oqtane.Controllers
                 return null;
             }
         }
-        
+
         // POST api/<controller>
         [HttpPost]
         [Authorize(Roles = Constants.RegisteredRole)]
@@ -103,7 +103,7 @@ namespace Oqtane.Controllers
                         new Permission(PermissionNames.Edit, Constants.AdminRole, true),
                     }.EncodePermissions();
                 }
-                if (_userPermissions.IsAuthorized(User,PermissionNames.Edit, permissions))
+                if (_userPermissions.IsAuthorized(User, PermissionNames.Edit, permissions))
                 {
                     if (FolderPathValid(folder))
                     {
@@ -214,7 +214,8 @@ namespace Oqtane.Controllers
         private bool FolderPathValid(Folder folder)
         {
             // prevent folder path traversal and reserved devices
-            return (folder.Name.IndexOfAny(@"<>:""/\|?*".ToCharArray()) == -1 && 
+            return (folder.Name.IndexOfAny(Constants.InvalidFileNameChars) == -1 &&
+                    !Constants.InvalidFileNameEndingChars.Any(x => folder.Name.EndsWith(x)) &&
                     !Constants.ReservedDevices.Split(',').Contains(folder.Name.ToUpper().Split('.')[0]));
         }
     }

--- a/Oqtane.Shared/Shared/Constants.cs
+++ b/Oqtane.Shared/Shared/Constants.cs
@@ -1,4 +1,6 @@
-﻿namespace Oqtane.Shared
+﻿using System;
+
+namespace Oqtane.Shared
 {
     public class Constants
     {
@@ -43,6 +45,14 @@
 
         public const string ImageFiles = "jpg,jpeg,jpe,gif,bmp,png";
         public const string UploadableFiles = "jpg,jpeg,jpe,gif,bmp,png,mov,wmv,avi,mp4,mp3,doc,docx,xls,xlsx,ppt,pptx,pdf,txt,zip,nupkg";
-        public const string ReservedDevices = "CON,NUL,PRN,COM1,COM2,COM3,COM4,COM5,COM6,COM7,COM8,COM9,LPT1,LPT2,LPT3,LPT4,LPT5,LPT6,LPT7,LPT8,LPT9,CONIN$,CONOUT$";
+        public const string ReservedDevices = "CON,NUL,PRN,,COM0,COM1,COM2,COM3,COM4,COM5,COM6,COM7,COM8,COM9,LPT0,LPT1,LPT2,LPT3,LPT4,LPT5,LPT6,LPT7,LPT8,LPT9,CONIN$,CONOUT$";
+        public static readonly char[] InvalidFileNameChars =
+        {
+            '\"', '<', '>', '|', '\0', (Char) 1, (Char) 2, (Char) 3, (Char) 4, (Char) 5, (Char) 6, (Char) 7, (Char) 8,
+            (Char) 9, (Char) 10, (Char) 11, (Char) 12, (Char) 13, (Char) 14, (Char) 15, (Char) 16, (Char) 17, (Char) 18,
+            (Char) 19, (Char) 20, (Char) 21, (Char) 22, (Char) 23, (Char) 24, (Char) 25, (Char) 26, (Char) 27,
+            (Char) 28, (Char) 29, (Char) 30, (Char) 31, ':', '*', '?', '\\', '/'
+        };
+        public static readonly string[] InvalidFileNameEndingChars = { ".", " " };
     }
 }


### PR DESCRIPTION
Apply the file and path naming rules found at [Naming Files, Paths, and Namespaces](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file)

Mitigate path traversal.