### PR TITLE
Fix for #1530 Error in Module templates

### DIFF
--- a/Oqtane.Server/wwwroot/Modules/Templates/External/Server/Controllers/[Module]Controller.cs
+++ b/Oqtane.Server/wwwroot/Modules/Templates/External/Server/Controllers/[Module]Controller.cs
@@ -45,7 +45,7 @@ namespace [Owner].[Module].Controllers
         public Models.[Module] Get(int id)
         {
             Models.[Module] [Module] = _[Module]Repository.Get[Module](id);
-            if ([Module] != null && [Module].ModuleId != AuthEntityId(EntityNames.Module))
+            if ([Module] != null && [Module].ModuleId == AuthEntityId(EntityNames.Module))
             {
                 return [Module];
             }


### PR DESCRIPTION
The Get public Models.[Module] Get(int id) method in the [Module]Controller has an incorrect IF statement which in turn returns nothing and logs an error