### PR TITLE
Url parameter helper enhancements

### DIFF
--- a/Oqtane.Client/Modules/ModuleBase.cs
+++ b/Oqtane.Client/Modules/ModuleBase.cs
@@ -44,6 +44,26 @@ namespace Oqtane.Modules
 
         public virtual List<Resource> Resources { get; set; }
 
+        public virtual string UrlParametersTemplate { get; set; } = "";
+        public virtual Dictionary<string, string> UrlParamerters
+        {
+            get
+            {
+                var urlparameters = new Dictionary<string, string>();
+
+                var templates = UrlParametersTemplate.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                foreach (var template in templates)
+                {
+                    urlparameters = GetUrlParameters(template);
+
+                    if (urlparameters.Count > 0) goto Return;
+                }
+
+                Return:
+                return urlparameters;
+            }
+        }
+
         // base lifecycle method for handling JSInterop script registration
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -116,7 +136,7 @@ namespace Oqtane.Modules
             return Utilities.ContentUrl(PageState.Alias, fileid);
         }
 
-        public Dictionary<string, string> GetUrlParameters(string parameterTemplate)
+        public virtual Dictionary<string, string> GetUrlParameters(string parameterTemplate)
         {
             var urlParameters = new Dictionary<string, string>();
 
@@ -131,7 +151,7 @@ namespace Oqtane.Modules
                     {
                         if (templateSegments[i] == parameters[i])
                         {
-                            urlParameters.TryAdd("action" + actionId, parameters[i]);
+                            urlParameters.TryAdd("parameter" + actionId, parameters[i]);
                             actionId += 1;
                         }
                         else if (templateSegments[i].StartsWith("{") && templateSegments[i].EndsWith("}"))

--- a/Oqtane.Client/Modules/ModuleBase.cs
+++ b/Oqtane.Client/Modules/ModuleBase.cs
@@ -122,7 +122,7 @@ namespace Oqtane.Modules
 
             var templateSegments = parameterTemplate.Split('/', StringSplitOptions.RemoveEmptyEntries);
             var parameters = PageState.UrlParameters.Split('/', StringSplitOptions.RemoveEmptyEntries);
-
+            var actionId = 1;
             if (parameters.Length == templateSegments.Length)
             {
                 for (int i = 0; i < parameters.Length; i++)
@@ -131,6 +131,8 @@ namespace Oqtane.Modules
                     {
                         if (templateSegments[i] == parameters[i])
                         {
+                            urlParameters.TryAdd("action" + actionId, parameters[i]);
+                            actionId += 1;
                         }
                         else if (templateSegments[i].StartsWith("{") && templateSegments[i].EndsWith("}"))
                         {


### PR DESCRIPTION
Currently the url parameter segments that are not variables are being discarded. It would be helpful to developers to be able to access the "action" segments, example:
`$"{{{parentId}}}/Edit/{{{childId}}}"` and `$"{{{parentId}}}/View/{{{childId}}}"`
Saving the "action" segments allows the developer to parse which "page" they are on if they want to ie: `Edit` or `View`

```csharp
            if (UrlParamerters.ContainsKey("action1"))
            {
                switch (UrlParamerters["action1"])
                {
                    case "Edit":
                        //set parameters
                        break;

                    case "View":
                        //set parameters
                        break;

                    default:
                        break;
                }
            }