### PR TITLE
Site Settings: removes ONLY " <Select Container>"Theme and Layout drop down options

### DIFF
--- a/Oqtane.Client/Modules/Admin/Site/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Site/Index.razor
@@ -56,7 +56,6 @@
             </td>
             <td>
                 <select id="defaultTheme" class="form-control" @onchange="(e => ThemeChanged(e))">
-                    <option value="">&lt;Select Theme&gt;</option>
                     @foreach (KeyValuePair<string, string> item in _themes)
                     {
                         if (item.Key == _themetype)
@@ -77,7 +76,6 @@
             </td>
             <td>
                 <select id="defaultLayout" class="form-control" @bind="@_layouttype">
-                    <option value="">&lt;Select Layout&gt;</option>
                     @foreach (KeyValuePair<string, string> panelayout in _panelayouts)
                     {
                         <option value="@panelayout.Key">@panelayout.Value</option>
@@ -91,7 +89,6 @@
             </td>
             <td>
                 <select id="defaultContainer" class="form-control" @bind="@_containertype">
-                    <option value="">&lt;Select Container&gt;</option>
                     @foreach (KeyValuePair<string, string> container in _containers)
                     {
                         <option value="@container.Key">@container.Value</option>


### PR DESCRIPTION
Fixes #537 

_Edited:_

**Select Theme, Select Layout** and **Select Container** options removed from the dropdown lists for selecting site default theme, layout and container.

    '<Select Theme>'  *** REMOVED ***
    Blazor
    Oqtane

**Reason:**
1.  This option will brick Oqtane Dashboard
2.  Oqtane is default option, why include "Select Theme" when you have label and help icon, too redundant and makes something more for your eyes to view that is irrelevant in a way self explanatory.