### PR TITLE
Switch DBType to use the fully-qualified type name rather than a simple name

### DIFF
--- a/Oqtane.Client/Installer/Installer.razor
+++ b/Oqtane.Client/Installer/Installer.razor
@@ -135,7 +135,7 @@
         var database = _databases.SingleOrDefault(d => d.Name == _databaseName);
         if (database != null)
         {
-            _databaseConfigType = Type.GetType(database.Type);
+            _databaseConfigType = Type.GetType(database.ControlType);
             DatabaseConfigComponent = builder =>
             {
                 builder.OpenComponent(0, _databaseConfigType);
@@ -169,10 +169,12 @@
             StateHasChanged();
 
             Uri uri = new Uri(NavigationManager.Uri);
+            
+            var database = _databases.SingleOrDefault(d => d.Name == _databaseName);
 
             var config = new InstallConfig
             {
-                DatabaseType = _databaseName,
+                DatabaseType = database.DBType,
                 ConnectionString = connectionString,
                 Aliases = uri.Authority,
                 HostEmail = _hostEmail,

--- a/Oqtane.Client/Modules/Admin/Sites/Add.razor
+++ b/Oqtane.Client/Modules/Admin/Sites/Add.razor
@@ -221,7 +221,7 @@ else
         var database = _databases.SingleOrDefault(d => d.Name == _databaseName);
         if (database != null)
         {
-            _databaseConfigType = Type.GetType(database.Type);
+            _databaseConfigType = Type.GetType(database.ControlType);
             DatabaseConfigComponent = builder =>
             {
                 builder.OpenComponent(0, _databaseConfigType);
@@ -301,9 +301,11 @@ else
                             {
                                 connectionString = databaseConfigControl.GetConnectionString();
                             }
+                            var database = _databases.SingleOrDefault(d => d.Name == _databaseName);
+                            
                             if (connectionString != "")
                             {
-                                config.DatabaseType = _databaseName;
+                                config.DatabaseType = database.DBType;
                                 config.ConnectionString = connectionString;
                                 config.HostPassword = _hostpassword;
                                 config.HostEmail = user.Email;

--- a/Oqtane.Database.MySQL/MySQLDatabase.cs
+++ b/Oqtane.Database.MySQL/MySQLDatabase.cs
@@ -18,6 +18,8 @@ namespace Oqtane.Database.MySQL
 
         public override string Provider => "MySql.EntityFrameworkCore";
 
+        public override string TypeName => "Oqtane.Database.MySQL.MySQLDatabase, Oqtane.Database.MySQL";
+
         public override OperationBuilder<AddColumnOperation> AddAutoIncrementColumn(ColumnsBuilder table, string name)
         {
             return table.Column<int>(name: name, nullable: false).Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn);

--- a/Oqtane.Database.PostgreSQL/PostgreSQLDatabase.cs
+++ b/Oqtane.Database.PostgreSQL/PostgreSQLDatabase.cs
@@ -26,6 +26,8 @@ namespace Oqtane.Database.PostgreSQL
 
         public override string Provider => "Npgsql.EntityFrameworkCore.PostgreSQL";
 
+        public override string TypeName => "Oqtane.Database.PostgreSQL.PostgreSQLDatabase, Oqtane.Database.PostgreSQL";
+
         public override OperationBuilder<AddColumnOperation> AddAutoIncrementColumn(ColumnsBuilder table, string name)
         {
             return table.Column<int>(name: name, nullable: false).Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityAlwaysColumn);

--- a/Oqtane.Database.SqlServer/LocalDbDatabase.cs
+++ b/Oqtane.Database.SqlServer/LocalDbDatabase.cs
@@ -6,5 +6,7 @@ namespace Oqtane.Database.SqlServer
         private static string _name => "LocalDB";
 
         public LocalDbDatabase() :base(_name, _friendlyName) { }
+
+        public override string TypeName => "Oqtane.Database.SqlServer.LocalDbDatabase, Oqtane.Database.SqlServer";
     }
 }

--- a/Oqtane.Database.SqlServer/SqlServerDatabase.cs
+++ b/Oqtane.Database.SqlServer/SqlServerDatabase.cs
@@ -6,6 +6,8 @@ namespace Oqtane.Database.SqlServer
 
         private static string _name => "SqlServer";
 
-        public SqlServerDatabase() :base(_name, _friendlyName) { }
+        public SqlServerDatabase() : base(_name, _friendlyName) { }
+
+        public override string TypeName => "Oqtane.Database.SqlServer.SqlServerDatabase, Oqtane.Database.SqlServer";
     }
 }

--- a/Oqtane.Database.Sqlite/SqliteDatabase.cs
+++ b/Oqtane.Database.Sqlite/SqliteDatabase.cs
@@ -18,6 +18,8 @@ namespace Oqtane.Database.Sqlite
 
         public override string Provider => "Microsoft.EntityFrameworkCore.Sqlite";
 
+        public override string TypeName => "Oqtane.Database.Sqlite.SqliteDatabase, Oqtane.Database.Sqlite";
+
         public override OperationBuilder<AddColumnOperation> AddAutoIncrementColumn(ColumnsBuilder table, string name)
         {
             return table.Column<int>(name: name, nullable: false).Annotation("Sqlite:Autoincrement", true);

--- a/Oqtane.Server/Controllers/DatabaseController.cs
+++ b/Oqtane.Server/Controllers/DatabaseController.cs
@@ -19,31 +19,36 @@ namespace Oqtane.Controllers
                 {
                     Name = "LocalDB",
                     FriendlyName = "Local Database",
-                    Type = "Oqtane.Installer.Controls.LocalDBConfig, Oqtane.Client"
+                    ControlType = "Oqtane.Installer.Controls.LocalDBConfig, Oqtane.Client",
+                    DBType = "Oqtane.Database.SqlServer.LocalDbDatabase, Oqtane.Database.SqlServer"
                 },
                 new()
                 {
                     Name = "SqlServer",
                     FriendlyName = "SQL Server",
-                    Type = "Oqtane.Installer.Controls.SqlServerConfig, Oqtane.Client"
+                    ControlType = "Oqtane.Installer.Controls.SqlServerConfig, Oqtane.Client",
+                    DBType = "Oqtane.Database.SqlServer.SqlServerDatabase, Oqtane.Database.SqlServer"
                 },
                 new()
                 {
                     Name = "Sqlite",
                     FriendlyName = "Sqlite",
-                    Type = "Oqtane.Installer.Controls.SqliteConfig, Oqtane.Client"
+                    ControlType = "Oqtane.Installer.Controls.SqliteConfig, Oqtane.Client",
+                    DBType = "Oqtane.Database.Sqlite.SqliteDatabase, Oqtane.Database.Sqlite"
                 },
                 new()
                 {
                     Name = "MySQL",
                     FriendlyName = "MySQL",
-                    Type = "Oqtane.Installer.Controls.MySQLConfig, Oqtane.Client"
+                    ControlType = "Oqtane.Installer.Controls.MySQLConfig, Oqtane.Client",
+                    DBType = "Oqtane.Database.MySQL.MySQLDatabase, Oqtane.Database.MySQL"
                 },
                 new()
                 {
                     Name = "PostgreSQL",
                     FriendlyName = "PostgreSQL",
-                    Type = "Oqtane.Installer.Controls.PostGreSQLConfig, Oqtane.Client"
+                    ControlType = "Oqtane.Installer.Controls.PostGreSQLConfig, Oqtane.Client",
+                    DBType = "Oqtane.Database.PostgreSQL.PostgreSQLDatabase, Oqtane.Database.PostgreSQL"
                 }
             };
             return databases;

--- a/Oqtane.Server/Infrastructure/DatabaseManager.cs
+++ b/Oqtane.Server/Infrastructure/DatabaseManager.cs
@@ -191,7 +191,7 @@ namespace Oqtane.Infrastructure
                     {
                         var databases = scope.ServiceProvider.GetServices<IOqtaneDatabase>();
 
-                        using (var dbc = new DbContext(new DbContextOptionsBuilder().UseOqtaneDatabase(databases.Single(d => d.Name == databaseType), connectionString).Options))
+                        using (var dbc = new DbContext(new DbContextOptionsBuilder().UseOqtaneDatabase(databases.Single(d => d.TypeName == databaseType), connectionString).Options))
                         {
                             // create empty database if it does not exist
                             dbc.Database.EnsureCreated();
@@ -596,7 +596,7 @@ namespace Oqtane.Infrastructure
             var databaseType = _config.GetSection(SettingKeys.DatabaseSection)[SettingKeys.DatabaseTypeKey];
             var connectionString = NormalizeConnectionString(_config.GetConnectionString(SettingKeys.ConnectionStringKey));
 
-            return new InstallationContext(databases.Single(d => d.Name == databaseType), connectionString);
+            return new InstallationContext(databases.Single(d => d.TypeName == databaseType), connectionString);
         }
 
         private string GetInstallationConfig(string key, string defaultValue)

--- a/Oqtane.Server/Repository/Context/DBContextBase.cs
+++ b/Oqtane.Server/Repository/Context/DBContextBase.cs
@@ -84,7 +84,7 @@ namespace Oqtane.Repository
             {
                 if (Databases != null)
                 {
-                    optionsBuilder.UseOqtaneDatabase(Databases.Single(d => d.Name == _databaseType), _connectionString);
+                    optionsBuilder.UseOqtaneDatabase(Databases.Single(d => d.TypeName == _databaseType), _connectionString);
                 }
                 else
                 {
@@ -101,7 +101,7 @@ namespace Oqtane.Repository
 
             if (Databases != null)
             {
-                var database = Databases.Single(d => d.Name == _databaseType);
+                var database = Databases.Single(d => d.TypeName == _databaseType);
 
                 database.UpdateIdentityStoreTableNames(builder);
             }

--- a/Oqtane.Server/Repository/Context/MasterDBContext.cs
+++ b/Oqtane.Server/Repository/Context/MasterDBContext.cs
@@ -52,7 +52,7 @@ namespace Oqtane.Repository
             {
                 if (Databases != null)
                 {
-                    optionsBuilder.UseOqtaneDatabase(Databases.Single(d => d.Name == databaseType), connectionString);
+                    optionsBuilder.UseOqtaneDatabase(Databases.Single(d => d.TypeName == databaseType), connectionString);
                 }
                 else
                 {

--- a/Oqtane.Server/Repository/SqlRepository.cs
+++ b/Oqtane.Server/Repository/SqlRepository.cs
@@ -80,13 +80,13 @@ namespace Oqtane.Repository
 
         public IDataReader ExecuteReader(Tenant tenant, string query)
         {
-            var db = _databases.Single(d => d.Name == tenant.DBType);
+            var db = _databases.Single(d => d.TypeName == tenant.DBType);
             return db.ExecuteReader(tenant.DBConnectionString, query);
         }
 
         private int ExecuteNonQuery(string connectionString, string databaseType, string query)
         {
-            var db = _databases.Single(d => d.Name == databaseType);
+            var db = _databases.Single(d => d.TypeName == databaseType);
 
             return db.ExecuteNonQuery(connectionString, query);
         }

--- a/Oqtane.Shared/Interfaces/IOqtaneDatabase.cs
+++ b/Oqtane.Shared/Interfaces/IOqtaneDatabase.cs
@@ -15,6 +15,8 @@ namespace Oqtane.Interfaces
 
         public string Provider { get; }
 
+        public string TypeName { get; }
+
         public OperationBuilder<AddColumnOperation> AddAutoIncrementColumn(ColumnsBuilder table, string name);
 
         public string ConcatenateSql(params string[] values);

--- a/Oqtane.Shared/Models/Database.cs
+++ b/Oqtane.Shared/Models/Database.cs
@@ -6,6 +6,8 @@ namespace Oqtane.Models
 
         public string Name { get; set; }
 
-        public string Type { get; set; }
+        public string ControlType { get; set; }
+
+        public string DBType { get; set; }
     }
 }

--- a/Oqtane.Shared/Shared/OqtaneDatabaseBase.cs
+++ b/Oqtane.Shared/Shared/OqtaneDatabaseBase.cs
@@ -23,6 +23,8 @@ namespace Oqtane.Shared
 
         public abstract string Provider { get; }
 
+        public abstract string TypeName { get; }
+
         public abstract OperationBuilder<AddColumnOperation> AddAutoIncrementColumn(ColumnsBuilder table, string name);
 
         public virtual string ConcatenateSql(params string[] values)


### PR DESCRIPTION
This PR fixes issue #1317 , by using the fully-qualified type name as the database type.