### PR TITLE
fix issue: WebAssembly with IDM app

### DIFF
--- a/Oqtane.Server/Controllers/InstallationController.cs
+++ b/Oqtane.Server/Controllers/InstallationController.cs
@@ -82,7 +82,7 @@ namespace Oqtane.Controllers
         {
             if (_config.GetSection("Runtime").Value == "WebAssembly")
             {
-                return File(GetAssemblies(), System.Net.Mime.MediaTypeNames.Application.Octet, "oqtane.zip");
+                return File(GetAssemblies(), System.Net.Mime.MediaTypeNames.Application.Octet, "oqtane.oqbz");
             }
             else
             {


### PR DESCRIPTION
when set Runtime as WebAssembly, IDM app recognize  oqtane.zip and download this file and this make an issue and oqtane does not work correctly and for this I set different extention that IDM can't recognize it