### PR TITLE
Fix directory separator in InstallationManager

### DIFF
--- a/Oqtane.Server/Infrastructure/InstallationManager.cs
+++ b/Oqtane.Server/Infrastructure/InstallationManager.cs
@@ -88,7 +88,7 @@ namespace Oqtane.Infrastructure
                             // deploy to appropriate locations
                             foreach (ZipArchiveEntry entry in archive.Entries)
                             {
-                                string foldername = Path.GetDirectoryName(entry.FullName).Split('\\')[0];
+                                string foldername = Path.GetDirectoryName(entry.FullName).Split(Path.DirectorySeparatorChar)[0];
                                 string filename = Path.GetFileName(entry.FullName);
 
                                 switch (foldername)
@@ -98,7 +98,7 @@ namespace Oqtane.Infrastructure
                                         ExtractFile(entry, filename);
                                         break;
                                     case "wwwroot":
-                                        filename = Path.Combine(webRootPath, Utilities.PathCombine(entry.FullName.Replace("wwwroot/", "").Split('/')));
+                                        filename = Path.Combine(webRootPath, Utilities.PathCombine(entry.FullName.Replace($"wwwroot{Path.DirectorySeparatorChar}", "").Split(Path.DirectorySeparatorChar)));
                                         ExtractFile(entry, filename);
                                         break;
                                 }


### PR DESCRIPTION
When running Oqtane on Linux Theme installation is failing. The root cause appears to be the handling of the directory splitting in the **InstallationManager**. Here a fixed string is used.

This should be changed to `Path.DirectorySeparatorChar` to be handled based on the runtime platform.

I have tested this change on Ubuntu and Windows.