### PR TITLE
Make external module localize ready

### DIFF
--- a/Oqtane.Server/wwwroot/Modules/Templates/External/Client/AssemblyInfo.cs
+++ b/Oqtane.Server/wwwroot/Modules/Templates/External/Client/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿using System.Resources;
+using Microsoft.Extensions.Localization;
+
+[assembly: RootNamespace("[Owner].[Module].Client")]


### PR DESCRIPTION
1. No chnages required for the internal module, because we already have a proper `RootNamespace`

2. `RootNamespace` added for the external module to make it localize ready, but still there are two steps to make the localization works. I think we need to write some docs about this

/cc @sbwalker  @nicpitsch