### PR TITLE
Remove dependency of Oqtane.Server on SqlClient

### DIFF
--- a/Oqtane.Database.SqlServer/LocalDbDatabase.cs
+++ b/Oqtane.Database.SqlServer/LocalDbDatabase.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using Oqtane.Models;
-
-namespace Oqtane.Repository.Databases
+namespace Oqtane.Database.SqlServer
 {
     public class LocalDbDatabase : SqlServerDatabaseBase
     {

--- a/Oqtane.Database.SqlServer/SqlServerDatabase.cs
+++ b/Oqtane.Database.SqlServer/SqlServerDatabase.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using Oqtane.Models;
-
-namespace Oqtane.Repository.Databases
+namespace Oqtane.Database.SqlServer
 {
     public class SqlServerDatabase : SqlServerDatabaseBase
     {

--- a/Oqtane.Database.SqlServer/SqlServerDatabaseBase.cs
+++ b/Oqtane.Database.SqlServer/SqlServerDatabaseBase.cs
@@ -1,11 +1,12 @@
-using System.Collections.Generic;
+using System;
+using System.Data;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
-using Oqtane.Models;
 using Oqtane.Shared;
 
-namespace Oqtane.Repository.Databases
+namespace Oqtane.Database.SqlServer
 {
     public abstract class SqlServerDatabaseBase : OqtaneDatabaseBase
     {
@@ -20,9 +21,55 @@ namespace Oqtane.Repository.Databases
             return table.Column<int>(name: name, nullable: false).Annotation("SqlServer:Identity", "1, 1");
         }
 
+        public override int ExecuteNonQuery(string connectionString, string query)
+        {
+            var conn = new SqlConnection(FormatConnectionString(connectionString));
+            var cmd = conn.CreateCommand();
+            using (conn)
+            {
+                PrepareCommand(conn, cmd, query);
+                var val = -1;
+                try
+                {
+                    val = cmd.ExecuteNonQuery();
+                }
+                catch
+                {
+                    // an error occurred executing the query
+                }
+                return val;
+            }
+
+        }
+
+        public override IDataReader ExecuteReader(string connectionString, string query)
+        {
+            var conn = new SqlConnection(FormatConnectionString(connectionString));
+            var cmd = conn.CreateCommand();
+            PrepareCommand(conn, cmd, query);
+            var dr = cmd.ExecuteReader(CommandBehavior.CloseConnection);
+            return dr;
+        }
+
         public override DbContextOptionsBuilder UseDatabase(DbContextOptionsBuilder optionsBuilder, string connectionString)
         {
             return optionsBuilder.UseSqlServer(connectionString);
+        }
+
+        private string FormatConnectionString(string connectionString)
+        {
+            return connectionString.Replace("|DataDirectory|", AppDomain.CurrentDomain.GetData("DataDirectory").ToString());
+        }
+
+        private void PrepareCommand(SqlConnection conn, SqlCommand cmd, string query)
+        {
+            if (conn.State != ConnectionState.Open)
+            {
+                conn.Open();
+            }
+            cmd.Connection = conn;
+            cmd.CommandText = query;
+            cmd.CommandType = CommandType.Text;
         }
     }
 }

--- a/Oqtane.Database.Sqlite/SqliteDatabase.cs
+++ b/Oqtane.Database.Sqlite/SqliteDatabase.cs
@@ -1,12 +1,12 @@
 using System;
-using System.Collections.Generic;
+using System.Data;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
-using Oqtane.Models;
 using Oqtane.Shared;
 
-namespace Oqtane.Repository.Databases
+namespace Oqtane.Database.Sqlite
 {
     public class SqliteDatabase : OqtaneDatabaseBase
     {
@@ -38,9 +38,50 @@ namespace Oqtane.Repository.Databases
             return returnValue;
         }
 
+        public override int ExecuteNonQuery(string connectionString, string query)
+        {
+            var conn = new SqliteConnection(connectionString);
+            var cmd = conn.CreateCommand();
+            using (conn)
+            {
+                PrepareCommand(conn, cmd, query);
+                var val = -1;
+                try
+                {
+                    val = cmd.ExecuteNonQuery();
+                }
+                catch
+                {
+                    // an error occurred executing the query
+                }
+                return val;
+            }
+
+        }
+
+        public override IDataReader ExecuteReader(string connectionString, string query)
+        {
+            var conn = new SqliteConnection(connectionString);
+            var cmd = conn.CreateCommand();
+            PrepareCommand(conn, cmd, query);
+            var dr = cmd.ExecuteReader(CommandBehavior.CloseConnection);
+            return dr;
+        }
+
         public override DbContextOptionsBuilder UseDatabase(DbContextOptionsBuilder optionsBuilder, string connectionString)
         {
             return optionsBuilder.UseSqlite(connectionString);
+        }
+
+        private void PrepareCommand(SqliteConnection conn, SqliteCommand cmd, string query)
+        {
+            if (conn.State != ConnectionState.Open)
+            {
+                conn.Open();
+            }
+            cmd.Connection = conn;
+            cmd.CommandText = query;
+            cmd.CommandType = CommandType.Text;
         }
     }
 }

--- a/Oqtane.Server/Controllers/SqlController.cs
+++ b/Oqtane.Server/Controllers/SqlController.cs
@@ -7,7 +7,7 @@ using Oqtane.Infrastructure;
 using Oqtane.Repository;
 using Oqtane.Enums;
 using System;
-using Microsoft.Data.SqlClient;
+using System.Data;
 
 namespace Oqtane.Controllers
 {
@@ -37,7 +37,7 @@ namespace Oqtane.Controllers
             {
                 foreach (string query in sqlquery.Query.Split("GO", StringSplitOptions.RemoveEmptyEntries))
                 {
-                    SqlDataReader dr = _sql.ExecuteReader(tenant, query);
+                    IDataReader dr = _sql.ExecuteReader(tenant, query);
                     _logger.Log(LogLevel.Information, this, LogFunction.Other, "Sql Query {Query} Executed on Tenant {TenantId}", query, sqlquery.TenantId);
                     while (dr.Read())
                     {

--- a/Oqtane.Server/Infrastructure/DatabaseManager.cs
+++ b/Oqtane.Server/Infrastructure/DatabaseManager.cs
@@ -232,7 +232,7 @@ namespace Oqtane.Infrastructure
                             var installation = IsInstalled();
                             if (installation.Success && (install.DatabaseType == "SqlServer" || install.DatabaseType == "LocalDB"))
                             {
-                                UpgradeSqlServer(sql, install.ConnectionString, true);
+                                UpgradeSqlServer(sql, install.ConnectionString, install.DatabaseType, true);
                             }
                             // Push latest model into database
                             masterDbContext.Database.Migrate();
@@ -344,9 +344,9 @@ namespace Oqtane.Infrastructure
                             var dbConfig = new DbConfig(null, null, databases) {ConnectionString = tenant.DBConnectionString, DatabaseType = tenant.DBType};
                             using (var tenantDbContext = new TenantDBContext(dbConfig, null))
                             {
-                                if (install.DatabaseType == "SqlServer" || install.DatabaseType == "LocalDB")
+                                if (dbConfig.DatabaseType == "SqlServer" || dbConfig.DatabaseType == "LocalDB")
                                 {
-                                    UpgradeSqlServer(sql, tenant.DBConnectionString, false);
+                                    UpgradeSqlServer(sql, tenant.DBConnectionString, tenant.DBType, false);
                                 }
 
                                 // Push latest model into database
@@ -649,11 +649,11 @@ namespace Oqtane.Infrastructure
             _config.Reload();
         }
 
-        public void UpgradeSqlServer(ISqlRepository sql, string connectionString, bool isMaster)
+        public void UpgradeSqlServer(ISqlRepository sql, string connectionString, string databaseType, bool isMaster)
         {
             var script = (isMaster) ? "MigrateMaster.sql" : "MigrateTenant.sql";
 
-            sql.ExecuteScript(connectionString, Assembly.GetExecutingAssembly(), script);
+            sql.ExecuteScript(connectionString, databaseType, Assembly.GetExecutingAssembly(), script);
         }
     }
 }

--- a/Oqtane.Server/Oqtane.Server.csproj
+++ b/Oqtane.Server/Oqtane.Server.csproj
@@ -32,7 +32,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="5.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.4" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.4">
       <PrivateAssets>all</PrivateAssets>

--- a/Oqtane.Server/Repository/Interfaces/ISqlRepository.cs
+++ b/Oqtane.Server/Repository/Interfaces/ISqlRepository.cs
@@ -1,5 +1,5 @@
-﻿using System.Reflection;
-using Microsoft.Data.SqlClient;
+﻿using System.Data;
+using System.Reflection;
 using Oqtane.Models;
 
 namespace Oqtane.Repository
@@ -8,12 +8,12 @@ namespace Oqtane.Repository
     {
         void ExecuteScript(Tenant tenant, string script);
 
-        bool ExecuteScript(string connectionString, Assembly assembly, string filename);
+        bool ExecuteScript(string connectionString, string databaseType, Assembly assembly, string filename);
 
         bool ExecuteScript(Tenant tenant, Assembly assembly, string filename);
 
         int ExecuteNonQuery(Tenant tenant, string query);
 
-        SqlDataReader ExecuteReader(Tenant tenant, string query);
+        IDataReader ExecuteReader(Tenant tenant, string query);
     }
 }

--- a/Oqtane.Shared/Interfaces/IOqtaneDatabase.cs
+++ b/Oqtane.Shared/Interfaces/IOqtaneDatabase.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
@@ -17,6 +18,10 @@ namespace Oqtane.Interfaces
         public OperationBuilder<AddColumnOperation> AddAutoIncrementColumn(ColumnsBuilder table, string name);
 
         public string ConcatenateSql(params string[] values);
+
+        public int ExecuteNonQuery(string connectionString, string query);
+
+        public IDataReader ExecuteReader(string connectionString, string query);
 
         public string RewriteName(string name);
 

--- a/Oqtane.Shared/Shared/OqtaneDatabaseBase.cs
+++ b/Oqtane.Shared/Shared/OqtaneDatabaseBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
@@ -38,6 +39,10 @@ namespace Oqtane.Shared
 
             return returnValue;
         }
+
+        public abstract int ExecuteNonQuery(string connectionString, string query);
+
+        public abstract IDataReader ExecuteReader(string connectionString, string query);
 
         public virtual string RewriteName(string name)
         {


### PR DESCRIPTION
The SqlRepository class is dependent on SqlClient (Sql Server).  In order to support multiple databases, this dependency must be removed, and replaced by a dependency on IOqtaneDatabase.  This pull request adds two new methods to IOqtaneDatabase, ExecuteRedaer and ExecuteNonQuery as well as the specific implementations in the 4 database projects.  The implementation has been tested in Sql Server and Sqlite.

In addition there are some minor namespace changes in the new database projects - for consistency