### PR TITLE
Fix for #1543 Localization Resources not being loaded for ext Modules

### DIFF
--- a/Oqtane.Shared/Shared/Constants.cs
+++ b/Oqtane.Shared/Shared/Constants.cs
@@ -72,7 +72,7 @@ namespace Oqtane.Shared {
         };
         public static readonly string[] InvalidFileNameEndingChars = { ".", " " };
 
-        public static readonly string SatelliteAssemblyExtension = ".resources.dll";
+        public static readonly string SatelliteAssemblyExtension = "*.resources.dll";
 
         public static readonly string DefaultCulture = "en";
 


### PR DESCRIPTION

The EnumerateFiles was not using the correct searchPattern, the Wildcard (*) was missing which in turn will not find any local Resources.
