### PR TITLE
Delete module pluralization in the location display.

### DIFF
--- a/Oqtane.Client/Modules/Admin/ModuleCreator/Index.razor
+++ b/Oqtane.Client/Modules/Admin/ModuleCreator/Index.razor
@@ -105,11 +105,11 @@
                     string[] path = systeminfo["serverpath"].Split('\\');
                     if (_template == "internal")
                     {
-                        _location = string.Join("\\", path, 0, path.Length - 1) + "\\Oqtane.Client\\Modules\\" + _owner + "." + _module + "s";
+                        _location = string.Join("\\", path, 0, path.Length - 1) + "\\Oqtane.Client\\Modules\\" + _owner + "." + _module;
                     }
                     else
                     {
-                        _location = string.Join("\\", path, 0, path.Length - 2) + "\\" + _owner + "." + _module + "s";
+                        _location = string.Join("\\", path, 0, path.Length - 2) + "\\" + _owner + "." + _module;
                     }
                 }
             }


### PR DESCRIPTION
Module pluralization was deleted in #683. 