### PR TITLE
Page path validation

### DIFF
--- a/Oqtane.Client/Modules/Admin/Pages/Add.razor
+++ b/Oqtane.Client/Modules/Admin/Pages/Add.razor
@@ -346,6 +346,12 @@
                     }
                 }
 
+                if (!PagePathIsUnique(page.Path, page.SiteId, _pageList))
+                {
+                    AddModuleMessage($"A page with path {_path} already exists for the selected parent page. The page path needs to be unique for the selected parent.", MessageType.Warning);
+                    return;
+                }
+
                 Page child;
                 switch (_insert)
                 {
@@ -407,4 +413,8 @@
         }
     }
 
+    private static bool PagePathIsUnique(string pagePath, int siteId, List<Page> existingPages)
+    {
+        return !existingPages.Any(page => page.SiteId == siteId && page.Path == pagePath);
+    }
 }

--- a/Oqtane.Client/Modules/Admin/Pages/Edit.razor
+++ b/Oqtane.Client/Modules/Admin/Pages/Edit.razor
@@ -333,7 +333,7 @@
             _children = new List<Page>();
             if (_parentid == "-1")
             {
-                foreach(Page p in PageState.Pages.Where(item => item.ParentId == null))
+                foreach (Page p in PageState.Pages.Where(item => item.ParentId == null))
                 {
                     if (UserSecurity.IsAuthorized(PageState.User, PermissionNames.View, p.Permissions))
                     {
@@ -433,6 +433,13 @@
                         page.Path = parent.Path + "/" + Utilities.GetFriendlyUrl(_path);
                     }
                 }
+
+                if (!PagePathIsUnique(page.Path, page.SiteId, page.PageId, _pageList))
+                {
+                    AddModuleMessage($"A page with path {_path} already exists for the selected parent page. The page path needs to be unique for the selected parent.", MessageType.Warning);
+                    return;
+                }
+
                 if (_insert != "=")
                 {
                     Page child;
@@ -511,5 +518,10 @@
             await logger.LogError(ex, "Error Saving Page {Page} {Error}", page, ex.Message);
             AddModuleMessage("Error Saving Page", MessageType.Error);
         }
+    }
+
+    private static bool PagePathIsUnique(string pagePath, int siteId, int pageId, List<Page> existingPages)
+    {
+        return !existingPages.Any(page => page.SiteId == siteId && page.Path == pagePath && page.PageId != pageId);
     }
 }


### PR DESCRIPTION
Closes #626 

The reason for the Exception described in #626 was the fact that the path of a page contains to a unique index in the db. And because the "deleted" page still existed with the deleted flag also the path still existed. The creation of a page with the exact same name leads to an exact same path like the one that still exists. This fact than hearts the unique index rule during the db update.

This could also happen if an user with permissions to change or add pages enters a path for the page that already exists for the selected parent page.

With this PR a path validation was implemented that prevents a user to enter an already existing path. 