### PR TITLE
Update SiteRouter.razor

### DIFF
--- a/Oqtane.Client/UI/SiteRouter.razor
+++ b/Oqtane.Client/UI/SiteRouter.razor
@@ -455,7 +455,7 @@
                 }
 
                 // handle default action
-                if (action == Constants.DefaultAction && !string.IsNullOrEmpty(module.ModuleDefinition.DefaultAction))
+                if (action == Constants.DefaultAction && !string.IsNullOrEmpty(module.ModuleDefinition?.DefaultAction))
                 {
                     action = module.ModuleDefinition.DefaultAction;
                 }


### PR DESCRIPTION
not every class that inherits from ModuleBase implements iModule.  So it's possible to add a module without a ModuleDefinition.  In that case the default action should be Index.