### PR TITLE
Skip missed satellite assemblies forlders

### DIFF
--- a/Oqtane.Server/Controllers/InstallationController.cs
+++ b/Oqtane.Server/Controllers/InstallationController.cs
@@ -79,14 +79,22 @@ namespace Oqtane.Controllers
                 // Get the satellite assemblies
                 foreach (var culture in _localizationManager.GetSupportedCultures())
                 {
+                    var assembliesFolderPath = Path.Combine(binFolder, culture);
                     if (culture == Constants.DefaultCulture)
                     {
                         continue;
                     }
 
-                    foreach (var resourceFile in Directory.EnumerateFiles(Path.Combine(binFolder, culture)))
+                    if(Directory.Exists(assembliesFolderPath))
                     {
-                        list.Add(Path.Combine(culture, Path.GetFileNameWithoutExtension(resourceFile)));
+                        foreach (var resourceFile in Directory.EnumerateFiles(assembliesFolderPath))
+                        {
+                            list.Add(Path.Combine(culture, Path.GetFileNameWithoutExtension(resourceFile)));
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine($"The satellite assemblies folder named '{culture}' is not found.");
                     }
                 }
 

--- a/Oqtane.Server/Extensions/OqtaneServiceCollectionExtensions.cs
+++ b/Oqtane.Server/Extensions/OqtaneServiceCollectionExtensions.cs
@@ -141,28 +141,35 @@ namespace Microsoft.Extensions.DependencyInjection
                 }
 
                 var assembliesFolder = new DirectoryInfo(Path.Combine(assemblyPath, culture));
-                foreach (var assemblyFile in assembliesFolder.EnumerateFiles(Constants.StalliteAssemblyExtension))
+                if (assembliesFolder.Exists)
                 {
-                    AssemblyName assemblyName;
-                    try
+                    foreach (var assemblyFile in assembliesFolder.EnumerateFiles(Constants.StalliteAssemblyExtension))
                     {
-                        assemblyName = AssemblyName.GetAssemblyName(assemblyFile.FullName);
-                    }
-                    catch
-                    {
-                        Console.WriteLine($"Not Satellite Assembly : {assemblyFile.Name}");
-                        continue;
-                    }
+                        AssemblyName assemblyName;
+                        try
+                        {
+                            assemblyName = AssemblyName.GetAssemblyName(assemblyFile.FullName);
+                        }
+                        catch
+                        {
+                            Console.WriteLine($"Not Satellite Assembly : {assemblyFile.Name}");
+                            continue;
+                        }
 
-                    try
-                    {
-                        Assembly assembly = AssemblyLoadContext.Default.LoadFromStream(new MemoryStream(File.ReadAllBytes(assemblyFile.FullName)));
-                        Console.WriteLine($"Loaded : {assemblyName}");
+                        try
+                        {
+                            Assembly assembly = AssemblyLoadContext.Default.LoadFromStream(new MemoryStream(File.ReadAllBytes(assemblyFile.FullName)));
+                            Console.WriteLine($"Loaded : {assemblyName}");
+                        }
+                        catch (Exception e)
+                        {
+                            Console.WriteLine($"Failed : {assemblyName}\n{e}");
+                        }
                     }
-                    catch (Exception e)
-                    {
-                        Console.WriteLine($"Failed : {assemblyName}\n{e}");
-                    }
+                }
+                else
+                {
+                    Console.WriteLine($"The satellite assemblies folder named '{culture}' is not found.");
                 }
             }
         }


### PR DESCRIPTION
Make sure that the application will not crash if satellite assemblies folders are missing, this could happen due any reason for example:

- Satellite assemblies for a particular culture are not deployed correctly

- The `SupportedCultures` contains non deployed resources, this could be done by adding extra cultures accidentally