### PR TITLE
Fix for  #1555 Username readonly on Register form

### DIFF
--- a/Oqtane.Client/Modules/Admin/Register/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Register/Index.razor
@@ -20,7 +20,7 @@
                 <div class="row mb-1 align-items-center">
                     <Label Class="col-sm-3" For="username" HelpText="Your username. Note that this field can not be modified once it is saved." ResourceKey="Username"></Label>
                     <div class="col-sm-9">
-                        <input id="username" class="form-control" @bind="@_username" readonly />
+                        <input id="username" class="form-control" @bind="@_username"  />
                     </div>
                 </div>
                 <div class="row mb-1 align-items-center">


### PR DESCRIPTION
Removed the readonly attribute from the username field.