### PR TITLE
Fixed type filtering in assembly extensions

### DIFF
--- a/Oqtane.Shared/Extensions/AssemblyExtensions.cs
+++ b/Oqtane.Shared/Extensions/AssemblyExtensions.cs
@@ -35,14 +35,14 @@ namespace System.Reflection
 
             return assembly.GetTypes()
                 //.Where(t => t.GetInterfaces().Contains(interfaceType));
-                .Where(x => interfaceType.IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract);
+                .Where(x => !x.IsInterface && !x.IsAbstract && interfaceType.IsAssignableFrom(x));
         }
-        
+
         public static IEnumerable<Type> GetTypes<T>(this Assembly assembly)
         {
             return assembly.GetTypes(typeof(T));
         }
-        
+
         public static IEnumerable<T> GetInstances<T>(this Assembly assembly) where T : class
         {
             if (assembly is null)
@@ -51,7 +51,7 @@ namespace System.Reflection
             }
             var type = typeof(T);
             var list = assembly.GetTypes()
-                .Where(x => type.IsAssignableFrom(x) && !x.IsInterface && !x.IsAbstract && !x.IsGenericType);
+                .Where(x => !x.IsInterface && !x.IsAbstract && !x.IsGenericType && type.IsAssignableFrom(x));
 
             foreach (var type1 in list)
             {


### PR DESCRIPTION
During tests adding third party dlls to external modules we have found an issue within the loading process of the external module. This issue is responsible that under some specific circumstances the loading process of the external module crashes with an exception.

This PR resolves the possible issue by changing the filter logic of types a little bit. Now the logic tests the reflected properties before the Type.isAssignableFrom method is called. This prevents that Type.isAssignableFrom is called for invalid types (e.g. abstract types etc.).