### PR TITLE
Fix bug with MySQL Installation caused by new Migration

### DIFF
--- a/Oqtane.Server/Migrations/02010002_ChangeFolderNameAndPathColumnsSize.cs
+++ b/Oqtane.Server/Migrations/02010002_ChangeFolderNameAndPathColumnsSize.cs
@@ -19,12 +19,14 @@ namespace Oqtane.Migrations
         {
             var folderEntityBuilder = new FolderEntityBuilder(migrationBuilder, ActiveDatabase);
 
-            folderEntityBuilder.AlterStringColumn("Name", 250);
+            folderEntityBuilder.AlterStringColumn("Name", 256);
 
             // Drop the index is needed because the Path is already associated with IX_Folder
+            folderEntityBuilder.DropForeignKey("FK_Folder_Site");
             folderEntityBuilder.DropIndex("IX_Folder");
-            folderEntityBuilder.AlterStringColumn("Path", 1000);
+            folderEntityBuilder.AlterStringColumn("Path", 512);
             folderEntityBuilder.AddIndex("IX_Folder", new[] { "SiteId", "Path" }, true);
+            folderEntityBuilder.AddForeignKey("FK_Folder_Site");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/Oqtane.Server/Migrations/EntityBuilders/BaseEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/BaseEntityBuilder.cs
@@ -183,6 +183,19 @@ namespace Oqtane.Migrations.EntityBuilders
                 onDelete: foreignKey.OnDeleteAction);
         }
 
+        public void AddForeignKey(string name)
+        {
+            var foreignKey = ForeignKeys.Single(k => k.Name == name);
+
+            _migrationBuilder.AddForeignKey(
+                    name: RewriteName(foreignKey.Name),
+                    table: RewriteName(EntityTableName),
+                    column: RewriteName(foreignKey.ColumnName),
+                    principalTable: RewriteName(foreignKey.PrincipalTable),
+                    principalColumn: RewriteName(foreignKey.PrincipalColumn),
+                    onDelete: foreignKey.OnDeleteAction);
+        }
+
         public void DropForeignKey(ForeignKey<TEntityBuilder> foreignKey)
         {
             DropForeignKey(RewriteName(foreignKey.Name));

--- a/Oqtane.Server/Migrations/Framework/ForeignKey.cs
+++ b/Oqtane.Server/Migrations/Framework/ForeignKey.cs
@@ -20,6 +20,14 @@ namespace Oqtane.Migrations
 
         public Expression<Func<TEntityBuilder, object>> Column { get;}
 
+        public string ColumnName
+        {
+            get
+            {
+                var body = Column.Body.ToString();
+                return body.Substring(body.IndexOf(".") + 1);
+            }
+        }
         public ReferentialAction OnDeleteAction { get; }
 
         public string PrincipalTable { get; }


### PR DESCRIPTION
The new Migration introduced to extend the length of the Path property of the Folder object throws an exception when installing in MySQL.  MySQL complains if you are dropping an Index that is used  by a Foreign Key, Furthermore, when re-applying the Index MySQL complains becuase the key is too long.   This PR reduces the length of the Path to 512 (rather than 1000). 