### PR TITLE
Fix for #1134 Files size incorrect when less than 1000 bytes

### DIFF
--- a/Oqtane.Client/Modules/Admin/Files/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Files/Index.razor
@@ -42,7 +42,7 @@
             <td><a href="@(ContentUrl(context.FileId))" target="_new">@context.Name</a></td>
             <td>@context.ModifiedOn</td>
             <td>@context.Extension.ToUpper() @Localizer["File"]</td>
-            <td>@(context.Size / 1000) KB</td>
+            <td>@string.Format("{0:0.00}", ((decimal)context.Size / 1000)) KB</td>
         </Row>
     </Pager>
     @if (_files.Count == 0)


### PR DESCRIPTION
Added a format to the context.size 
`string.Format("{0:0.00}", ((decimal)context.Size / 1000)) KB`