### PR TITLE
Oqtane Theme:  Adjustment to nav items padding and size

### DIFF
--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
@@ -12,8 +12,8 @@ body {
 }
 
 .app-menu .nav-item {
-    font-size: 0.9rem;
-    padding-bottom: 0.5rem;
+    font-size: 1rem;
+    padding-bottom: -0.5rem;
 }
 
 .app-menu .nav-item a {


### PR DESCRIPTION
I believe this may help the following issue with the Oqtane Theme.
Does not by may... fixes #467 (discovered while reviewing this issue)

This PR will:

- Adjust App-Menu Nav item CSS for Oqtane Theme
- Nav Items will be bigger and the bottom of the buttons will align with the bottom of the 'oqtane' characters
 
Screenshots:  

![image](https://user-images.githubusercontent.com/13577556/82838756-0381d980-9e82-11ea-8159-402dc39c2b0b.png)

![image](https://user-images.githubusercontent.com/13577556/82838794-244a2f00-9e82-11ea-90a9-6997a722ef1c.png)


Notes:
I think the offsetting of the logo should be done with CSS instead of adjusting the logo position in the palette.  This way any logo uploaded will look good and this CSS will need adjusted to allow that to happen along with the logo.

A fixed up version of the logo (Centered) is below (White) I can adjust this PR for this logo which I recommend.  Or you can change it using your app so the images stay a same or I can create another PR submitting the logo fix for the Oqtane theme with the CSS adjustments later.

![logo-white](https://user-images.githubusercontent.com/13577556/82838494-468f7d00-9e81-11ea-85c6-7f3e679c984e.png)

Or we can close this if not an issue or desired solution for Oqtane Theme style.
