### PR TITLE
Allows page to find Custom Index page in Module from Actions Property

### DIFF
--- a/Oqtane.Client/UI/SiteRouter.razor
+++ b/Oqtane.Client/UI/SiteRouter.razor
@@ -76,7 +76,7 @@
         User user = null;
         List<Module> modules;
         var moduleid = -1;
-        var action = string.Empty;
+        var action = Constants.DefaultAction;
         var urlparameters = string.Empty;
         var editmode = false;
         var reload = Reload.None;
@@ -459,25 +459,18 @@
                     typename = Constants.ErrorModule;
                 }
 
-                if (module.ModuleId == moduleid && action != "")
+                // check if the module defines custom routes*@
+                if (module.ModuleDefinition.ControlTypeRoutes != "")
                 {
-                    // check if the module defines custom routes
-                    if (module.ModuleDefinition.ControlTypeRoutes != "")
+                    foreach (string route in module.ModuleDefinition.ControlTypeRoutes.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
                     {
-                        foreach (string route in module.ModuleDefinition.ControlTypeRoutes.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+                        if (route.StartsWith(action + "="))
                         {
-                            if (route.StartsWith(action + "="))
-                            {
-                                typename = route.Replace(action + "=", "");
-                            }
+                            typename = route.Replace(action + "=", "");
                         }
                     }
-                    module.ModuleType = typename.Replace(Constants.ActionToken, action);
                 }
-                else
-                {
-                    module.ModuleType = typename.Replace(Constants.ActionToken, Constants.DefaultAction);
-                }
+                module.ModuleType = typename.Replace(Constants.ActionToken, action);
 
                 // get additional metadata from IModuleControl interface
                 typename = module.ModuleType;

--- a/Oqtane.Client/UI/SiteRouter.razor
+++ b/Oqtane.Client/UI/SiteRouter.razor
@@ -202,6 +202,7 @@
                 {
                     modIdPos = i + 1;
                     actionPos = modIdPos + 1;
+                    // Route to index page if no action is specifed
                     if (actionPos > segments.Length - 1)
                     {
                         action = Constants.DefaultAction;


### PR DESCRIPTION
added after this discussion post was made: #765
This if statement just checks if the route is inside a Module, we do not need to check that anymore because the Index Page should always be displayed if we are not in the Module. ` if (module.ModuleId == moduleid && action != "")`  Which is why we set this `var action = Constants.DefaultAction;` Which basically the same thing that this was doing: `else{module.ModuleType = typename.Replace(Constants.ActionToken, Constants.DefaultAction);}`
I did test this with an External Module and the internal HtmlText Module, I did not find any errors.