### PR TITLE
Fix - return to url during login fail when returnurl contains "/"

### DIFF
--- a/Oqtane.Client/Themes/Controls/LoginBase.cs
+++ b/Oqtane.Client/Themes/Controls/LoginBase.cs
@@ -22,7 +22,7 @@ namespace Oqtane.Themes.Controls
             {
                 returnurl += "/" + PageState.Page.Path;
             }
-            NavigationManager.NavigateTo(NavigateUrl("login", "returnurl=" + returnurl));
+            NavigationManager.NavigateTo(NavigateUrl("login", "?returnurl=" + returnurl));
         }
 
         protected async Task LogoutUser()

--- a/Oqtane.Client/UI/SiteRouter.razor
+++ b/Oqtane.Client/UI/SiteRouter.razor
@@ -300,7 +300,7 @@
                 if (user == null)
                 {
                     // redirect to login page
-                    NavigationManager.NavigateTo(Utilities.NavigateUrl(alias.Path, "login", "returnurl=" + path));
+                    NavigationManager.NavigateTo(Utilities.NavigateUrl(alias.Path, "login", "?returnurl=" + path));
                 }
                 else
                 {


### PR DESCRIPTION
Url was transformed to 
https://xxxx.yyy/login/!/returnurl=test/Detail
instead of
https://xxxx.yyy/login?returnurl=test/Detail