### PR TITLE
Convert Database projects so they build installable Packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ msbuild.binlog
 .vscode/
 *.binlog
 *.nupkg
+*.nupkg.bak
 
 *.idea
 
@@ -17,3 +18,6 @@ Oqtane.Server/Data/*.db
 
 /Oqtane.Server/Properties/PublishProfiles/FolderProfile.pubxml
 Oqtane.Server/Content
+Oqtane.Server/wwwroot/Packages/**/assets.json
+
+

--- a/Oqtane.Client/Installer/Installer.razor
+++ b/Oqtane.Client/Installer/Installer.razor
@@ -175,6 +175,7 @@
             var config = new InstallConfig
             {
                 DatabaseType = database.DBType,
+                DatabasePackage = database.Package,
                 ConnectionString = connectionString,
                 Aliases = uri.Authority,
                 HostEmail = _hostEmail,

--- a/Oqtane.Client/Modules/Admin/Sites/Add.razor
+++ b/Oqtane.Client/Modules/Admin/Sites/Add.razor
@@ -306,6 +306,7 @@ else
                             {
                                 config.TenantName = _tenantName;
                                 config.DatabaseType = database.DBType;
+                                config.DatabasePackage = database.Package;
                                 config.ConnectionString = connectionString;
                                 config.HostEmail = user.Email;
                                 config.HostPassword = _hostpassword;

--- a/Oqtane.Database.MySQL/MySQLDatabase.cs
+++ b/Oqtane.Database.MySQL/MySQLDatabase.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
 using MySql.Data.MySqlClient;
 using MySql.EntityFrameworkCore.Metadata;
+using Oqtane.Databases;
 using Oqtane.Shared;
 
 namespace Oqtane.Database.MySQL
@@ -14,20 +15,14 @@ namespace Oqtane.Database.MySQL
 
         private static string _name => "MySQL";
 
-        private readonly static string _typeName;
-
         static MySQLDatabase()
         {
-            var typeQualifiedName = typeof(MySQLDatabase).AssemblyQualifiedName;
-
-            _typeName = typeQualifiedName.Substring(0, typeQualifiedName.IndexOf(", Version"));
+            Initialize(typeof(MySQLDatabase));
         }
 
         public MySQLDatabase() :base(_name, _friendlyName) { }
 
         public override string Provider => "MySql.EntityFrameworkCore";
-
-        public override string TypeName => _typeName;
 
         public override OperationBuilder<AddColumnOperation> AddAutoIncrementColumn(ColumnsBuilder table, string name)
         {

--- a/Oqtane.Database.MySQL/Oqtane.Database.MySQL.csproj
+++ b/Oqtane.Database.MySQL/Oqtane.Database.MySQL.csproj
@@ -1,16 +1,32 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-        <LangVersion>9</LangVersion>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>1.0.0</Version>
+    <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
+    <PackageName>$(MSBuildProjectName).$(Version).nupkg</PackageName>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="MySql.EntityFrameworkCore" Version="5.0.0" />
-    </ItemGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <OutputPath>bin</OutputPath>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Oqtane.Shared\Oqtane.Shared.csproj" />
-    </ItemGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <OutputPath>bin</OutputPath>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="MySql.EntityFrameworkCore" Version="5.0.0" />
+  </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Oqtane.Server\Oqtane.Server.csproj" />
+  </ItemGroup>
+
+  <Target Name="CopyPackage" AfterTargets="Pack">
+    <Copy SourceFiles="$(OutputPath)..\$(PackageName)" DestinationFiles="..\Oqtane.Server\wwwroot\Packages\$(PackageName).bak" />
+  </Target>
 </Project>

--- a/Oqtane.Database.MySQL/Oqtane.Database.MySQL.nuspec
+++ b/Oqtane.Database.MySQL/Oqtane.Database.MySQL.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>Oqtane.Database.MySQL</id>
+        <version>1.0.0</version>
+        <authors>Shaun Walker</authors>
+        <owners>.NET Foundation</owners>
+        <title>Oqtane MySQL Provider</title>
+        <description>Add support for MySQL to the Oqtane Framework</description>
+        <copyright>.NET Foundation</copyright>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <license type="expression">MIT</license>
+        <projectUrl>https://github.com/oqtane/oqtane.framework</projectUrl>
+        <iconUrl>https://www.oqtane.org/Portals/0/icon.jpg</iconUrl>
+        <tags>oqtane</tags>
+        <releaseNotes>https://github.com/oqtane/oqtane.framework/releases/tag/v2.0.2</releaseNotes>
+        <summary>Add support for MySQL to the Oqtane Framework</summary>
+    </metadata>
+    <files>
+        <file src="bin\net5.0\Oqtane.Database.MySQL.dll" target="lib\net5.0" />
+        <file src="bin\net5.0\Oqtane.Database.MySQL.pdb" target="lib\net5.0" />
+        <file src="bin\net5.0\Mysql.EntityFrameworkCore.dll" target="lib\net5.0" />
+        <file src="bin\net5.0\Mysql.Data.dll" target="lib\net5.0" />
+    </files>
+</package>

--- a/Oqtane.Database.PostgreSQL/Oqtane.Database.PostgreSQL.csproj
+++ b/Oqtane.Database.PostgreSQL/Oqtane.Database.PostgreSQL.csproj
@@ -1,18 +1,34 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <LangVersion>9</LangVersion>
-        <TargetFramework>net5.0</TargetFramework>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>1.0.0</Version>
+    <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
+    <PackageName>$(MSBuildProjectName).$(Version).nupkg</PackageName>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="EFCore.NamingConventions" Version="5.0.2" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.4" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.2" />
-    </ItemGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <OutputPath>bin</OutputPath>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Oqtane.Shared\Oqtane.Shared.csproj" />
-    </ItemGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <OutputPath>bin</OutputPath>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="EFCore.NamingConventions" Version="5.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.4" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.2" />
+  </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Oqtane.Server\Oqtane.Server.csproj" />
+  </ItemGroup>
+
+  <Target Name="CopyPackage" AfterTargets="Pack">
+    <Copy SourceFiles="$(OutputPath)..\$(PackageName)" DestinationFiles="..\Oqtane.Server\wwwroot\Packages\$(PackageName).bak" />
+  </Target>
 </Project>

--- a/Oqtane.Database.PostgreSQL/Oqtane.Database.PostgreSQL.nuspec
+++ b/Oqtane.Database.PostgreSQL/Oqtane.Database.PostgreSQL.nuspec
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>Oqtane.Database.PostgreSQL</id>
+        <version>1.0.0</version>
+        <authors>Shaun Walker</authors>
+        <owners>.NET Foundation</owners>
+        <title>Oqtane PostgreSQL Provider</title>
+        <description>Add support for PostgreSQL to the Oqtane Framework</description>
+        <copyright>.NET Foundation</copyright>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <license type="expression">MIT</license>
+        <projectUrl>https://github.com/oqtane/oqtane.framework</projectUrl>
+        <iconUrl>https://www.oqtane.org/Portals/0/icon.jpg</iconUrl>
+        <tags>oqtane</tags>
+        <releaseNotes>https://github.com/oqtane/oqtane.framework/releases/tag/v2.0.2</releaseNotes>
+        <summary>Add support for PostgreSQL to the Oqtane Framework</summary>
+    </metadata>
+    <files>
+        <file src="bin\net5.0\Oqtane.Database.PostgreSQL.dll" target="lib\net5.0" />
+        <file src="bin\net5.0\Oqtane.Database.PostgreSQL.pdb" target="lib\net5.0" />
+        <file src="bin\net5.0\EFCore.NamingConventions.dll" target="lib\net5.0" />
+        <file src="bin\net5.0\Npgsql.EntityFrameworkCore.PostgreSQL.dll" target="lib\net5.0" />
+        <file src="bin\net5.0\Npgsql.dll" target="lib\net5.0" />
+    </files>
+</package>

--- a/Oqtane.Database.PostgreSQL/PostgreSQLDatabase.cs
+++ b/Oqtane.Database.PostgreSQL/PostgreSQLDatabase.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
 using Npgsql;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using Oqtane.Databases;
 using Oqtane.Shared;
 
 namespace Oqtane.Database.PostgreSQL
@@ -17,15 +18,11 @@ namespace Oqtane.Database.PostgreSQL
 
         private static string _name => "PostgreSQL";
 
-        private readonly static string _typeName;
-
         private readonly INameRewriter _rewriter;
 
         static PostgreSQLDatabase()
         {
-            var typeQualifiedName = typeof(PostgreSQLDatabase).AssemblyQualifiedName;
-
-            _typeName = typeQualifiedName.Substring(0, typeQualifiedName.IndexOf(", Version"));
+            Initialize(typeof(PostgreSQLDatabase));
         }
 
         public PostgreSQLDatabase() : base(_name, _friendlyName)
@@ -34,8 +31,6 @@ namespace Oqtane.Database.PostgreSQL
         }
 
         public override string Provider => "Npgsql.EntityFrameworkCore.PostgreSQL";
-
-        public override string TypeName => _typeName;
 
         public override OperationBuilder<AddColumnOperation> AddAutoIncrementColumn(ColumnsBuilder table, string name)
         {

--- a/Oqtane.Database.SqlServer/LocalDbDatabase.cs
+++ b/Oqtane.Database.SqlServer/LocalDbDatabase.cs
@@ -5,17 +5,11 @@ namespace Oqtane.Database.SqlServer
         private static string _friendlyName => "Local Database";
         private static string _name => "LocalDB";
 
-        private readonly static string _typeName;
-
         static LocalDbDatabase()
         {
-            var typeQualifiedName = typeof(LocalDbDatabase).AssemblyQualifiedName;
-
-            _typeName = typeQualifiedName.Substring(0, typeQualifiedName.IndexOf(", Version"));
+            Initialize(typeof(LocalDbDatabase));
         }
 
         public LocalDbDatabase() :base(_name, _friendlyName) { }
-
-        public override string TypeName => _typeName;
     }
 }

--- a/Oqtane.Database.SqlServer/Oqtane.Database.SqlServer.csproj
+++ b/Oqtane.Database.SqlServer/Oqtane.Database.SqlServer.csproj
@@ -1,15 +1,33 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>1.0.0</Version>
+    <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
+    <PackageName>$(MSBuildProjectName).$(Version).nupkg</PackageName>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.4" />
-    </ItemGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <OutputPath>bin</OutputPath>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Oqtane.Shared\Oqtane.Shared.csproj" />
-    </ItemGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <OutputPath>bin</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Oqtane.Server\Oqtane.Server.csproj" />
+  </ItemGroup>
+
+  <Target Name="CopyPackage" AfterTargets="Pack">
+    <Copy SourceFiles="$(OutputPath)..\$(PackageName)" DestinationFiles="..\Oqtane.Server\wwwroot\Packages\$(PackageName).bak" />
+  </Target>
 
 </Project>

--- a/Oqtane.Database.SqlServer/Oqtane.Database.SqlServer.nuspec
+++ b/Oqtane.Database.SqlServer/Oqtane.Database.SqlServer.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>Oqtane.Database.SqlServer</id>
+        <version>1.0.0</version>
+        <authors>Shaun Walker</authors>
+        <owners>.NET Foundation</owners>
+        <title>Oqtane SqlServer Provider</title>
+        <description>Add support for SqlServer to the Oqtane Framework</description>
+        <copyright>.NET Foundation</copyright>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <license type="expression">MIT</license>
+        <projectUrl>https://github.com/oqtane/oqtane.framework</projectUrl>
+        <iconUrl>https://www.oqtane.org/Portals/0/icon.jpg</iconUrl>
+        <tags>oqtane</tags>
+        <releaseNotes>https://github.com/oqtane/oqtane.framework/releases/tag/v2.0.2</releaseNotes>
+        <summary>Add support for SqlServer to the Oqtane Framework</summary>
+    </metadata>
+    <files>
+        <file src="bin\net5.0\Oqtane.Database.SqlServer.dll" target="lib\net5.0" />
+        <file src="bin\net5.0\Oqtane.Database.SqlServer.pdb" target="lib\net5.0" />
+        <file src="bin\net5.0\Microsoft.EntityFrameworkCore.SqlServer.dll" target="lib\net5.0" />
+    </files>
+</package>

--- a/Oqtane.Database.SqlServer/SqlServerDatabase.cs
+++ b/Oqtane.Database.SqlServer/SqlServerDatabase.cs
@@ -6,17 +6,11 @@ namespace Oqtane.Database.SqlServer
 
         private static string _name => "SqlServer";
 
-        private readonly static string _typeName;
-
         static SqlServerDatabase()
         {
-            var typeQualifiedName = typeof(SqlServerDatabase).AssemblyQualifiedName;
-
-            _typeName = typeQualifiedName.Substring(0, typeQualifiedName.IndexOf(", Version"));
+            Initialize(typeof(SqlServerDatabase));
         }
 
         public SqlServerDatabase() : base(_name, _friendlyName) { }
-
-        public override string TypeName => _typeName;
     }
 }

--- a/Oqtane.Database.SqlServer/SqlServerDatabaseBase.cs
+++ b/Oqtane.Database.SqlServer/SqlServerDatabaseBase.cs
@@ -4,6 +4,7 @@ using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases;
 using Oqtane.Shared;
 
 namespace Oqtane.Database.SqlServer

--- a/Oqtane.Database.Sqlite/Oqtane.Database.Sqlite.csproj
+++ b/Oqtane.Database.Sqlite/Oqtane.Database.Sqlite.csproj
@@ -1,15 +1,33 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>1.0.0</Version>
+    <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
+    <PackageName>$(MSBuildProjectName).$(Version).nupkg</PackageName>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.4" />
-    </ItemGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <OutputPath>bin</OutputPath>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Oqtane.Shared\Oqtane.Shared.csproj" />
-    </ItemGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <OutputPath>bin</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Oqtane.Server\Oqtane.Server.csproj" />
+  </ItemGroup>
+
+  <Target Name="CopyPackage" AfterTargets="Pack">
+    <Copy SourceFiles="$(OutputPath)..\$(PackageName)" DestinationFiles="..\Oqtane.Server\wwwroot\Packages\$(PackageName).bak" />
+  </Target>
 
 </Project>

--- a/Oqtane.Database.Sqlite/Oqtane.Database.Sqlite.nuspec
+++ b/Oqtane.Database.Sqlite/Oqtane.Database.Sqlite.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>Oqtane.Database.Sqlite</id>
+        <version>1.0.0</version>
+        <authors>Shaun Walker</authors>
+        <owners>.NET Foundation</owners>
+        <title>Oqtane Sqlite Provider</title>
+        <description>Add support for Sqlite to the Oqtane Framework</description>
+        <copyright>.NET Foundation</copyright>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <license type="expression">MIT</license>
+        <projectUrl>https://github.com/oqtane/oqtane.framework</projectUrl>
+        <iconUrl>https://www.oqtane.org/Portals/0/icon.jpg</iconUrl>
+        <tags>oqtane</tags>
+        <releaseNotes>https://github.com/oqtane/oqtane.framework/releases/tag/v2.0.2</releaseNotes>
+        <summary>Add support for Sqlite to the Oqtane Framework</summary>
+    </metadata>
+    <files>
+        <file src="bin\net5.0\Oqtane.Database.Sqlite.dll" target="lib\net5.0" />
+        <file src="bin\net5.0\Oqtane.Database.Sqlite.pdb" target="lib\net5.0" />
+        <file src="bin\net5.0\Microsoft.EntityFrameworkCore.Sqlite.dll" target="lib\net5.0" />
+    </files>
+</package>

--- a/Oqtane.Database.Sqlite/SqliteDatabase.cs
+++ b/Oqtane.Database.Sqlite/SqliteDatabase.cs
@@ -4,6 +4,7 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases;
 using Oqtane.Shared;
 
 namespace Oqtane.Database.Sqlite
@@ -14,20 +15,14 @@ namespace Oqtane.Database.Sqlite
 
         private static string _name => "Sqlite";
 
-        private readonly static string _typeName;
-
         static SqliteDatabase()
         {
-            var typeQualifiedName = typeof(SqliteDatabase).AssemblyQualifiedName;
-
-            _typeName = typeQualifiedName.Substring(0, typeQualifiedName.IndexOf(", Version"));
+            Initialize(typeof(SqliteDatabase));
         }
 
         public SqliteDatabase() :base(_name, _friendlyName) { }
 
         public override string Provider => "Microsoft.EntityFrameworkCore.Sqlite";
-
-        public override string TypeName => _typeName;
 
         public override OperationBuilder<AddColumnOperation> AddAutoIncrementColumn(ColumnsBuilder table, string name)
         {

--- a/Oqtane.Server/Controllers/DatabaseController.cs
+++ b/Oqtane.Server/Controllers/DatabaseController.cs
@@ -20,35 +20,40 @@ namespace Oqtane.Controllers
                     Name = "LocalDB",
                     FriendlyName = "Local Database",
                     ControlType = "Oqtane.Installer.Controls.LocalDBConfig, Oqtane.Client",
-                    DBType = "Oqtane.Database.SqlServer.LocalDbDatabase, Oqtane.Database.SqlServer"
+                    DBType = "Oqtane.Database.SqlServer.LocalDbDatabase, Oqtane.Database.SqlServer",
+                    Package = "Oqtane.Database.SqlServer"
                 },
                 new()
                 {
                     Name = "SqlServer",
                     FriendlyName = "SQL Server",
                     ControlType = "Oqtane.Installer.Controls.SqlServerConfig, Oqtane.Client",
-                    DBType = "Oqtane.Database.SqlServer.SqlServerDatabase, Oqtane.Database.SqlServer"
+                    DBType = "Oqtane.Database.SqlServer.SqlServerDatabase, Oqtane.Database.SqlServer",
+                    Package = "Oqtane.Database.SqlServer"
                 },
                 new()
                 {
                     Name = "Sqlite",
                     FriendlyName = "Sqlite",
                     ControlType = "Oqtane.Installer.Controls.SqliteConfig, Oqtane.Client",
-                    DBType = "Oqtane.Database.Sqlite.SqliteDatabase, Oqtane.Database.Sqlite"
+                    DBType = "Oqtane.Database.Sqlite.SqliteDatabase, Oqtane.Database.Sqlite",
+                    Package = "Oqtane.Database.Sqlite"
                 },
                 new()
                 {
                     Name = "MySQL",
                     FriendlyName = "MySQL",
                     ControlType = "Oqtane.Installer.Controls.MySQLConfig, Oqtane.Client",
-                    DBType = "Oqtane.Database.MySQL.MySQLDatabase, Oqtane.Database.MySQL"
+                    DBType = "Oqtane.Database.MySQL.MySQLDatabase, Oqtane.Database.MySQL",
+                    Package = "Oqtane.Database.MySQL"
                 },
                 new()
                 {
                     Name = "PostgreSQL",
                     FriendlyName = "PostgreSQL",
-                    ControlType = "Oqtane.Installer.Controls.PostGreSQLConfig, Oqtane.Client",
-                    DBType = "Oqtane.Database.PostgreSQL.PostgreSQLDatabase, Oqtane.Database.PostgreSQL"
+                    ControlType = "Oqtane.Installer.Controls.PostgreSQLConfig, Oqtane.Client",
+                    DBType = "Oqtane.Database.PostgreSQL.PostgreSQLDatabase, Oqtane.Database.PostgreSQL",
+                    Package = "Oqtane.Database.PostgreSQL"
                 }
             };
             return databases;

--- a/Oqtane.Server/Databases/Interfaces/IMultiDatabase.cs
+++ b/Oqtane.Server/Databases/Interfaces/IMultiDatabase.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 namespace Oqtane.Repository.Databases.Interfaces

--- a/Oqtane.Server/Databases/Interfaces/IOqtaneDatabase.cs
+++ b/Oqtane.Server/Databases/Interfaces/IOqtaneDatabase.cs
@@ -1,14 +1,14 @@
-using System.Collections.Generic;
 using System.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
-using Oqtane.Models;
 
-namespace Oqtane.Interfaces
+namespace Oqtane.Databases.Interfaces
 {
     public interface IOqtaneDatabase
     {
+        public string AssemblyName { get; }
+
         public string FriendlyName { get; }
 
         public string Name { get; }

--- a/Oqtane.Server/Databases/OqtaneDatabaseBase.cs
+++ b/Oqtane.Server/Databases/OqtaneDatabaseBase.cs
@@ -1,29 +1,43 @@
 using System;
-using System.Collections.Generic;
 using System.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
-using Oqtane.Interfaces;
-using Oqtane.Models;
+using Oqtane.Databases.Interfaces;
 
-namespace Oqtane.Shared
+namespace Oqtane.Databases
 {
     public abstract class OqtaneDatabaseBase : IOqtaneDatabase
     {
+        private static string _assemblyName;
+
+        private static string _typeName;
+
         protected OqtaneDatabaseBase(string name, string friendlyName)
         {
             Name = name;
             FriendlyName = friendlyName;
         }
 
-        public  string FriendlyName { get; }
+        protected static void Initialize(Type type)
+        {
+            var typeQualifiedName = type.AssemblyQualifiedName;
+            var assembly = type.Assembly;
+            var assemblyName = assembly.FullName;
+
+            _typeName = typeQualifiedName.Substring(0, typeQualifiedName.IndexOf(", Version"));
+            _assemblyName = assemblyName.Substring(0, assemblyName.IndexOf(", Version"));
+        }
+
+        public string AssemblyName => _assemblyName;
+
+        public string FriendlyName { get; }
 
         public string Name { get; }
 
         public abstract string Provider { get; }
 
-        public abstract string TypeName { get; }
+        public string TypeName => _typeName;
 
         public abstract OperationBuilder<AddColumnOperation> AddAutoIncrementColumn(ColumnsBuilder table, string name);
 

--- a/Oqtane.Server/Extensions/DbContextOptionsBuilderExtensions.cs
+++ b/Oqtane.Server/Extensions/DbContextOptionsBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 // ReSharper disable ConvertToUsingDeclaration
 

--- a/Oqtane.Server/Extensions/OqtaneServiceCollectionExtensions.cs
+++ b/Oqtane.Server/Extensions/OqtaneServiceCollectionExtensions.cs
@@ -101,26 +101,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
                 if (!assemblies.Any(a => AssemblyName.ReferenceMatchesDefinition(assemblyName, a.GetName())))
                 {
-                    try
-                    {
-                        var pdb = Path.ChangeExtension(dll.FullName, ".pdb");
-                        Assembly assembly = null;
-
-                        // load assembly ( and symbols ) from stream to prevent locking files ( as long as dependencies are in /bin they will load as well )
-                        if (File.Exists(pdb))
-                        {
-                            assembly = AssemblyLoadContext.Default.LoadFromStream(new MemoryStream(File.ReadAllBytes(dll.FullName)), new MemoryStream(File.ReadAllBytes(pdb)));
-                        }
-                        else
-                        {
-                            assembly = AssemblyLoadContext.Default.LoadFromStream(new MemoryStream(File.ReadAllBytes(dll.FullName)));
-                        }
-                        Console.WriteLine($"Loaded : {assemblyName}");
-                    }
-                    catch (Exception e)
-                    {
-                        Console.WriteLine($"Failed : {assemblyName}\n{e}");
-                    }
+                    AssemblyLoadContext.Default.LoadOqtaneAssembly(dll, assemblyName);
                 }
             }
         }

--- a/Oqtane.Server/Migrations/01000000_InitializeMaster.cs
+++ b/Oqtane.Server/Migrations/01000000_InitializeMaster.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Migrations.EntityBuilders;
 using Oqtane.Repository;

--- a/Oqtane.Server/Migrations/01000000_InitializeTenant.cs
+++ b/Oqtane.Server/Migrations/01000000_InitializeTenant.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Migrations.EntityBuilders;
 using Oqtane.Repository;

--- a/Oqtane.Server/Migrations/01000100_AddAdditionalIndexesInMaster.cs
+++ b/Oqtane.Server/Migrations/01000100_AddAdditionalIndexesInMaster.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Migrations.EntityBuilders;
 using Oqtane.Repository;

--- a/Oqtane.Server/Migrations/01000100_AddAdditionalIndexesInTenant.cs
+++ b/Oqtane.Server/Migrations/01000100_AddAdditionalIndexesInTenant.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Migrations.EntityBuilders;
 using Oqtane.Repository;

--- a/Oqtane.Server/Migrations/01000101_AddAdditionColumnToNotifications.cs
+++ b/Oqtane.Server/Migrations/01000101_AddAdditionColumnToNotifications.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Migrations.EntityBuilders;
 using Oqtane.Repository;

--- a/Oqtane.Server/Migrations/01000201_DropColumnFromPage.cs
+++ b/Oqtane.Server/Migrations/01000201_DropColumnFromPage.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Migrations.EntityBuilders;
 using Oqtane.Repository;

--- a/Oqtane.Server/Migrations/02000001_AddColumnToProfileAndUpdatePage.cs
+++ b/Oqtane.Server/Migrations/02000001_AddColumnToProfileAndUpdatePage.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Migrations.EntityBuilders;
 using Oqtane.Repository;

--- a/Oqtane.Server/Migrations/02000101_UpdateIconColumnInPage.cs
+++ b/Oqtane.Server/Migrations/02000101_UpdateIconColumnInPage.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Migrations.EntityBuilders;
 using Oqtane.Repository;

--- a/Oqtane.Server/Migrations/02000102_AddLanguageTable.cs
+++ b/Oqtane.Server/Migrations/02000102_AddLanguageTable.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Migrations.EntityBuilders;
 using Oqtane.Repository;

--- a/Oqtane.Server/Migrations/02000103_UpdatePageAndAddColumnToSite.cs
+++ b/Oqtane.Server/Migrations/02000103_UpdatePageAndAddColumnToSite.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Migrations.EntityBuilders;
 using Oqtane.Repository;

--- a/Oqtane.Server/Migrations/02000201_AddSiteGuidToSite.cs
+++ b/Oqtane.Server/Migrations/02000201_AddSiteGuidToSite.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Migrations.EntityBuilders;
 using Oqtane.Repository;

--- a/Oqtane.Server/Migrations/02000202_UpdateDefaultContainerTypeInSitePage.cs
+++ b/Oqtane.Server/Migrations/02000202_UpdateDefaultContainerTypeInSitePage.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Migrations.EntityBuilders;
 using Oqtane.Repository;

--- a/Oqtane.Server/Migrations/02000203_DropDefaultLayoutInSite.cs
+++ b/Oqtane.Server/Migrations/02000203_DropDefaultLayoutInSite.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Migrations.EntityBuilders;
 using Oqtane.Repository;

--- a/Oqtane.Server/Migrations/02010000_AddAppVersionsTableInTenant.cs
+++ b/Oqtane.Server/Migrations/02010000_AddAppVersionsTableInTenant.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Migrations.EntityBuilders;
 using Oqtane.Repository;
@@ -58,7 +59,7 @@ namespace Oqtane.Migrations
 
             migrationBuilder.Sql($@"
                 INSERT INTO {appVersions}({version}, {appledDate})
-                    VALUES('02.01.00', '{DateTime.UtcNow:u}')
+                    VALUES('02.01.00', '{DateTime.UtcNow.ToString("yyyy'-'MM'-'dd HH':'mm':'ss")}')
             ");
         }
 

--- a/Oqtane.Server/Migrations/02010000_AddIndexesForForeignKeyInMaster.cs
+++ b/Oqtane.Server/Migrations/02010000_AddIndexesForForeignKeyInMaster.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Migrations.EntityBuilders;
 using Oqtane.Repository;

--- a/Oqtane.Server/Migrations/02010001_AddDatabaseTypeColumnToTenant.cs
+++ b/Oqtane.Server/Migrations/02010001_AddDatabaseTypeColumnToTenant.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Migrations.EntityBuilders;
 using Oqtane.Repository;

--- a/Oqtane.Server/Migrations/02010002_ChangeFolderNameAndPathColumnsSize.cs
+++ b/Oqtane.Server/Migrations/02010002_ChangeFolderNameAndPathColumnsSize.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Migrations.EntityBuilders;
 using Oqtane.Repository;

--- a/Oqtane.Server/Migrations/EntityBuilders/AliasEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/AliasEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/AppVersionsEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/AppVersionsEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 namespace Oqtane.Migrations.EntityBuilders

--- a/Oqtane.Server/Migrations/EntityBuilders/AspNetUserClaimsEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/AspNetUserClaimsEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/AspNetUsersEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/AspNetUsersEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/AuditableBaseEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/AuditableBaseEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable UnusedAutoPropertyAccessor.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/BaseEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/BaseEntityBuilder.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 // ReSharper disable BuiltInTypeReferenceStyleForMemberAccess
 

--- a/Oqtane.Server/Migrations/EntityBuilders/DeletableAuditableBaseEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/DeletableAuditableBaseEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable UnusedAutoPropertyAccessor.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/DeletableBaseEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/DeletableBaseEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable UnusedAutoPropertyAccessor.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/FileEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/FileEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/FolderEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/FolderEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/JobEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/JobEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/JobLogEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/JobLogEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/LanguageEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/LanguageEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/LogEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/LogEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/ModuleDefinitionsEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/ModuleDefinitionsEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/ModuleEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/ModuleEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/NotificationEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/NotificationEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/PageEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/PageEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/PageModuleEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/PageModuleEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/PermissionEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/PermissionEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/ProfileEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/ProfileEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/RoleEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/RoleEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/SettingEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/SettingEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/SiteEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/SiteEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/TenantEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/TenantEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/UserEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/UserEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/EntityBuilders/UserRoleEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/UserRoleEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 // ReSharper disable MemberCanBePrivate.Global

--- a/Oqtane.Server/Migrations/Framework/MultiDatabaseMigration.cs
+++ b/Oqtane.Server/Migrations/Framework/MultiDatabaseMigration.cs
@@ -1,14 +1,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 
 namespace Oqtane.Migrations
 {
     public abstract class MultiDatabaseMigration : Migration
     {
-        private readonly IOqtaneDatabase _databases;
-
         protected MultiDatabaseMigration(IOqtaneDatabase database)
         {
             ActiveDatabase = database;

--- a/Oqtane.Server/Migrations/Framework/MultiDatabaseMigrationsAssembly.cs
+++ b/Oqtane.Server/Migrations/Framework/MultiDatabaseMigrationsAssembly.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Repository.Databases.Interfaces;
 

--- a/Oqtane.Server/Modules/HtmlText/Manager/HtmlTextManager.cs
+++ b/Oqtane.Server/Modules/HtmlText/Manager/HtmlTextManager.cs
@@ -61,11 +61,15 @@ namespace Oqtane.Modules.HtmlText.Manager
 
         public bool Install(Tenant tenant, string version)
         {
+            _tenantManager.SetTenant(tenant.TenantId);
+
             return Migrate(new HtmlTextContext(_tenantManager, _accessor), tenant, MigrationType.Up);
         }
 
         public bool Uninstall(Tenant tenant)
         {
+            _tenantManager.SetTenant(tenant.TenantId);
+
             return Migrate(new HtmlTextContext(_tenantManager, _accessor), tenant, MigrationType.Down);
         }
     }

--- a/Oqtane.Server/Modules/HtmlText/Migrations/01000000_InitializeModule.cs
+++ b/Oqtane.Server/Modules/HtmlText/Migrations/01000000_InitializeModule.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Migrations;
 using Oqtane.Modules.HtmlText.Migrations.EntityBuilders;

--- a/Oqtane.Server/Modules/HtmlText/Migrations/EntityBuilders/HtmlTextEntityBuilder.cs
+++ b/Oqtane.Server/Modules/HtmlText/Migrations/EntityBuilders/HtmlTextEntityBuilder.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Migrations;
 using Oqtane.Migrations.EntityBuilders;

--- a/Oqtane.Server/Oqtane.Server.csproj
+++ b/Oqtane.Server/Oqtane.Server.csproj
@@ -32,21 +32,20 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="5.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="5.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Localization" Version="5.0.4" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Oqtane.Client\Oqtane.Client.csproj" />
-    <ProjectReference Include="..\Oqtane.Database.MySQL\Oqtane.Database.MySQL.csproj" />
-    <ProjectReference Include="..\Oqtane.Database.PostgreSQL\Oqtane.Database.PostgreSQL.csproj" />
-    <ProjectReference Include="..\Oqtane.Database.Sqlite\Oqtane.Database.Sqlite.csproj" />
-    <ProjectReference Include="..\Oqtane.Database.SqlServer\Oqtane.Database.SqlServer.csproj" />
     <ProjectReference Include="..\Oqtane.Shared\Oqtane.Shared.csproj" />
     <ProjectReference Include="..\Oqtane.Upgrade\Oqtane.Upgrade.csproj" />
   </ItemGroup>

--- a/Oqtane.Server/Repository/Context/DBContextBase.cs
+++ b/Oqtane.Server/Repository/Context/DBContextBase.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.Configuration;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Extensions;
 using Oqtane.Infrastructure;
 using Oqtane.Interfaces;

--- a/Oqtane.Server/Repository/Context/InstallationContext.cs
+++ b/Oqtane.Server/Repository/Context/InstallationContext.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Extensions;
 using Oqtane.Interfaces;
 using Oqtane.Models;

--- a/Oqtane.Server/Repository/Context/MasterDBContext.cs
+++ b/Oqtane.Server/Repository/Context/MasterDBContext.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Oqtane.Models;
 using Microsoft.Extensions.Configuration;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Extensions;
 using Oqtane.Interfaces;
 using Oqtane.Migrations.Framework;

--- a/Oqtane.Server/Repository/SqlRepository.cs
+++ b/Oqtane.Server/Repository/SqlRepository.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Oqtane.Databases.Interfaces;
 using Oqtane.Interfaces;
 using Oqtane.Models;
 // ReSharper disable ConvertToUsingDeclaration

--- a/Oqtane.Shared/Models/Database.cs
+++ b/Oqtane.Shared/Models/Database.cs
@@ -9,5 +9,7 @@ namespace Oqtane.Models
         public string ControlType { get; set; }
 
         public string DBType { get; set; }
+
+        public string Package { get; set; }
     }
 }

--- a/Oqtane.Shared/Shared/InstallConfig.cs
+++ b/Oqtane.Shared/Shared/InstallConfig.cs
@@ -1,29 +1,11 @@
-using System;
-using Oqtane.Interfaces;
 
 namespace Oqtane.Shared
 {
     public class InstallConfig
     {
-        private IOqtaneDatabase _database;
-
         public string ConnectionString { get; set; }
         public string DatabaseType { get; set; }
-
-        public IOqtaneDatabase Database
-        {
-            get
-            {
-                if (_database == null)
-                {
-                    var type = Type.GetType(DatabaseType);
-                    _database = Activator.CreateInstance(type) as IOqtaneDatabase;
-                }
-
-                return _database;
-            }
-        }
-
+        public string DatabasePackage { get; set; }
         public string Aliases { get; set; }
         public string TenantName { get; set; }
         public bool IsNewTenant { get; set; }


### PR DESCRIPTION
Convert Database projects so they build installable Packages rather than deploy to bin and modify installation to deploy Databases on demand as needed.  This PR also includes moving the IOqtaneDatabase interface out of the Shared project and to the Server project.
Tested for all 4 Database projects and new Installs and new Tenants.