### PR TITLE
Few Enhancements in Language Management

### DIFF
--- a/Oqtane.Client/Modules/Admin/Languages/Add.razor
+++ b/Oqtane.Client/Modules/Admin/Languages/Add.razor
@@ -16,39 +16,39 @@ else
 {
     <TabStrip>
         <TabPanel Name="Manage" ResourceKey="Manage">
-            @if (_supportedCultures?.Count() > 1)
+            @if (_availableCultures.Count() == 0)
             {
-                <table class="table table-borderless">
-                    <tr>
-                        <td>
-                            <Label For="name" HelpText="Name Of The Language" ResourceKey="Name">Name:</Label>
-                        </td>
-                        <td>
-                            <select id="_code" class="form-control" @bind="@_code">
-                                @foreach (var culture in _supportedCultures)
-                                {
-                                    <option value="@culture.Name">@culture.DisplayName</option>
-                                }
-                            </select>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <Label For="default" HelpText="Indicates Whether Or Not This Language Is The Default For The Site" ResourceKey="IsDefault">Default?</Label>
-                        </td>
-                        <td>
-                            <select id="default" class="form-control" @bind="@_isDefault">
-                                <option value="True">@Localizer["Yes"]</option>
-                                <option value="False">@Localizer["No"]</option>
-                            </select>
-                        </td>
-                    </tr>
-                </table>
-                <button type="button" class="btn btn-success" @onclick="SaveLanguage">@Localizer["Save"]</button>
+                <ModuleMessage Type="MessageType.Info" Message="@_message"></ModuleMessage>
             }
             else
             {
-                <ModuleMessage Type="MessageType.Info" Message="The Only Installed Language Is English"></ModuleMessage>
+            <table class="table table-borderless">
+                <tr>
+                    <td>
+                        <Label For="name" HelpText="Name Of The Language" ResourceKey="Name">Name:</Label>
+                    </td>
+                    <td>
+                        <select id="_code" class="form-control" @bind="@_code">
+                            @foreach (var culture in _availableCultures)
+                            {
+                                <option value="@culture.Name">@culture.DisplayName</option>
+                            }
+                        </select>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <Label For="default" HelpText="Indicates Whether Or Not This Language Is The Default For The Site" ResourceKey="IsDefault">Default?</Label>
+                    </td>
+                    <td>
+                        <select id="default" class="form-control" @bind="@_isDefault">
+                            <option value="True">@Localizer["Yes"]</option>
+                            <option value="False">@Localizer["No"]</option>
+                        </select>
+                    </td>
+                </tr>
+            </table>
+            <button type="button" class="btn btn-success" @onclick="SaveLanguage">@Localizer["Save"]</button>
             }
             <NavLink class="btn btn-secondary" href="@NavigateUrl()">@Localizer["Cancel"]</NavLink>
         </TabPanel>
@@ -98,17 +98,31 @@ else
 @code {
     private string _code = string.Empty;
     private string _isDefault = "False";
+    private string _message;
+    private IEnumerable<Culture> _supportedCultures;
+    private IEnumerable<Culture> _availableCultures;
     private List<Package> _packages;
 
     public override SecurityAccessLevel SecurityAccessLevel => SecurityAccessLevel.Admin;
 
-    private IEnumerable<Culture> _supportedCultures;
-
     protected override async Task OnParametersSetAsync()
     {
+        var languages = await LanguageService.GetLanguagesAsync(PageState.Site.SiteId);
+        var languagesCodes = languages.Select(l => l.Code).ToList();
+
         _supportedCultures = await LocalizationService.GetCulturesAsync();
-        _supportedCultures = _supportedCultures.Where(c => !c.Name.Equals(Constants.DefaultCulture));
+        _availableCultures = _supportedCultures
+            .Where(c => !c.Name.Equals(Constants.DefaultCulture) && !languagesCodes.Contains(c.Name));
         _packages = await PackageService.GetPackagesAsync("language");
+
+        if (_supportedCultures.Count() == 1)
+        {
+            _message = Localizer["The Only Installed Language Is English"];
+        }
+        else if (_availableCultures.Count() == 0)
+        {
+            _message = Localizer["All The Installed Languages Have Been Added."];
+        }
     }
 
     private async Task SaveLanguage()

--- a/Oqtane.Client/Modules/Admin/Languages/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Languages/Index.razor
@@ -22,7 +22,7 @@ else
             <th style="width: 1px;">&nbsp;</th>
         </Header>
         <Row>
-            <td><ActionDialog Header="Delete Langauge" Message="@Localizer["Are You Sure You Wish To Delete The {0} Language From This Site?", context.Name]" Action="Delete" Security="SecurityAccessLevel.Admin" Class="btn btn-danger" OnClick="@(async () => await DeleteLanguage(context))" Disabled="@(context.IsDefault)" ResourceKey="DeleteLanguage" /></td>
+            <td><ActionDialog Header="Delete Langauge" Message="@Localizer["Are You Sure You Wish To Delete The {0} Language From This Site?", context.Name]" Action="Delete" Security="SecurityAccessLevel.Admin" Class="btn btn-danger" OnClick="@(async () => await DeleteLanguage(context))" Disabled="@(context.IsDefault || context.Code == Constants.DefaultCulture)" ResourceKey="DeleteLanguage" /></td>
             <td>@context.Name</td>
             <td>@context.Code</td>
             <td><TriStateCheckBox Value="@(context.IsDefault)" Disabled="true"></TriStateCheckBox></td>
@@ -45,12 +45,13 @@ else
     protected override async Task OnParametersSetAsync()
     {
         _languages = await LanguageService.GetLanguagesAsync(PageState.Site.SiteId);
-        if (_languages.Count == 0)
-        {
-            var cultures = await LocalizationService.GetCulturesAsync();
-            var culture = cultures.First(c => c.Name.Equals(Constants.DefaultCulture));
-            _languages.Add(new Language { Name = culture.DisplayName, Code = culture.Name, IsDefault = culture.IsDefault });
-        }
+
+        var cultures = await LocalizationService.GetCulturesAsync();
+        var culture = cultures.First(c => c.Name.Equals(Constants.DefaultCulture));
+        
+        // Adds English as default language
+        _languages.Insert(0, new Language { Name = culture.DisplayName, Code = culture.Name, IsDefault = culture.IsDefault });
+
         if (UserSecurity.IsAuthorized(PageState.User, RoleNames.Host))
         {
             _packages = await PackageService.GetPackagesAsync("language");

--- a/Oqtane.Client/Modules/Admin/Languages/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Languages/Index.razor
@@ -50,7 +50,7 @@ else
         var culture = cultures.First(c => c.Name.Equals(Constants.DefaultCulture));
         
         // Adds English as default language
-        _languages.Insert(0, new Language { Name = culture.DisplayName, Code = culture.Name, IsDefault = culture.IsDefault });
+        _languages.Insert(0, new Language { Name = culture.DisplayName, Code = culture.Name, IsDefault = !_languages.Any(l => l.IsDefault) });
 
         if (UserSecurity.IsAuthorized(PageState.User, RoleNames.Host))
         {

--- a/Oqtane.Client/Modules/Admin/Languages/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Languages/Index.razor
@@ -22,7 +22,7 @@ else
             <th style="width: 1px;">&nbsp;</th>
         </Header>
         <Row>
-            <td><ActionDialog Header="Delete Langauge" Message="@Localizer["Are You Sure You Wish To Delete The {0} Language From This Site?", context.Name]" Action="Delete" Security="SecurityAccessLevel.Admin" Class="btn btn-danger" OnClick="@(async () => await DeleteLanguage(context))" Disabled="@(context.IsDefault || context.Code == Constants.DefaultCulture)" ResourceKey="DeleteLanguage" /></td>
+            <td><ActionDialog Header="Delete Langauge" Message="@Localizer["Are You Sure You Wish To Delete The {0} Language From This Site?", context.Name]" Action="Delete" Security="SecurityAccessLevel.Admin" Class="btn btn-danger" OnClick="@(async () => await DeleteLanguage(context))" Disabled="@((context.IsDefault && _languages.Count > 2) || context.Code == Constants.DefaultCulture)" ResourceKey="DeleteLanguage" /></td>
             <td>@context.Name</td>
             <td>@context.Code</td>
             <td><TriStateCheckBox Value="@(context.IsDefault)" Disabled="true"></TriStateCheckBox></td>


### PR DESCRIPTION
This includes:

- Show the Default language in the languages list
- Ability to delete the default language if it's a last language alongside with English, this is useful when the website is no longer support multilingual
- Fix the UX when adding a new language