### PR TITLE
Secure ConnectionString with Data protection

### DIFF
--- a/Oqtane.Client/Program.cs
+++ b/Oqtane.Client/Program.cs
@@ -15,7 +15,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using Oqtane.Modules;
 using Oqtane.Providers;
-using Oqtane.Security;
 using Oqtane.Services;
 using Oqtane.Shared;
 using Oqtane.UI;
@@ -70,8 +69,7 @@ namespace Oqtane.Client
             builder.Services.AddScoped<ILocalizationService, LocalizationService>();
             builder.Services.AddScoped<ILanguageService, LanguageService>();
 
-            builder.Services.AddDataProtection();
-            builder.Services.AddSingleton<DataProtector>();
+            builder.Services.AddOqtaneDataProtection();
 
             await LoadClientAssemblies(httpClient);
 

--- a/Oqtane.Client/Program.cs
+++ b/Oqtane.Client/Program.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using Oqtane.Modules;
 using Oqtane.Providers;
+using Oqtane.Security;
 using Oqtane.Services;
 using Oqtane.Shared;
 using Oqtane.UI;
@@ -68,6 +69,9 @@ namespace Oqtane.Client
             builder.Services.AddScoped<ISystemService, SystemService>();
             builder.Services.AddScoped<ILocalizationService, LocalizationService>();
             builder.Services.AddScoped<ILanguageService, LanguageService>();
+
+            builder.Services.AddDataProtection();
+            builder.Services.AddSingleton<DataProtector>();
 
             await LoadClientAssemblies(httpClient);
 

--- a/Oqtane.Server/Startup.cs
+++ b/Oqtane.Server/Startup.cs
@@ -130,6 +130,9 @@ namespace Oqtane
 
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
+            services.AddDataProtection();
+            services.AddSingleton<DataProtector>();
+
             services.AddDbContext<MasterDBContext>(options => { });
             services.AddDbContext<TenantDBContext>(options => { });
 

--- a/Oqtane.Server/Startup.cs
+++ b/Oqtane.Server/Startup.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -10,7 +9,6 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -130,8 +128,7 @@ namespace Oqtane
 
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
-            services.AddDataProtection();
-            services.AddSingleton<DataProtector>();
+            services.AddOqtaneDataProtection();
 
             services.AddDbContext<MasterDBContext>(options => { });
             services.AddDbContext<TenantDBContext>(options => { });

--- a/Oqtane.Shared/Extensions/ServiceCollectionExtensions.cs
+++ b/Oqtane.Shared/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,15 @@
+using Oqtane.Security;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddOqtaneDataProtection(this IServiceCollection services)
+        {
+            services.AddDataProtection();
+            services.AddSingleton<DataProtector>();
+
+            return services;
+        }
+    }
+}

--- a/Oqtane.Shared/Oqtane.Shared.csproj
+++ b/Oqtane.Shared/Oqtane.Shared.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.0" />

--- a/Oqtane.Shared/Oqtane.Shared.csproj
+++ b/Oqtane.Shared/Oqtane.Shared.csproj
@@ -18,6 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.0" />

--- a/Oqtane.Shared/Security/DataProtector.cs
+++ b/Oqtane.Shared/Security/DataProtector.cs
@@ -6,13 +6,11 @@ namespace Oqtane.Security
     {
         private static readonly string _purpose = "Oqtane.Security";
 
-        private readonly IDataProtectionProvider _dataProtectionProvider;
         private readonly IDataProtector _dataProtector;
 
         public DataProtector(IDataProtectionProvider dataProtectionProvider)
         {
-            _dataProtectionProvider = dataProtectionProvider;
-            _dataProtector = _dataProtectionProvider.CreateProtector(_purpose);
+            _dataProtector = dataProtectionProvider.CreateProtector(_purpose);
         }
 
         public string Protect(string plaintext) => _dataProtector.Protect(plaintext);

--- a/Oqtane.Shared/Security/DataProtector.cs
+++ b/Oqtane.Shared/Security/DataProtector.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.DataProtection;
+
+namespace Oqtane.Security
+{
+    public sealed class DataProtector
+    {
+        private static readonly string _purpose = "Oqtane.Security";
+
+        private readonly IDataProtectionProvider _dataProtectionProvider;
+        private readonly IDataProtector _dataProtector;
+
+        public DataProtector(IDataProtectionProvider dataProtectionProvider)
+        {
+            _dataProtectionProvider = dataProtectionProvider;
+            _dataProtector = _dataProtectionProvider.CreateProtector(_purpose);
+        }
+
+        public string Protect(string plaintext) => _dataProtector.Protect(plaintext);
+
+        public string Unprotect(string protectedData) => _dataProtector.Unprotect(protectedData);
+    }
+}

--- a/Oqtane.Test/Oqtane.Security/DataProtectorTests.cs
+++ b/Oqtane.Test/Oqtane.Security/DataProtectorTests.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Oqtane.Security
+{
+    public class DataProtectorTests
+    {
+        [Theory]
+        [InlineData("Oqtane")]
+        [InlineData("Oqtane Framework")]
+        public void ProtectData(string data)
+        {
+            // Arrange
+            var serviceProvider = GetServiceProvider();
+            var dataProtector = serviceProvider.GetService<DataProtector>();
+
+            // Act
+            var protectedData = dataProtector.Protect(data);
+
+            //Assert
+            Assert.NotEmpty(protectedData);
+        }
+
+        [Theory]
+        [InlineData("CfDJ8JMKOwNQ58dGvkWTQhUZUsMZG0CtwOWYebvGhEX59zmRKLvcFfqNaxHUEqhzIWBKv851iYokPt5E4UtN9orICXyhTKjuzm8ioqJQPr5lYhJ_yYF2AUpsNdsGcbmSxVNPQg", "Oqtane")]
+        [InlineData("CfDJ8JMKOwNQ58dGvkWTQhUZUsMIFpxoXyJyuNperxexjGrCvLHiWCNhsaHuugzyY2E4uhU1XvnppoUdoUj5PN-M5R10RmMt3dIAbuwzt2a4NChVasq6uZzL9mTPFTm_As81DlJzQWZ0UXzGYiAAIGy1QUY", "Oqtane Framework")]
+        public void UnprotectData(string protectedData, string expectedData)
+        {
+            // Arrange
+            var serviceProvider = GetServiceProvider();
+            var dataProtector = serviceProvider.GetService<DataProtector>();
+
+            // Act
+            var data = dataProtector.Unprotect(protectedData);
+
+            //Assert
+            Assert.Equal(expectedData, data);
+        }
+
+        private static ServiceProvider GetServiceProvider()
+            => new ServiceCollection()
+                .AddDataProtection()
+                .Services
+                .AddSingleton<DataProtector>()
+                .BuildServiceProvider();
+    }
+}

--- a/Oqtane.Test/Oqtane.Test.csproj
+++ b/Oqtane.Test/Oqtane.Test.csproj
@@ -18,7 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="bunit.web" Version="1.0.0-beta-10" />
     <PackageReference Include="bunit.xunit" Version="1.0.0-beta-10" />

--- a/Oqtane.Test/Oqtane.Test.csproj
+++ b/Oqtane.Test/Oqtane.Test.csproj
@@ -13,11 +13,12 @@
     <RepositoryUrl>https://github.com/oqtane</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageReleaseNotes>https://github.com/oqtane/oqtane.framework/releases/tag/v2.0.1</PackageReleaseNotes>
-    <RootNamespace>Oqtane</RootNamespace>
+    <RootNamespace>Oqtane.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup>    
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="bunit.web" Version="1.0.0-beta-10" />
     <PackageReference Include="bunit.xunit" Version="1.0.0-beta-10" />


### PR DESCRIPTION
While see the `2.0.1` updates (issues & PRs), more specifically https://github.com/oqtane/oqtane.framework/issues/1145?notification_referrer_id=MDE4Ok5vdGlmaWNhdGlvblRocmVhZDE2MzE5OTYzMTM6MzIzNzI2Ng%3D%3D&notifications_query=repo%3Aoqtane%2Foqtane.framework#issuecomment-787326260 I just notice that the connection string is not secure, I think it will be a good to keep safe even in the data base

This PR introduces `DataProtector` service, to secure connection strings, passwords and sensitive data

/cc @sbwalker