### PR TITLE
Default Alias

### DIFF
--- a/Oqtane.Server/Repository/AliasRepository.cs
+++ b/Oqtane.Server/Repository/AliasRepository.cs
@@ -65,8 +65,8 @@ namespace Oqtane.Repository
                     break; // found a matching alias
                 }
             }
-
-            return alias;
+            // return fallback alias
+            return alias ?? aliases.Find(item => item.Name.Equals("*"));
         }
 
         public void DeleteAlias(int aliasId)


### PR DESCRIPTION
When alias is not found in alias table, Oqtane fails with exception in SiteRouter.razor line 108 - alias is null. This solution allows define default alias "*" for determine a site which will be shown when alias is not found. 
#1156 