### PR TITLE
Add project reference for dotnet publish to work without errors.

### DIFF
--- a/Oqtane.Server/Oqtane.Server.csproj
+++ b/Oqtane.Server/Oqtane.Server.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Oqtane.Client\Oqtane.Client.csproj" />
     <ProjectReference Include="..\Oqtane.Shared\Oqtane.Shared.csproj" />
+    <ProjectReference Include="..\Oqtane.Upgrade\Oqtane.Upgrade.csproj" />
   </ItemGroup>
   <ItemGroup>
     <UpgradeFiles Include="$(ProjectDir)bin\Release\netcoreapp3.1\Oqtane.Upgrade.deps.json" />


### PR DESCRIPTION
It seems when you navigate to the Oqtane.Server folder and run ```dotnet publish``` there is an error. Adding a project reference to the Upgrade project fixes that error.

You can follow the discussion here at:
https://github.com/oqtane/oqtane.framework/discussions/681