### PR TITLE
Fix site router.

### DIFF
--- a/Oqtane.Client/UI/SiteRouter.razor
+++ b/Oqtane.Client/UI/SiteRouter.razor
@@ -173,7 +173,7 @@
 
             if (alias.Path != "")
             {
-                path = path.Replace(alias.Path + "/", "");
+                path = Regex.Replace(path, $"^{alias.Path}/", "");
             }
 
             // extract admin route elements from path

--- a/Oqtane.Client/UI/SiteRouter.razor
+++ b/Oqtane.Client/UI/SiteRouter.razor
@@ -1,5 +1,6 @@
 ﻿@using System.Diagnostics.CodeAnalysis
 @using System.Runtime.InteropServices
+@using System.Text.RegularExpressions
 @namespace Oqtane.UI
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject SiteState SiteState


### PR DESCRIPTION
When page name ends in the same value as the alias the path becomes invalid.

The scenario I had was that the alias was the word **fusion** and the page name was **homefusion**.

This lead to **fusion/homefusion/** becoming **home**. 

The consequence was that I kept getting "Page Does Not Exist Or User Is Not Authorized To View Page home" when I tried to edit the page. After applying the fix described in the pull request the page editing feature worked as expected.