### PR TITLE
Remove admin border after edit

### DIFF
--- a/Oqtane.Client/UI/Pane.razor
+++ b/Oqtane.Client/UI/Pane.razor
@@ -18,7 +18,7 @@ else
 
 @code {
     private bool _useadminborder = false;
-    private string _paneadminborder = "container";
+    private string _paneadminborder = "app-pane-admin-border";
     private string _panetitle = "";
 
     [CascadingParameter]
@@ -34,12 +34,11 @@ else
         if (PageState.EditMode && UserSecurity.IsAuthorized(PageState.User, PermissionNames.Edit, PageState.Page.Permissions) && Name != PaneNames.Admin)
         {
             _useadminborder = true;
-            _paneadminborder = "app-pane-admin-border";
             _panetitle = "<div class=\"app-pane-admin-title\">" + Name + " Pane</div>";
         }
         else
         {
-            _paneadminborder = "container";
+            _useadminborder = false;
             _panetitle = "";
         }
 


### PR DESCRIPTION
After finish Edit, there's a class "container" which is conflict with Bootstrap that cause an issue on Full-width pane.