### PR TITLE
Adding new DatabaseConfig components in the Client project for supported Databases

### DIFF
--- a/Oqtane.Client/Installer/Controls/LocalDBConfig.razor
+++ b/Oqtane.Client/Installer/Controls/LocalDBConfig.razor
@@ -1,0 +1,63 @@
+@namespace Oqtane.Installer.Controls
+
+@using System.ComponentModel.Design.Serialization
+@implements Oqtane.Interfaces.IDatabaseConfigControl
+
+@inject IStringLocalizer<Installer> Localizer
+
+@{
+    foreach (var field in _connectionStringFields)
+    {
+        var fieldId = field.Name.ToLowerInvariant();
+        field.Value = field.Value.Replace("{{Date}}", DateTime.UtcNow.ToString("yyyyMMddHHmm"));
+
+        if (IsInstaller)
+        {
+            <tr>
+                <td>
+                    <label class="control-label" style="font-weight: bold">@Localizer[$"{field.FriendlyName}:"]</label>
+                </td>
+                <td>
+                    <input type="text" class="form-control" @bind="@field.Value" />
+                </td>
+            </tr>
+        }
+        else
+        {
+            <tr>
+                <td>
+                    <Label For="@fieldId" HelpText="@field.HelpText" ResourceKey="@field.Name">@Localizer[$"{field.FriendlyName}:"]</Label>
+                </td>
+                <td>
+                    <input id="@fieldId" type="text" class="form-control" @bind="@field.Value" />
+                </td>
+            </tr>
+        }        
+    }
+}
+
+@code {
+    [Parameter]
+    public bool IsInstaller { get; set; }
+
+    private readonly List<ConnectionStringField> _connectionStringFields = new()
+    {
+        new() {Name = "Server", FriendlyName = "Server", Value = "(LocalDb)\\MSSQLLocalDB", HelpText="Enter the database server"},
+        new() {Name = "Database", FriendlyName = "Database", Value = "Oqtane-{{Date}}", HelpText="Enter the name of the database"}
+    };
+
+    public string GetConnectionString()
+    {
+        var connectionString = String.Empty;
+
+        var server = _connectionStringFields[0].Value;
+        var database = _connectionStringFields[1].Value;
+
+        if (!String.IsNullOrEmpty(server)  && !String.IsNullOrEmpty(database))
+        {
+            connectionString = $"Data Source={server};AttachDbFilename=|DataDirectory|\\{database}.mdf;Initial Catalog={database};Integrated Security=SSPI;";
+        }
+
+        return connectionString;
+    }
+}

--- a/Oqtane.Client/Installer/Controls/MySQLConfig.razor
+++ b/Oqtane.Client/Installer/Controls/MySQLConfig.razor
@@ -1,0 +1,73 @@
+@namespace Oqtane.Installer.Controls
+
+@implements Oqtane.Interfaces.IDatabaseConfigControl
+
+@inject IStringLocalizer<Installer> Localizer
+
+@{
+    foreach (var field in _connectionStringFields)
+    {
+        var fieldId = field.Name.ToLowerInvariant();
+        var fieldType = (field.Name == "Pwd") ? "password" : "text";
+        field.Value = field.Value.Replace("{{Date}}", DateTime.UtcNow.ToString("yyyyMMddHHmm"));
+            
+        if (IsInstaller)
+        {
+            <tr>
+                <td>
+                    <label class="control-label" style="font-weight: bold">@Localizer[$"{field.FriendlyName}:"]</label>
+                </td>
+                <td>
+                    <input type="@fieldType" class="form-control" @bind="@field.Value" />
+                </td>
+            </tr>
+        }
+        else
+        {
+            <tr>
+                <td>
+                    <Label For="@fieldId" HelpText="@field.HelpText" ResourceKey="@field.Name">@Localizer[$"{field.FriendlyName}:"]</Label>
+                </td>
+                <td>
+                    <input id="@fieldId" type="@fieldType" class="form-control" @bind="@field.Value" />
+                </td>
+            </tr>
+        }   
+    }
+}
+
+@code {
+    [Parameter]
+    public bool IsInstaller { get; set; }
+
+    private readonly List<ConnectionStringField> _connectionStringFields = new()
+    {
+        new() {Name = "Server", FriendlyName = "Server", Value = "127.0.0.1", HelpText="Enter the database server"},
+        new() {Name = "Port", FriendlyName = "Port", Value = "3306", HelpText="Enter the port used to connect to the server"},
+        new() {Name = "Database", FriendlyName = "Database", Value = "Oqtane-{{Date}}", HelpText="Enter the name of the database"},
+        new() {Name = "Uid", FriendlyName = "User Id", Value = "", HelpText="Enter the username to use for the database"},
+        new() {Name = "Pwd", FriendlyName = "Password", Value = "", HelpText="Enter the password to use for the database"}
+    };
+
+    public string GetConnectionString()
+    {
+        var connectionString = String.Empty;
+
+        var server = _connectionStringFields[0].Value;
+        var port = _connectionStringFields[1].Value;
+        var database = _connectionStringFields[2].Value;
+        var userId = _connectionStringFields[3].Value;
+        var password = _connectionStringFields[4].Value;
+
+        if (!String.IsNullOrEmpty(server) && !String.IsNullOrEmpty(database) && !String.IsNullOrEmpty(userId) && !String.IsNullOrEmpty(password))
+        {
+            connectionString = $"Server={server};Database={database};Uid={userId};Pwd={password};";
+        }
+
+        if (!String.IsNullOrEmpty(port))
+        {
+            connectionString += $"Port={port};";
+        }
+        return connectionString;
+    }
+}

--- a/Oqtane.Client/Installer/Controls/PostgreSQLConfig.razor
+++ b/Oqtane.Client/Installer/Controls/PostgreSQLConfig.razor
@@ -1,0 +1,131 @@
+@namespace Oqtane.Installer.Controls
+
+@implements Oqtane.Interfaces.IDatabaseConfigControl
+
+@inject IStringLocalizer<Installer> Localizer
+
+@{
+    foreach (var field in _connectionStringFields)
+    {
+        var fieldId = field.Name.ToLowerInvariant();
+        if (field.Name != "IntegratedSecurity")
+        {
+            var isVisible = "";
+            var fieldType = (field.Name == "Pwd") ? "password" : "text";
+            if ((field.Name == "Uid" || field.Name == "Pwd") )
+            {
+                var intSecurityField = _connectionStringFields.Single(f => f.Name == "IntegratedSecurity");
+                if (intSecurityField != null)
+                {
+                    isVisible = (Convert.ToBoolean(intSecurityField.Value)) ? "display: none;" : "";
+                }
+            }
+
+            field.Value = field.Value.Replace("{{Date}}", DateTime.UtcNow.ToString("yyyyMMddHHmm"));
+            
+            if (IsInstaller)
+            {
+                <tr style="@isVisible">
+                    <td>
+                        <label class="control-label" style="font-weight: bold">@Localizer[$"{field.FriendlyName}:"]</label>
+                    </td>
+                    <td>
+                        <input type="@fieldType" class="form-control" @bind="@field.Value" />
+                    </td>
+                </tr>
+            }
+            else
+            {
+                <tr style="@isVisible">
+                    <td>
+                        <Label For="@fieldId" HelpText="@field.HelpText" ResourceKey="@field.Name">@Localizer[$"{field.FriendlyName}:"]</Label>
+                    </td>
+                    <td>
+                        <input id="@fieldId" type="@fieldType" class="form-control" @bind="@field.Value" />
+                    </td>
+                </tr>
+            }    
+        }
+        else
+        {
+            if (IsInstaller)
+            {
+                <tr>
+                    <td>
+                        <label class="control-label" style="font-weight: bold">@Localizer[$"{field.FriendlyName}:"]</label>
+                    </td>
+                    <td>
+                        <select class="custom-select" @bind="@field.Value">
+                            <option value="true" selected>@Localizer["True"]</option>
+                            <option value="false">@Localizer["False"]</option>
+                        </select>
+                    </td>
+                </tr>
+            }
+            else
+            {
+                <tr>
+                    <td>
+                        <Label For="@fieldId" HelpText="@field.HelpText" ResourceKey="@field.Name">@Localizer[$"{field.FriendlyName}:"]</Label>
+                    </td>
+                    <td>
+                        <select id="@fieldId" class="custom-select" @bind="@field.Value">
+                            <option value="true" selected>@Localizer["True"]</option>
+                            <option value="false">@Localizer["False"]</option>
+                        </select>
+                    </td>
+                </tr>
+            }
+        }
+    }
+}
+
+@code {
+    [Parameter]
+    public bool IsInstaller { get; set; }
+
+    private readonly List<ConnectionStringField> _connectionStringFields = new()
+    {
+        new() {Name = "Server", FriendlyName = "Server", Value = "127.0.0.1", HelpText="Enter the database server"},
+        new() {Name = "Port", FriendlyName = "Port", Value = "5432", HelpText="Enter the port used to connect to the server"},
+        new() {Name = "Database", FriendlyName = "Database", Value = "Oqtane-{{Date}}", HelpText="Enter the name of the database"},
+        new() {Name = "IntegratedSecurity", FriendlyName = "Integrated Security", Value = "true", HelpText="Select if you want integrated security or not"},
+        new() {Name = "Uid", FriendlyName = "User Id", Value = "", HelpText="Enter the username to use for the database"},
+        new() {Name = "Pwd", FriendlyName = "Password", Value = "", HelpText="Enter the password to use for the database"}
+    };
+
+    public string GetConnectionString()
+    {
+        var connectionString = String.Empty;
+
+        var server = _connectionStringFields[0].Value;
+        var port = _connectionStringFields[1].Value;
+        var database = _connectionStringFields[2].Value;
+        var integratedSecurity = Boolean.Parse(_connectionStringFields[3].Value);
+        var userId = _connectionStringFields[4].Value;
+        var password = _connectionStringFields[5].Value;
+
+        if (!String.IsNullOrEmpty(server)  && !String.IsNullOrEmpty(database) && !String.IsNullOrEmpty(port))
+        {
+            connectionString = $"Server={server};Port={port};Database={database};";
+        }
+
+        if (integratedSecurity)
+        {
+            connectionString += "Integrated Security=true;";
+        }
+        else
+        {
+            if (!String.IsNullOrEmpty(userId) && !String.IsNullOrEmpty(password))
+            {
+                connectionString += $"User ID={userId};Password={password};";
+            }
+            else
+            {
+                connectionString = String.Empty;
+            }
+        }
+
+        return connectionString;
+    }
+}

--- a/Oqtane.Client/Installer/Controls/SqlServerConfig.razor
+++ b/Oqtane.Client/Installer/Controls/SqlServerConfig.razor
@@ -1,0 +1,131 @@
+@namespace Oqtane.Installer.Controls
+
+@implements Oqtane.Interfaces.IDatabaseConfigControl
+
+@inject IStringLocalizer<Installer> Localizer
+
+@{
+    foreach (var field in _connectionStringFields)
+    {
+        var fieldId = field.Name.ToLowerInvariant();
+        if (field.Name != "IntegratedSecurity")
+        {
+            var isVisible = "";
+            var fieldType = (field.Name == "Pwd") ? "password" : "text";
+            if ((field.Name == "Uid" || field.Name == "Pwd") )
+            {
+                var intSecurityField = _connectionStringFields.Single(f => f.Name == "IntegratedSecurity");
+                if (intSecurityField != null)
+                {
+                    isVisible = (Convert.ToBoolean(intSecurityField.Value)) ? "display: none;" : "";
+                }
+            }
+
+            field.Value = field.Value.Replace("{{Date}}", DateTime.UtcNow.ToString("yyyyMMddHHmm"));
+            
+            if (IsInstaller)
+            {
+                <tr style="@isVisible">
+                    <td>
+                        <label class="control-label" style="font-weight: bold">@Localizer[$"{field.FriendlyName}:"]</label>
+                    </td>
+                    <td>
+                        <input type="@fieldType" class="form-control" @bind="@field.Value" />
+                    </td>
+                </tr>
+            }
+            else
+            {
+                <tr style="@isVisible">
+                    <td>
+                        <Label For="@fieldId" HelpText="@field.HelpText" ResourceKey="@field.Name">@Localizer[$"{field.FriendlyName}:"]</Label>
+                    </td>
+                    <td>
+                        <input id="@fieldId" type="@fieldType" class="form-control" @bind="@field.Value" />
+                    </td>
+                </tr>
+            }        
+        }
+        else
+        {
+            if (IsInstaller)
+            {
+                <tr>
+                    <td>
+                        <label class="control-label" style="font-weight: bold">@Localizer[$"{field.FriendlyName}:"]</label>
+                    </td>
+                    <td>
+                        <select class="custom-select" @bind="@field.Value">
+                            <option value="true" selected>@Localizer["True"]</option>
+                            <option value="false">@Localizer["False"]</option>
+                        </select>
+                    </td>
+                </tr>
+            }
+            else
+            {
+                <tr>
+                    <td>
+                        <Label For="@fieldId" HelpText="@field.HelpText" ResourceKey="@field.Name">@Localizer[$"{field.FriendlyName}:"]</Label>
+                    </td>
+                    <td>
+                        <select id="@fieldId" class="custom-select" @bind="@field.Value">
+                            <option value="true" selected>@Localizer["True"]</option>
+                            <option value="false">@Localizer["False"]</option>
+                        </select>
+                    </td>
+                </tr>
+            }
+        }
+    }
+}
+
+@code {
+    
+    [Parameter]
+    public bool IsInstaller { get; set; }
+
+    private readonly List<ConnectionStringField> _connectionStringFields = new()
+    {
+        new() {Name = "Server", FriendlyName = "Server", Value = ".", HelpText="Enter the database server"},
+        new() {Name = "Database", FriendlyName = "Database", Value = "Oqtane-{{Date}}", HelpText="Enter the name of the database"},
+        new() {Name = "IntegratedSecurity", FriendlyName = "Integrated Security", Value = "true", HelpText="Select if you want integrated security or not"},
+        new() {Name = "Uid", FriendlyName = "User Id", Value = "", HelpText="Enter the username to use for the database"},
+        new() {Name = "Pwd", FriendlyName = "Password", Value = "", HelpText="Enter the password to use for the database"}
+    };
+
+    public string GetConnectionString()
+    {
+        var connectionString = String.Empty;
+
+        var server = _connectionStringFields[0].Value;
+        var database = _connectionStringFields[1].Value;
+        var integratedSecurity = Boolean.Parse(_connectionStringFields[2].Value);
+        var userId = _connectionStringFields[3].Value;
+        var password = _connectionStringFields[4].Value;
+
+        if (!String.IsNullOrEmpty(server)  && !String.IsNullOrEmpty(database))
+        {
+            connectionString = $"Data Source={server};Initial Catalog={database};";
+        }
+
+        if (integratedSecurity)
+        {
+            connectionString += "Integrated Security=SSPI;";
+        }
+        else
+        {
+            if (!String.IsNullOrEmpty(userId) && !String.IsNullOrEmpty(password))
+            {
+                connectionString += $"User ID={userId};Password={password};";
+            }
+            else
+            {
+                connectionString = String.Empty;
+            }
+        }
+
+        return connectionString;
+    }
+
+}

--- a/Oqtane.Client/Installer/Controls/SqliteConfig.razor
+++ b/Oqtane.Client/Installer/Controls/SqliteConfig.razor
@@ -1,0 +1,60 @@
+@namespace Oqtane.Installer.Controls
+
+@implements Oqtane.Interfaces.IDatabaseConfigControl
+
+@inject IStringLocalizer<Installer> Localizer
+
+@{
+    foreach (var field in _connectionStringFields)
+    {        
+        var fieldId = field.Name.ToLowerInvariant();
+        field.Value = field.Value.Replace("{{Date}}", DateTime.UtcNow.ToString("yyyyMMddHHmm"));
+        
+        if (IsInstaller)
+        {
+            <tr>
+                <td>
+                    <label class="control-label" style="font-weight: bold">@Localizer[$"{field.FriendlyName}:"]</label>
+                </td>
+                <td>
+                    <input type="text" class="form-control" @bind="@field.Value" />
+                </td>
+            </tr>
+        }
+        else
+        {
+            <tr>
+                <td>
+                    <Label For="@fieldId" HelpText="@field.HelpText" ResourceKey="@field.Name">@Localizer[$"{field.FriendlyName}:"]</Label>
+                </td>
+                <td>
+                    <input id="@fieldId" type="text" class="form-control" @bind="@field.Value" />
+                </td>
+            </tr>
+        }       
+    }
+}
+
+@code {
+    [Parameter]
+    public bool IsInstaller { get; set; }
+
+    private readonly List<ConnectionStringField> _connectionStringFields = new()
+    {
+        new() {Name = "Server", FriendlyName = "File Name", Value = "Oqtane-{{Date}}.db", HelpText="Enter the file name to use for the database"}
+    };
+
+    public string GetConnectionString()
+    {
+        var connectionstring = String.Empty;
+
+        var server = _connectionStringFields[0].Value;
+
+        if (!String.IsNullOrEmpty(server))
+        {
+            connectionstring = $"Data Source={server};";
+        }
+
+        return connectionstring;
+    }
+}

--- a/Oqtane.Client/Installer/Installer.razor
+++ b/Oqtane.Client/Installer/Installer.razor
@@ -1,13 +1,13 @@
+@namespace Oqtane.Installer
 @using Oqtane.Interfaces
-@using System.Reflection
-@namespace Oqtane.UI
+@using Oqtane.Installer.Controls
+
 @inject NavigationManager NavigationManager
 @inject IInstallationService InstallationService
 @inject ISiteService SiteService
 @inject IUserService UserService
 @inject IJSRuntime JSRuntime
 @inject IStringLocalizer<Installer> Localizer
-@inject IEnumerable<IOqtaneDatabase> Databases
 
 <div class="container">
     <div class="row">
@@ -22,63 +22,23 @@
             <h2>@Localizer["Database Configuration"]</h2><br />
             <table class="form-group" cellpadding="4" cellspacing="4" style="margin: auto;">
                 <tbody>
-                    <tr>
-                        <td>
-                            <label class="control-label" style="font-weight: bold">@Localizer["Database Type:"] </label>
-                        </td>
-                        <td>
-                            <select class="custom-select" @bind="@_databaseType">
-                                @{
-                                    foreach (var database in Databases)
-                                    {
-                                        <option value="@database.Name">@Localizer[@database.FriendlyName]</option>
-                                    }
-                                }
-                            </select>
-                        </td>
-                    </tr>
-                @{
-                    _selectedDatabase = Databases.Single(d => d.Name == _databaseType);
-                    foreach (var field in _selectedDatabase.ConnectionStringFields)
-                    {
-                        if (field.Name != "IntegratedSecurity")
-                        {
-                            var isVisible = "";
-                            var fieldType = (field.Name == "Pwd") ? "password" : "text";
-                            if ((field.Name == "Uid" || field.Name == "Pwd") && _selectedDatabase.Name != "MySQL" )
+                <tr>
+                    <td>
+                        <label class="control-label" style="font-weight: bold">@Localizer["Database Type:"]</label>
+                    </td>
+                    <td>
+                        <select class="custom-select" value="@_databaseName" @onchange="(e => DatabaseChanged(e))">
+                            @foreach (var database in _databases)
                             {
-                                var intSecurityField = _selectedDatabase.ConnectionStringFields.Single(f => f.Name == "IntegratedSecurity");
-                                if (intSecurityField != null)
-                                {
-                                    isVisible = (Convert.ToBoolean(intSecurityField.Value)) ? "display: none;" : "";
-                                }
+                                <option value="@database.Name">@Localizer[@database.FriendlyName]</option>
                             }
-
-                            field.Value = field.Value.Replace("{{Date}}", DateTime.UtcNow.ToString("yyyyMMddHHmm"));
-                            
-                            <tr style="@isVisible">
-                                <td>
-                                    <label class="control-label" style="font-weight: bold">@Localizer[$"{field.FriendlyName}:"]</label>
-                                </td>
-                                <td>
-                                    <input type="@fieldType" class="form-control" @bind="@field.Value" />
-                                </td>
-                            </tr>
-                        }
-                        else
-                        {
-                            <tr>
-                                <td>
-                                    <label class="control-label" style="font-weight: bold">@Localizer[$"{field.FriendlyName}:"]</label>
-                                </td>
-                                <td>
-                                    <select class="custom-select" @bind="@field.Value">
-                                        <option value="true" selected>@Localizer["True"]</option>
-                                        <option value="false">@Localizer["False"]</option>
-                                    </select>
-                                </td>
-                            </tr>
-                        }
+                        </select>
+                    </td>
+                </tr>
+                @{
+                    if (_databaseConfigType != null)
+                    {
+                        @DatabaseConfigComponent;
                     }
                 }
                 </tbody>
@@ -135,14 +95,89 @@
 </div>
 
 @code {
-    private IOqtaneDatabase _selectedDatabase;
-    private string _databaseType = "LocalDB";
+    private IList<Database> _databases;
+    private string _databaseName = "LocalDB";
+    private Type _databaseConfigType;
+    private object _databaseConfig;
+    private RenderFragment DatabaseConfigComponent { get; set; }
+
     private string _hostUsername = UserNames.Host;
     private string _hostPassword = string.Empty;
     private string _confirmPassword = string.Empty;
     private string _hostEmail = string.Empty;
     private string _message = string.Empty;
     private string _loadingDisplay = "display: none;";
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+
+        _databases = new List<Database>
+        {
+            new()
+            {
+                Name = "LocalDB",
+                FriendlyName = "Local Database",
+                Type = "Oqtane.Installer.Controls.LocalDBConfig, Oqtane.Client"
+            },
+            new()
+            {
+                Name = "SqlServer",
+                FriendlyName = "SQL Server",
+                Type = "Oqtane.Installer.Controls.SqlServerConfig, Oqtane.Client"
+            },
+            new()
+            {
+                Name = "Sqlite",
+                FriendlyName = "Sqlite",
+                Type = "Oqtane.Installer.Controls.SqliteConfig, Oqtane.Client"
+            },
+            new()
+            {
+                Name = "MySQL",
+                FriendlyName = "MySQL",
+                Type = "Oqtane.Installer.Controls.MySQLConfig, Oqtane.Client"
+            },
+            new()
+            {
+                Name = "PostgreSQL",
+                FriendlyName = "PostgreSQL",
+                Type = "Oqtane.Installer.Controls.PostgreSQLConfig, Oqtane.Client"
+            }
+        };
+        
+        LoadDatabaseConfigComponent();
+    }
+
+    private void DatabaseChanged(ChangeEventArgs eventArgs)
+    {
+        try
+        {
+            _databaseName = (string)eventArgs.Value;
+
+            LoadDatabaseConfigComponent();
+        }
+        catch (Exception exception)
+        {
+            _message = Localizer["Error loading Database Configuration Control"];
+        }
+    }
+
+    private void LoadDatabaseConfigComponent()
+    {
+        var database = _databases.SingleOrDefault(d => d.Name == _databaseName);
+        if (database != null)
+        {
+            _databaseConfigType = Type.GetType(database.Type);
+            DatabaseConfigComponent = builder =>
+            {
+                builder.OpenComponent(0, _databaseConfigType);
+                builder.AddAttribute(1, "IsInstaller", true);
+                builder.AddComponentReferenceCapture(2, inst => { _databaseConfig = Convert.ChangeType(inst, _databaseConfigType); });
+                builder.CloseComponent();
+            };
+        }
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -155,7 +190,11 @@
 
     private async Task Install()
     {
-        var connectionString = _selectedDatabase.BuildConnectionString();
+        var connectionString = String.Empty;
+        if (_databaseConfig is IDatabaseConfigControl databaseConfigControl)
+        {
+            connectionString = databaseConfigControl.GetConnectionString();
+        }
 
         if (connectionString != "" && _hostUsername != "" && _hostPassword.Length >= 6 && _hostPassword == _confirmPassword && _hostEmail != "")
         {
@@ -166,7 +205,7 @@
 
             var config = new InstallConfig
             {
-                DatabaseType = _databaseType,
+                DatabaseType = _databaseName,
                 ConnectionString = connectionString,
                 Aliases = uri.Authority,
                 HostEmail = _hostEmail,

--- a/Oqtane.Client/Modules/Admin/Sites/Add.razor
+++ b/Oqtane.Client/Modules/Admin/Sites/Add.razor
@@ -127,60 +127,17 @@ else
                 <Label For="databaseType" HelpText="Select the database type for the tenant" ResourceKey="DatabaseType">Database Type: </Label>
             </td>
             <td>
-                <select id="databaseType" class="custom-select" @bind="@_databaseType">
-                    @{
-                        foreach (var database in Databases)
-                        {
-                            <option value="@database.Name">@Localizer[@database.FriendlyName]</option>
-                        }
+                <select id="databaseType" class="custom-select" value="@_databaseName" @onchange="(e => DatabaseChanged(e))">
+                    @foreach (var database in _databases)
+                    {
+                        <option value="@database.Name">@Localizer[@database.FriendlyName]</option>
                     }
                 </select>
             </td>
         </tr>
+        if (_databaseConfigType != null)
         {
-            _selectedDatabase = Databases.Single(d => d.Name == _databaseType);
-            foreach (var field in _selectedDatabase.ConnectionStringFields)
-            {
-                var fieldId = field.Name.ToLowerInvariant();
-                if (field.Name != "IntegratedSecurity")
-                {
-                    var isVisible = "";
-                    var fieldType = (field.Name == "Pwd") ? "password" : "text";
-                    if ((field.Name == "Uid" || field.Name == "Pwd") && _selectedDatabase.Name != "MySQL" )
-                    {
-                        var intSecurityField = _selectedDatabase.ConnectionStringFields.Single(f => f.Name == "IntegratedSecurity");
-                        if (intSecurityField != null)
-                        {
-                            isVisible = (Convert.ToBoolean(intSecurityField.Value)) ? "display: none;" : "";
-                        }
-                    }
-
-                    field.Value = field.Value.Replace("{{Date}}", DateTime.UtcNow.ToString("yyyyMMddHHmm"));
-                    
-                    <tr style="@isVisible">
-                        <td>
-                            <Label For="@fieldId" HelpText="@field.HelpText" ResourceKey="@field.Name">@Localizer[$"{field.FriendlyName}:"]</Label>
-                        </td>
-                        <td>
-                            <input id="@fieldId" type="@fieldType" class="form-control" @bind="@field.Value" />
-                        </td>
-                    </tr>
-                }
-                else
-                {
-                    <tr>
-                        <td>
-                            <Label For="@fieldId" HelpText="@field.HelpText" ResourceKey="@field.Name">@Localizer[$"{field.FriendlyName}:"]</Label>
-                        </td>
-                        <td>
-                            <select id="@fieldId" class="custom-select" @bind="@field.Value">
-                                <option value="true" selected>@Localizer["True"]</option>
-                                <option value="false">@Localizer["False"]</option>
-                            </select>
-                        </td>
-                    </tr>
-                }
-            }
+            @DatabaseConfigComponent;
         }
         <tr>
             <td>
@@ -205,6 +162,13 @@ else
 }
 
 @code {
+    private IList<Database> _databases;
+    private string _databaseName = "LocalDB";
+    private Type _databaseConfigType;
+    private object _databaseConfig;
+    private RenderFragment DatabaseConfigComponent { get; set; }
+
+
     private List<Theme> _themeList;
     private List<ThemeControl> _themes = new List<ThemeControl>();
     private List<ThemeControl> _containers = new List<ThemeControl>();
@@ -213,9 +177,7 @@ else
     private string _tenantid = "-";
 
     private string _tenantName = string.Empty;
-    private IOqtaneDatabase _selectedDatabase;
-    private string _databaseType = "LocalDB";
-
+    
     private string _hostUserName = UserNames.Host;
     private string _hostpassword = string.Empty;
 
@@ -235,6 +197,72 @@ else
         _themeList = await ThemeService.GetThemesAsync();
         _themes = ThemeService.GetThemeControls(_themeList);
         _siteTemplates = await SiteTemplateService.GetSiteTemplatesAsync();
+        
+        _databases = new List<Database>
+        {
+            new()
+            {
+                Name = "LocalDB",
+                FriendlyName = "Local Database",
+                Type = "Oqtane.Installer.Controls.LocalDBConfig, Oqtane.Client"
+            },
+            new()
+            {
+                Name = "SqlServer",
+                FriendlyName = "SQL Server",
+                Type = "Oqtane.Installer.Controls.SqlServerConfig, Oqtane.Client"
+            },
+            new()
+            {
+                Name = "Sqlite",
+                FriendlyName = "Sqlite",
+                Type = "Oqtane.Installer.Controls.SqliteConfig, Oqtane.Client"
+            },
+            new()
+            {
+                Name = "MySQL",
+                FriendlyName = "MySQL",
+                Type = "Oqtane.Installer.Controls.MySQLConfig, Oqtane.Client"
+            },
+            new()
+            {
+                Name = "PostgreSQL",
+                FriendlyName = "PostgreSQL",
+                Type = "Oqtane.Installer.Controls.PostGreSQLConfig, Oqtane.Client"
+            }
+        };
+        
+        LoadDatabaseConfigComponent();
+    }
+    
+    private void DatabaseChanged(ChangeEventArgs eventArgs)
+    {
+        try
+        {
+            _databaseName = (string)eventArgs.Value;
+
+            LoadDatabaseConfigComponent();
+        }
+        catch (Exception exception)
+        {
+            AddModuleMessage(Localizer["Error loading Database Configuration Control"], MessageType.Error);
+        }
+    }
+
+    private void LoadDatabaseConfigComponent()
+    {
+        var database = _databases.SingleOrDefault(d => d.Name == _databaseName);
+        if (database != null)
+        {
+            _databaseConfigType = Type.GetType(database.Type);
+            DatabaseConfigComponent = builder =>
+            {
+                builder.OpenComponent(0, _databaseConfigType);
+                builder.AddAttribute(1, "IsInstaller", false);
+                builder.AddComponentReferenceCapture(2, inst => { _databaseConfig = Convert.ChangeType(inst, _databaseConfigType); });
+                builder.CloseComponent();
+            };
+        }
     }
 
     private void TenantChanged(ChangeEventArgs e)
@@ -301,10 +329,14 @@ else
                         user = await UserService.LoginUserAsync(user, false, false);
                         if (user.IsAuthenticated)
                         {
-                            var connectionString = _selectedDatabase.BuildConnectionString();
+                            var connectionString = String.Empty;
+                            if (_databaseConfig is IDatabaseConfigControl databaseConfigControl)
+                            {
+                                connectionString = databaseConfigControl.GetConnectionString();
+                            }
                             if (connectionString != "")
                             {
-                                config.DatabaseType = _databaseType;
+                                config.DatabaseType = _databaseName;
                                 config.ConnectionString = connectionString;
                                 config.HostPassword = _hostpassword;
                                 config.HostEmail = user.Email;

--- a/Oqtane.Client/Program.cs
+++ b/Oqtane.Client/Program.cs
@@ -86,17 +86,6 @@ namespace Oqtane.Client
                     }
                 }
 
-                // dynamically register database providers
-                var databaseTypes = assembly.GetInterfaces<IOqtaneDatabase>();
-                foreach (var databaseType in databaseTypes)
-                {
-                    if (databaseType.AssemblyQualifiedName != null)
-                    {
-                        var serviceType = Type.GetType("Oqtane.Interfaces.IDatabase, Oqtane.Shared");
-                        builder.Services.AddScoped(serviceType ?? databaseType, databaseType);
-                    }
-                }
-
                 // register client startup services
                 var startUps = assembly.GetInstances<IClientStartup>();
                 foreach (var startup in startUps)

--- a/Oqtane.Client/_Imports.razor
+++ b/Oqtane.Client/_Imports.razor
@@ -21,3 +21,4 @@
 @using Oqtane.Themes.Controls
 @using Oqtane.UI
 @using Oqtane.Enums
+@using Oqtane.Installer

--- a/Oqtane.Database.MySQL/MySQLDatabase.cs
+++ b/Oqtane.Database.MySQL/MySQLDatabase.cs
@@ -15,44 +15,13 @@ namespace Oqtane.Database.MySQL
 
         private static string _name => "MySQL";
 
-        private static readonly List<ConnectionStringField> _connectionStringFields = new()
-        {
-            new() {Name = "Server", FriendlyName = "Server", Value = "127.0.0.1", HelpText="Enter the database server"},
-            new() {Name = "Port", FriendlyName = "Port", Value = "3306", HelpText="Enter the port used to connect to the server"},
-            new() {Name = "Database", FriendlyName = "Database", Value = "Oqtane-{{Date}}", HelpText="Enter the name of the database"},
-            new() {Name = "Uid", FriendlyName = "User Id", Value = "", HelpText="Enter the username to use for the database"},
-            new() {Name = "Pwd", FriendlyName = "Password", Value = "", HelpText="Enter the password to use for the database"}
-        };
-
-        public MySQLDatabase() :base(_name, _friendlyName, _connectionStringFields) { }
+        public MySQLDatabase() :base(_name, _friendlyName) { }
 
         public override string Provider => "MySql.EntityFrameworkCore";
 
         public override OperationBuilder<AddColumnOperation> AddAutoIncrementColumn(ColumnsBuilder table, string name)
         {
             return table.Column<int>(name: name, nullable: false).Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn);
-        }
-
-        public override string BuildConnectionString()
-        {
-            var connectionString = String.Empty;
-
-            var server = ConnectionStringFields[0].Value;
-            var port = ConnectionStringFields[1].Value;
-            var database = ConnectionStringFields[2].Value;
-            var userId = ConnectionStringFields[3].Value;
-            var password = ConnectionStringFields[4].Value;
-
-            if (!String.IsNullOrEmpty(server) && !String.IsNullOrEmpty(database) && !String.IsNullOrEmpty(userId) && !String.IsNullOrEmpty(password))
-            {
-                connectionString = $"Server={server};Database={database};Uid={userId};Pwd={password};";
-            }
-
-            if (!String.IsNullOrEmpty(port))
-            {
-                connectionString += $"Port={port};";
-            }
-            return connectionString;
         }
 
         public override string ConcatenateSql(params string[] values)

--- a/Oqtane.Database.PostgreSQL/PostgreSQLDatabase.cs
+++ b/Oqtane.Database.PostgreSQL/PostgreSQLDatabase.cs
@@ -20,17 +20,7 @@ namespace Oqtane.Database.PostgreSQL
 
         private readonly INameRewriter _rewriter;
 
-        private static readonly List<ConnectionStringField> _connectionStringFields = new()
-        {
-            new() {Name = "Server", FriendlyName = "Server", Value = "127.0.0.1", HelpText="Enter the database server"},
-            new() {Name = "Port", FriendlyName = "Port", Value = "5432", HelpText="Enter the port used to connect to the server"},
-            new() {Name = "Database", FriendlyName = "Database", Value = "Oqtane-{{Date}}", HelpText="Enter the name of the database"},
-            new() {Name = "IntegratedSecurity", FriendlyName = "Integrated Security", Value = "true", HelpText="Select if you want integrated security or not"},
-            new() {Name = "Uid", FriendlyName = "User Id", Value = "", HelpText="Enter the username to use for the database"},
-            new() {Name = "Pwd", FriendlyName = "Password", Value = "", HelpText="Enter the password to use for the database"}
-        };
-
-        public PostgreSQLDatabase() : base(_name, _friendlyName, _connectionStringFields)
+        public PostgreSQLDatabase() : base(_name, _friendlyName)
         {
             _rewriter = new SnakeCaseNameRewriter(CultureInfo.InvariantCulture);
         }
@@ -40,41 +30,6 @@ namespace Oqtane.Database.PostgreSQL
         public override OperationBuilder<AddColumnOperation> AddAutoIncrementColumn(ColumnsBuilder table, string name)
         {
             return table.Column<int>(name: name, nullable: false).Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityAlwaysColumn);
-        }
-
-        public override string BuildConnectionString()
-        {
-            var connectionString = String.Empty;
-
-            var server = ConnectionStringFields[0].Value;
-            var port = ConnectionStringFields[1].Value;
-            var database = ConnectionStringFields[2].Value;
-            var integratedSecurity = Boolean.Parse(ConnectionStringFields[3].Value);
-            var userId = ConnectionStringFields[4].Value;
-            var password = ConnectionStringFields[5].Value;
-
-            if (!String.IsNullOrEmpty(server)  && !String.IsNullOrEmpty(database) && !String.IsNullOrEmpty(port))
-            {
-                connectionString = $"Server={server};Port={port};Database={database};";
-            }
-
-            if (integratedSecurity)
-            {
-                connectionString += "Integrated Security=true;";
-            }
-            else
-            {
-                if (!String.IsNullOrEmpty(userId) && !String.IsNullOrEmpty(password))
-                {
-                    connectionString += $"User ID={userId};Password={password};";
-                }
-                else
-                {
-                    connectionString = String.Empty;
-                }
-            }
-
-            return connectionString;
         }
 
         public override string ConcatenateSql(params string[] values)

--- a/Oqtane.Database.Sqlite/SqliteDatabase.cs
+++ b/Oqtane.Database.Sqlite/SqliteDatabase.cs
@@ -14,32 +14,13 @@ namespace Oqtane.Repository.Databases
 
         private static string _name => "Sqlite";
 
-        private static readonly List<ConnectionStringField> _connectionStringFields = new()
-        {
-            new() {Name = "Server", FriendlyName = "File Name", Value = "Oqtane-{{Date}}.db", HelpText="Enter the file name to use for the database"}
-        };
-
-        public SqliteDatabase() :base(_name, _friendlyName, _connectionStringFields) { }
+        public SqliteDatabase() :base(_name, _friendlyName) { }
 
         public override string Provider => "Microsoft.EntityFrameworkCore.Sqlite";
 
         public override OperationBuilder<AddColumnOperation> AddAutoIncrementColumn(ColumnsBuilder table, string name)
         {
             return table.Column<int>(name: name, nullable: false).Annotation("Sqlite:Autoincrement", true);
-        }
-
-        public override string BuildConnectionString()
-        {
-            var connectionstring = String.Empty;
-
-            var server = ConnectionStringFields[0].Value;
-
-            if (!String.IsNullOrEmpty(server))
-            {
-                connectionstring = $"Data Source={server};";
-            }
-
-            return connectionstring;
         }
 
         public override string ConcatenateSql(params string[] values)

--- a/Oqtane.Server/Databases/LocalDbDatabase.cs
+++ b/Oqtane.Server/Databases/LocalDbDatabase.cs
@@ -10,27 +10,6 @@ namespace Oqtane.Databases
         private static string _friendlyName => "Local Database";
         private static string _name => "LocalDB";
 
-        private static readonly List<ConnectionStringField> _connectionStringFields = new()
-        {
-            new() {Name = "Server", FriendlyName = "Server", Value = "(LocalDb)\\MSSQLLocalDB", HelpText="Enter the database server"},
-            new() {Name = "Database", FriendlyName = "Database", Value = "Oqtane-{{Date}}", HelpText="Enter the name of the database"}
-        };
-
-        public LocalDbDatabase() :base(_name, _friendlyName, _connectionStringFields) { }
-
-        public override string BuildConnectionString()
-        {
-            var connectionString = String.Empty;
-
-            var server = ConnectionStringFields[0].Value;
-            var database = ConnectionStringFields[1].Value;
-
-            if (!String.IsNullOrEmpty(server)  && !String.IsNullOrEmpty(database))
-            {
-                connectionString = $"Data Source={server};AttachDbFilename=|DataDirectory|\\{database}.mdf;Initial Catalog={database};Integrated Security=SSPI;";
-            }
-
-            return connectionString;
-        }
+        public LocalDbDatabase() :base(_name, _friendlyName) { }
     }
 }

--- a/Oqtane.Server/Databases/SqlServerDatabase.cs
+++ b/Oqtane.Server/Databases/SqlServerDatabase.cs
@@ -13,50 +13,6 @@ namespace Oqtane.Databases
 
         private static string _name => "SqlServer";
 
-        private static readonly List<ConnectionStringField> _connectionStringFields = new()
-        {
-            new() {Name = "Server", FriendlyName = "Server", Value = ".", HelpText="Enter the database server"},
-            new() {Name = "Database", FriendlyName = "Database", Value = "Oqtane-{{Date}}", HelpText="Enter the name of the database"},
-            new() {Name = "IntegratedSecurity", FriendlyName = "Integrated Security", Value = "true", HelpText="Select if you want integrated security or not"},
-            new() {Name = "Uid", FriendlyName = "User Id", Value = "", HelpText="Enter the username to use for the database"},
-            new() {Name = "Pwd", FriendlyName = "Password", Value = "", HelpText="Enter the password to use for the database"}
-        };
-
-        public SqlServerDatabase() :base(_name, _friendlyName, _connectionStringFields) { }
-
-        public override string BuildConnectionString()
-        {
-            var connectionString = String.Empty;
-
-            var server = ConnectionStringFields[0].Value;
-            var database = ConnectionStringFields[1].Value;
-            var integratedSecurity = Boolean.Parse(ConnectionStringFields[2].Value);
-            var userId = ConnectionStringFields[3].Value;
-            var password = ConnectionStringFields[4].Value;
-
-            if (!String.IsNullOrEmpty(server)  && !String.IsNullOrEmpty(database))
-            {
-                connectionString = $"Data Source={server};Initial Catalog={database};";
-            }
-
-            if (integratedSecurity)
-            {
-                connectionString += "Integrated Security=SSPI;";
-            }
-            else
-            {
-                if (!String.IsNullOrEmpty(userId) && !String.IsNullOrEmpty(password))
-                {
-                    connectionString += $"User ID={userId};Password={password};";
-                }
-                else
-                {
-                    connectionString = String.Empty;
-                }
-            }
-
-            return connectionString;
-
-        }
+        public SqlServerDatabase() :base(_name, _friendlyName) { }
     }
 }

--- a/Oqtane.Server/Databases/SqlServerDatabaseBase.cs
+++ b/Oqtane.Server/Databases/SqlServerDatabaseBase.cs
@@ -11,7 +11,7 @@ namespace Oqtane.Repository.Databases
 {
     public abstract class SqlServerDatabaseBase : OqtaneDatabaseBase
     {
-        protected SqlServerDatabaseBase(string name, string friendlyName, List<ConnectionStringField> connectionStringFields) : base(name, friendlyName, connectionStringFields)
+        protected SqlServerDatabaseBase(string name, string friendlyName) : base(name, friendlyName)
         {
         }
 

--- a/Oqtane.Shared/Interfaces/IDatabaseConfigControl.cs
+++ b/Oqtane.Shared/Interfaces/IDatabaseConfigControl.cs
@@ -1,0 +1,9 @@
+namespace Oqtane.Interfaces
+{
+    public interface IDatabaseConfigControl
+    {
+        string GetConnectionString();
+
+        bool IsInstaller { get; set; }
+    }
+}

--- a/Oqtane.Shared/Interfaces/IOqtaneDatabase.cs
+++ b/Oqtane.Shared/Interfaces/IOqtaneDatabase.cs
@@ -14,11 +14,7 @@ namespace Oqtane.Interfaces
 
         public string Provider { get; }
 
-        public List<ConnectionStringField> ConnectionStringFields { get; }
-
         public OperationBuilder<AddColumnOperation> AddAutoIncrementColumn(ColumnsBuilder table, string name);
-
-        public string BuildConnectionString();
 
         public string ConcatenateSql(params string[] values);
 

--- a/Oqtane.Shared/Models/Database.cs
+++ b/Oqtane.Shared/Models/Database.cs
@@ -2,6 +2,8 @@ namespace Oqtane.Models
 {
     public class Database
     {
+        public string FriendlyName { get; set; }
+
         public string Name { get; set; }
 
         public string Type { get; set; }

--- a/Oqtane.Shared/Shared/OqtaneDatabaseBase.cs
+++ b/Oqtane.Shared/Shared/OqtaneDatabaseBase.cs
@@ -10,11 +10,10 @@ namespace Oqtane.Shared
 {
     public abstract class OqtaneDatabaseBase : IOqtaneDatabase
     {
-        protected OqtaneDatabaseBase(string name, string friendlyName, List<ConnectionStringField> connectionStringFields)
+        protected OqtaneDatabaseBase(string name, string friendlyName)
         {
             Name = name;
             FriendlyName = friendlyName;
-            ConnectionStringFields = connectionStringFields;
         }
 
         public  string FriendlyName { get; }
@@ -23,11 +22,7 @@ namespace Oqtane.Shared
 
         public abstract string Provider { get; }
 
-        public List<ConnectionStringField> ConnectionStringFields { get; }
-
         public abstract OperationBuilder<AddColumnOperation> AddAutoIncrementColumn(ColumnsBuilder table, string name);
-
-        public abstract string BuildConnectionString();
 
         public virtual string ConcatenateSql(params string[] values)
         {


### PR DESCRIPTION
The initial code for handling multiple databases required the "Server" assemblies to be deployed to the Blazor client.  This change adds new Razor Components for each database that work in both the Installer and AddSite Components.