### PR TITLE
Factored out DataDirectory string replacements.

### DIFF
--- a/Oqtane.Client/UI/Installer.razor
+++ b/Oqtane.Client/UI/Installer.razor
@@ -1,4 +1,4 @@
-﻿@namespace Oqtane.UI
+@namespace Oqtane.UI
 @inject NavigationManager NavigationManager
 @inject IInstallationService InstallationService
 @inject ISiteService SiteService
@@ -165,18 +165,18 @@
             var connectionstring = "";
             if (_databaseType == "LocalDB")
             {
-                connectionstring = "Data Source=" + _serverName + ";AttachDbFilename=|DataDirectory|\\" + _databaseName + ".mdf;Initial Catalog=" + _databaseName + ";Integrated Security=SSPI;";
+                connectionstring = $@"Data Source={_serverName};AttachDbFilename={Configuration.ConnectionString.DataDirectoryVariable}\{_databaseName}.mdf;Initial Catalog={_databaseName};Integrated Security=SSPI;";
             }
             else
             {
-                connectionstring = "Data Source=" + _serverName + ";Initial Catalog=" + _databaseName + ";";
+                connectionstring = $@"Data Source={_serverName};Initial Catalog={_databaseName};";
                 if (_integratedSecurityDisplay == "display: none;")
                 {
-                    connectionstring += "Integrated Security=SSPI;";
+                    connectionstring += $@"Integrated Security=SSPI;";
                 }
                 else
                 {
-                    connectionstring += "User ID=" + _username + ";Password=" + _password;
+                    connectionstring += $@"User ID={_username};Password={_password}";
                 }
             }
 

--- a/Oqtane.Server/Controllers/InstallationController.cs
+++ b/Oqtane.Server/Controllers/InstallationController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Reflection;
 using System.Linq;
@@ -69,7 +69,7 @@ namespace Oqtane.Controllers
         [HttpGet("load")]
         public IActionResult Load()
         {
-            if (_config.GetSection("Runtime").Value == "WebAssembly")
+            if (_config.GetSection(SettingKeys.RuntimeSection).Value == "WebAssembly")
             {
                 // get list of assemblies which should be downloaded to browser
                 var assemblies = AppDomain.CurrentDomain.GetOqtaneClientAssemblies();

--- a/Oqtane.Server/Extensions/WebHostBuilderExtensions.cs
+++ b/Oqtane.Server/Extensions/WebHostBuilderExtensions.cs
@@ -1,6 +1,7 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Oqtane.Infrastructure;
+using Oqtane.Shared;
 
 namespace Microsoft.AspNetCore.Hosting
 {
@@ -12,7 +13,7 @@ namespace Microsoft.AspNetCore.Hosting
             {
                 var config = context.Configuration;
 
-                services.Configure<LocalizationOptions>(config.GetSection("Localization"));
+                services.Configure<LocalizationOptions>(config.GetSection(SettingKeys.LocalizationSection));
                 services.AddSingleton(ctx => ctx.GetService<IOptions<LocalizationOptions>>().Value);
                 services.AddTransient<ILocalizationManager, LocalizationManager>();
             });

--- a/Oqtane.Server/Pages/_Host.cshtml
+++ b/Oqtane.Server/Pages/_Host.cshtml
@@ -45,7 +45,7 @@
 
     <script src="js/interop.js"></script>
 
-    @if (Configuration.GetSection("Runtime").Value == "WebAssembly")
+    @if (Configuration.GetSection(Oqtane.Shared.SettingKeys.RuntimeSection).Value == "WebAssembly")
     {
         <script src="_framework/blazor.webassembly.js"></script>
     }

--- a/Oqtane.Server/Repository/Context/DBContextBase.cs
+++ b/Oqtane.Server/Repository/Context/DBContextBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
@@ -21,8 +21,8 @@ namespace Oqtane.Repository
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseSqlServer(_tenant.DBConnectionString
-                    .Replace("|DataDirectory|", AppDomain.CurrentDomain.GetData("DataDirectory")?.ToString())
+            optionsBuilder.UseSqlServer(
+                Oqtane.Configuration.ConnectionString.Normalize(_tenant.DBConnectionString)
             );
             base.OnConfiguring(optionsBuilder);
         }

--- a/Oqtane.Server/Repository/SqlRepository.cs
+++ b/Oqtane.Server/Repository/SqlRepository.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data;
 using System.Data.SqlClient;
 using System.IO;
@@ -59,7 +59,7 @@ namespace Oqtane.Repository
 
         public int ExecuteNonQuery(Tenant tenant, string query)
         {
-            SqlConnection conn = new SqlConnection(FormatConnectionString(tenant.DBConnectionString));
+            SqlConnection conn = new SqlConnection(Oqtane.Configuration.ConnectionString.Normalize(tenant.DBConnectionString));
             SqlCommand cmd = conn.CreateCommand();
             using (conn)
             {
@@ -79,7 +79,7 @@ namespace Oqtane.Repository
 
         public SqlDataReader ExecuteReader(Tenant tenant, string query)
         {
-            SqlConnection conn = new SqlConnection(FormatConnectionString(tenant.DBConnectionString));
+            SqlConnection conn = new SqlConnection(Oqtane.Configuration.ConnectionString.Normalize(tenant.DBConnectionString));
             SqlCommand cmd = conn.CreateCommand();
             PrepareCommand(conn, cmd, query);
             var dr = cmd.ExecuteReader(CommandBehavior.CloseConnection);
@@ -97,9 +97,5 @@ namespace Oqtane.Repository
             cmd.CommandType = CommandType.Text;
         }
 
-        private string FormatConnectionString(string connectionString)
-        {
-            return connectionString.Replace("|DataDirectory|", AppDomain.CurrentDomain.GetData("DataDirectory").ToString());
-        }
     }
 }

--- a/Oqtane.Server/Startup.cs
+++ b/Oqtane.Server/Startup.cs
@@ -44,7 +44,7 @@ namespace Oqtane
 
             _supportedCultures = localizationManager.GetSupportedCultures();
 
-            _runtime = (Configuration.GetSection("Runtime").Value == "WebAssembly") ? Runtime.WebAssembly : Runtime.Server;
+            _runtime = (Configuration.GetSection(SettingKeys.RuntimeSection).Value == "WebAssembly") ? Runtime.WebAssembly : Runtime.Server;
 
             //add possibility to switch off swagger on production.
             _useSwagger = Configuration.GetSection("UseSwagger").Value != "false";

--- a/Oqtane.Server/Startup.cs
+++ b/Oqtane.Server/Startup.cs
@@ -50,7 +50,7 @@ namespace Oqtane
             _useSwagger = Configuration.GetSection("UseSwagger").Value != "false";
 
             _webRoot = env.WebRootPath;
-            AppDomain.CurrentDomain.SetData("DataDirectory", Path.Combine(env.ContentRootPath, "Data"));
+            Oqtane.Configuration.DataDirectory.Set(Path.Combine(env.ContentRootPath, "Data"));
 
             _env = env;
         }
@@ -132,8 +132,8 @@ namespace Oqtane
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
             services.AddDbContext<MasterDBContext>(options =>
-                options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection")
-                    .Replace("|DataDirectory|", AppContext.GetData("DataDirectory")?.ToString())
+                options.UseSqlServer(
+                    Oqtane.Configuration.ConnectionString.Normalize(Configuration.GetConnectionString("DefaultConnection"))
                 ));
             services.AddDbContext<TenantDBContext>(options => { });
 

--- a/Oqtane.Shared/Configuration/ConnectionString.cs
+++ b/Oqtane.Shared/Configuration/ConnectionString.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Oqtane.Configuration
+{
+    public static class ConnectionString
+    {
+        public static readonly string DataDirectoryVariable = $@"|{DataDirectory.KeyName}|";
+
+        public static string Normalize(string connectionString)
+        {
+            var ret = connectionString.Replace(DataDirectoryVariable, DataDirectory.Current());
+            return connectionString;
+        }
+
+        public static string Denormalize(string connectionString)
+        {
+            var ret = connectionString.Replace(DataDirectory.Current(), DataDirectoryVariable);
+            return ret;
+        }
+    }
+}

--- a/Oqtane.Shared/Configuration/ConnectionString.cs
+++ b/Oqtane.Shared/Configuration/ConnectionString.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,7 +15,7 @@ namespace Oqtane.Configuration
         public static string Normalize(string connectionString)
         {
             var ret = connectionString.Replace(DataDirectoryVariable, DataDirectory.Current());
-            return connectionString;
+            return ret;
         }
 
         public static string Denormalize(string connectionString)

--- a/Oqtane.Shared/Configuration/DataDirectory.cs
+++ b/Oqtane.Shared/Configuration/DataDirectory.cs
@@ -1,0 +1,28 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Oqtane.Configuration
+{
+    public static class DataDirectory
+    {
+        public static readonly string KeyName = "DataDirectory";
+
+        public static string Current()
+        {
+            var ret = AppContext.GetData(KeyName)?.ToString() ?? String.Empty;
+            return ret;
+        }
+
+        public static void Set(string Value)
+        {
+            AppDomain.CurrentDomain.SetData(KeyName, Value);
+        }
+
+    }
+
+}

--- a/Oqtane.Shared/Shared/SettingKeys.cs
+++ b/Oqtane.Shared/Shared/SettingKeys.cs
@@ -1,8 +1,11 @@
-﻿namespace Oqtane.Shared
+namespace Oqtane.Shared
 {
     public static class SettingKeys
     {
         public const string InstallationSection = "Installation";
+        public const string RuntimeSection = "Runtime";
+        public const string LocalizationSection = "Localization";
+
         public const string DefaultAliasKey = "DefaultAlias";
         public const string HostPasswordKey = "HostPassword";
         public const string HostEmailKey = "HostEmail";


### PR DESCRIPTION
There were a number of places where the ```DataDirectory``` variable was being retrieved and then was having string replacements done.  I factored out these methods into their own classes and then updated the code so that everywhere calls the same methods.