### PR TITLE
Add Content folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Oqtane.Server/Data/*.mdf
 Oqtane.Server/Data/*.ldf
 
 /Oqtane.Server/Properties/PublishProfiles/FolderProfile.pubxml
+Oqtane.Server/Content


### PR DESCRIPTION
During development I notice that whenever you upload a file, the git traking the `Content` folder, so it will be nice to ignore this folder