### PR TITLE
Simplify localization settings configurations

### DIFF
--- a/Oqtane.Server/Extensions/WebHostBuilderExtensions.cs
+++ b/Oqtane.Server/Extensions/WebHostBuilderExtensions.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Oqtane.Infrastructure;
+
+namespace Microsoft.AspNetCore.Hosting
+{
+    public static class WebHostBuilderExtensions
+    {
+        public static IWebHostBuilder ConfigureLocalizationSettings(this IWebHostBuilder builder)
+        {
+            return builder.ConfigureServices((context, services) =>
+            {
+                var config = context.Configuration;
+
+                services.Configure<LocalizationOptions>(config.GetSection("Localization"));
+                services.AddSingleton(ctx => ctx.GetService<IOptions<LocalizationOptions>>().Value);
+                services.AddTransient<ILocalizationManager, LocalizationManager>();
+            });
+        }
+    }
+}

--- a/Oqtane.Server/Program.cs
+++ b/Oqtane.Server/Program.cs
@@ -26,6 +26,7 @@ namespace Oqtane.Server
                     .AddCommandLine(args)
                     .Build())
                 .UseStartup<Startup>()
+                .ConfigureLocalizationSettings()
                 .Build();
     }
 }


### PR DESCRIPTION
This PR will:

- Simplify the localization configuration settings

- More important it uses `ILocalizationManager`, so no need for code redundancy to make initialize the default culture and supported cultures