### PR TITLE
#1106 Fix issue where Section would not initialize Expanded.

### DIFF
--- a/Oqtane.Client/Modules/Controls/Section.razor
+++ b/Oqtane.Client/Modules/Controls/Section.razor
@@ -16,13 +16,14 @@
 <div class="d-flex">
     <hr class="app-rule" />
 </div>
-<div class="collapse" id="@Name">
+<div class="collapse @_show" id="@Name">
     @ChildContent
 </div>
 
 @code {
     private string _heading = string.Empty;
     private string _expanded = string.Empty;
+    private string _show = string.Empty;
 
     [Parameter]
     public RenderFragment ChildContent { get; set; }
@@ -40,6 +41,7 @@
     {
         _heading = (!string.IsNullOrEmpty(Heading)) ? Heading : Name;
         _expanded = (!string.IsNullOrEmpty(Expanded)) ? Expanded : "false";
+        if (_expanded == "true") { _show = "show"; }
     }
 
     protected override void OnParametersSet()


### PR DESCRIPTION
From Bootstrap

_Usage
The collapse plugin utilizes a few classes to handle the heavy lifting:

.collapse hides the content
**.collapse .show** shows the content
.collapsing is added when the transition starts, and removed when it finishes_