### PR TITLE
Reset IsDefault per site Id for newly added language

### DIFF
--- a/Oqtane.Server/Repository/LanguageRepository.cs
+++ b/Oqtane.Server/Repository/LanguageRepository.cs
@@ -20,7 +20,10 @@ namespace Oqtane.Repository
             if (language.IsDefault)
             {
                 // Ensure all other languages are not set to current
-                _db.Language.ToList().ForEach(l => l.IsDefault = false);
+                _db.Language
+                    .Where(l => l.SiteId == language.SiteId)
+                    .ToList()
+                    .ForEach(l => l.IsDefault = false);
             }
 
             _db.Language.Add(language);


### PR DESCRIPTION
@sbwalker this avoid to reset all the languages - even for other sites - when a newly added language is set to the default