### PR TITLE
Localize ActionDialog.Text

### DIFF
--- a/Oqtane.Client/Modules/Controls/ActionDialog.razor
+++ b/Oqtane.Client/Modules/Controls/ActionDialog.razor
@@ -99,6 +99,7 @@
 
         if (IsLocalizable)
         {
+            Text = Localize(nameof(Text), Text);
             Header = Localize(nameof(Header), Header);
             Message = Localize(nameof(Message), Message);
         }


### PR DESCRIPTION
I'm working on Arabic translation for Oqtane, I just found that I miss to localize `Text` for `ActionDialog`