### PR TITLE
Move Available Databases to appsettings and use IOptions

### DIFF
--- a/Oqtane.Server/Controllers/DatabaseController.cs
+++ b/Oqtane.Server/Controllers/DatabaseController.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Oqtane.Models;
 using Oqtane.Shared;
 
 namespace Oqtane.Controllers
@@ -7,56 +9,18 @@ namespace Oqtane.Controllers
     [Route(ControllerRoutes.ApiRoute)]
     public class DatabaseController : Controller
     {
-        public DatabaseController() { }
+        private IOptions<List<Database>> _databaseOptions;
+
+        public DatabaseController(IOptions<List<Database>> databaseOptions)
+        {
+            _databaseOptions = databaseOptions;
+        }
 
         // GET: api/<controller>
         [HttpGet]
         public IEnumerable<Models.Database> Get()
         {
-            var databases = new List<Models.Database>
-            {
-                new()
-                {
-                    Name = "LocalDB",
-                    FriendlyName = "Local Database",
-                    ControlType = "Oqtane.Installer.Controls.LocalDBConfig, Oqtane.Client",
-                    DBType = "Oqtane.Database.SqlServer.SqlServerDatabase, Oqtane.Database.SqlServer",
-                    Package = "Oqtane.Database.SqlServer"
-                },
-                new()
-                {
-                    Name = "SqlServer",
-                    FriendlyName = "SQL Server",
-                    ControlType = "Oqtane.Installer.Controls.SqlServerConfig, Oqtane.Client",
-                    DBType = "Oqtane.Database.SqlServer.SqlServerDatabase, Oqtane.Database.SqlServer",
-                    Package = "Oqtane.Database.SqlServer"
-                },
-                new()
-                {
-                    Name = "Sqlite",
-                    FriendlyName = "Sqlite",
-                    ControlType = "Oqtane.Installer.Controls.SqliteConfig, Oqtane.Client",
-                    DBType = "Oqtane.Database.Sqlite.SqliteDatabase, Oqtane.Database.Sqlite",
-                    Package = "Oqtane.Database.Sqlite"
-                },
-                new()
-                {
-                    Name = "MySQL",
-                    FriendlyName = "MySQL",
-                    ControlType = "Oqtane.Installer.Controls.MySQLConfig, Oqtane.Client",
-                    DBType = "Oqtane.Database.MySQL.MySQLDatabase, Oqtane.Database.MySQL",
-                    Package = "Oqtane.Database.MySQL"
-                },
-                new()
-                {
-                    Name = "PostgreSQL",
-                    FriendlyName = "PostgreSQL",
-                    ControlType = "Oqtane.Installer.Controls.PostgreSQLConfig, Oqtane.Client",
-                    DBType = "Oqtane.Database.PostgreSQL.PostgreSQLDatabase, Oqtane.Database.PostgreSQL",
-                    Package = "Oqtane.Database.PostgreSQL"
-                }
-            };
-            return databases;
+            return _databaseOptions.Value;
         }
     }
 }

--- a/Oqtane.Server/Startup.cs
+++ b/Oqtane.Server/Startup.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -15,6 +16,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 using Oqtane.Extensions;
 using Oqtane.Infrastructure;
+using Oqtane.Models;
 using Oqtane.Repository;
 using Oqtane.Security;
 using Oqtane.Services;
@@ -55,6 +57,8 @@ namespace Oqtane
         {
             // Register localization services
             services.AddLocalization(options => options.ResourcesPath = "Resources");
+
+            services.AddOptions<List<Database>>().Bind(Configuration.GetSection("AvailableDatabases"));
 
             services.AddServerSideBlazor().AddCircuitOptions(options =>
             {

--- a/Oqtane.Server/appsettings.json
+++ b/Oqtane.Server/appsettings.json
@@ -1,4 +1,41 @@
 {
+  "AvailableDatabases": [
+    {
+      "Name": "LocalDB",
+      "FriendlyName": "Local Database",
+      "ControlType": "Oqtane.Installer.Controls.LocalDBConfig, Oqtane.Client",
+      "DBType": "Oqtane.Database.SqlServer.SqlServerDatabase, Oqtane.Database.SqlServer",
+      "Package": "Oqtane.Database.SqlServer"
+    },
+    {
+      "Name": "SqlServer",
+      "FriendlyName": "SQL Server",
+      "ControlType": "Oqtane.Installer.Controls.SqlServerConfig, Oqtane.Client",
+      "DBType": "Oqtane.Database.SqlServer.SqlServerDatabase, Oqtane.Database.SqlServer",
+      "Package": "Oqtane.Database.SqlServer"
+    },
+    {
+      "Name": "Sqlite",
+      "FriendlyName": "Sqlite",
+      "ControlType": "Oqtane.Installer.Controls.SqliteConfig, Oqtane.Client",
+      "DBType": "Oqtane.Database.Sqlite.SqliteDatabase, Oqtane.Database.Sqlite",
+      "Package": "Oqtane.Database.Sqlite"
+    },
+    {
+      "Name": "MySQL",
+      "FriendlyName": "MySQL",
+      "ControlType": "Oqtane.Installer.Controls.MySQLConfig, Oqtane.Client",
+      "DBType": "Oqtane.Database.MySQL.MySQLDatabase, Oqtane.Database.MySQL",
+      "Package": "Oqtane.Database.MySQL"
+    },
+    {
+      "Name": "PostgreSQL",
+      "FriendlyName": "PostgreSQL",
+      "ControlType": "Oqtane.Installer.Controls.PostgreSQLConfig, Oqtane.Client",
+      "DBType": "Oqtane.Database.PostgreSQL.PostgreSQLDatabase, Oqtane.Database.PostgreSQL",
+      "Package": "Oqtane.Database.PostgreSQL"
+    }
+  ],
   "Database": {
     "DatabaseType": ""
   },


### PR DESCRIPTION
This PR moves the list of available databases to appsettings. While it is not the intention to support additional databases, this provides an option for the enterprising developer to create their own Database project and configure it by updating the settings.