### PR TITLE
UI localization: don't ignore current ui (browser) language.

### DIFF
--- a/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
+++ b/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
@@ -67,56 +67,9 @@ else
     <TabPanel Name="Profile" ResourceKey="Profile">
         @if (profiles != null && settings != null)
         {
-
-
             <div class="container">
                 <div class="row mb-1 align-items-center">
-                    @foreach (Profile profile in profiles)
-                    {
-                        var p = profile;
-                        if (!p.IsPrivate || UserSecurity.IsAuthorized(PageState.User, RoleNames.Admin))
-                        {
-                            if (p.Category != category)
-                            {
-                                <div class="col text-center pb-2">
-                                    @p.Category
-                                </div>
-                                category = p.Category;
-                            }
-                            <div class="row mb-1 align-items-center">
-                                <Label Class="col-sm-3" For="@p.Name" HelpText="@p.Description">@p.Title</Label>
-                                <div class="col-sm-9">
-                                    @if (!string.IsNullOrEmpty(p.Options))
-                                    {
-                                        <select id="@p.Name" class="form-select" @onchange="@(e => ProfileChanged(e, p.Name))">
-                                            @foreach (var option in p.Options.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
-                                            {
-                                                @if (GetProfileValue(p.Name, "") == option || (GetProfileValue(p.Name, "") == "" && p.DefaultValue == option))
-                                                {
-                                                    <option value="@option" selected>@option</option>
-                                                }
-                                                else
-                                                {
-                                                    <option value="@option">@option</option>
-                                                }
-                                            }
-                                        </select>
-                                    }
-                                    else
-                                    {
-                                        @if (p.IsRequired)
-                                        {
-                                            <input id="@p.Name" class="form-control" maxlength="@p.MaxLength" value="@GetProfileValue(p.Name, p.DefaultValue)" required @onchange="@(e => ProfileChanged(e, p.Name))" />
-                                        }
-                                        else
-                                        {
-                                            <input id="@p.Name" class="form-control" maxlength="@p.MaxLength" value="@GetProfileValue(p.Name, p.DefaultValue)" @onchange="@(e => ProfileChanged(e, p.Name))" />
-                                        }
-                                    }
-                                </div>
-                            </div>
-                        }
-                    }
+                    <UserProfileComponent Profiles="profiles" Settings="settings" />
                 </div>
             </div>
             <button type="button" class="btn btn-success" @onclick="Save">@SharedLocalizer["Save"]</button>
@@ -132,11 +85,11 @@ else
             {
                 <Pager Items="@notifications">
                     <Header>
-                    <th style="width: 1px;">&nbsp;</th>
-                    <th style="width: 1px;">&nbsp;</th>
-                    <th>@Localizer["From"]</th>
-                    <th>@Localizer["Subject"]</th>
-                    <th>@Localizer["Received"]</th>
+                        <th style="width: 1px;">&nbsp;</th>
+                        <th style="width: 1px;">&nbsp;</th>
+                        <th>@Localizer["From"]</th>
+                        <th>@Localizer["Subject"]</th>
+                        <th>@Localizer["Received"]</th>
                     </Header>
                     <Row>
                         <td><ActionLink Action="View" Parameters="@($"id=" + context.NotificationId.ToString())" Security="SecurityAccessLevel.View" EditMode="false" ResourceKey="ViewNotification" /></td>
@@ -149,13 +102,14 @@ else
                         <td colspan="2"></td>
                         <td colspan="3">
                             @{
-                                        string input = "___";
-                                        if (context.Body.Contains(input))
-                                        {
-                                            context.Body = context.Body.Split(input)[0];
-                                            context.Body = context.Body.Replace("\n", "");
-                                            context.Body = context.Body.Replace("\r", "");
-                                        } }
+                                string input = "___";
+                                if (context.Body.Contains(input))
+                                {
+                                    context.Body = context.Body.Split(input)[0];
+                                    context.Body = context.Body.Replace("\n", "");
+                                    context.Body = context.Body.Replace("\r", "");
+                                } 
+                            }
                             @(context.Body.Length > 100 ? (context.Body.Substring(0, 97) + "...") : context.Body)
                         </td>
                     </Detail>
@@ -182,13 +136,13 @@ else
                         <td colspan="2"></td>
                         <td colspan="3">
                             @{
-                                        string input = "___";
-                                        if (context.Body.Contains(input))
-                                        {
-                                            context.Body = context.Body.Split(input)[0];
-                                            context.Body = context.Body.Replace("\n", "");
-                                            context.Body = context.Body.Replace("\r", "");
-                                        } }
+                                string input = "___";
+                                if (context.Body.Contains(input))
+                                {
+                                    context.Body = context.Body.Split(input)[0];
+                                    context.Body = context.Body.Replace("\n", "");
+                                    context.Body = context.Body.Replace("\r", "");
+                                } }
                             @(context.Body.Length > 100 ? (context.Body.Substring(0, 97) + "...") : context.Body)
                         </td>
                     </Detail>
@@ -309,35 +263,9 @@ else
         }
     }
 
-    private bool ValidateProfiles()
-    {
-        bool valid = true;
-        foreach (Profile profile in profiles)
-        {
-            if (string.IsNullOrEmpty(SettingService.GetSetting(settings, profile.Name, string.Empty)) && !string.IsNullOrEmpty(profile.DefaultValue))
-            {
-                settings = SettingService.SetSetting(settings, profile.Name, profile.DefaultValue);
-            }
-            if (!profile.IsPrivate || UserSecurity.IsAuthorized(PageState.User, RoleNames.Admin))
-            {
-                if (profile.IsRequired && string.IsNullOrEmpty(SettingService.GetSetting(settings, profile.Name, string.Empty)))
-                {
-                    valid = false;
-                }
-            }
-        }
-        return valid;
-    }
-
     private void Cancel()
     {
         NavigationManager.NavigateTo(NavigateUrl(string.Empty));
-    }
-
-    private void ProfileChanged(ChangeEventArgs e, string SettingName)
-    {
-        var value = (string)e.Value;
-        settings = SettingService.SetSetting(settings, SettingName, value);
     }
 
     private async Task Delete(Notification Notification)
@@ -363,6 +291,32 @@ else
             await logger.LogError(ex, "Error Deleting Notification {Notification} {Error}", Notification, ex.Message);
             AddModuleMessage(ex.Message, MessageType.Error);
         }
+    }
+
+    private bool ValidateProfiles()
+    {
+        bool valid = true;
+        foreach (Profile profile in profiles)
+        {
+            if (string.IsNullOrEmpty(SettingService.GetSetting(settings, profile.Name, string.Empty)) && !string.IsNullOrEmpty(profile.DefaultValue))
+            {
+                settings = SettingService.SetSetting(settings, profile.Name, profile.DefaultValue);
+            }
+            if (!profile.IsPrivate || UserSecurity.IsAuthorized(PageState.User, RoleNames.Admin))
+            {
+                if (profile.IsRequired && string.IsNullOrEmpty(SettingService.GetSetting(settings, profile.Name, string.Empty)))
+                {
+                    valid = false;
+                }
+            }
+        }
+        return valid;
+    }
+
+    private void ProfileChanged(ChangeEventArgs e, string SettingName)
+    {
+        var value = (string)e.Value;
+        settings = SettingService.SetSetting(settings, SettingName, value);
     }
 
     private async void FilterChanged(ChangeEventArgs e)

--- a/Oqtane.Client/Modules/Admin/Users/Edit.razor
+++ b/Oqtane.Client/Modules/Admin/Users/Edit.razor
@@ -67,7 +67,6 @@ else
                     </div>
                 </div>
             </div>
-
         }
     </TabPanel>
     <TabPanel Name="Profile" ResourceKey="Profile">
@@ -75,30 +74,7 @@ else
         {
             <div class="container">
                 <div class="row mb-1 align-items-center">
-                    @foreach (Profile profile in profiles)
-                    {
-                        var p = profile;
-                        if (p.Category != category)
-                        {
-                            <div class="col text-center pb-2">
-                                <strong>@p.Category</strong>
-                            </div>
-                            category = p.Category;
-                        }
-                        <div class="row mb-1 align-items-center">
-                            <Label Class="col-sm-3" For="@p.Name" HelpText="@p.Description">@p.Title</Label>
-                            <div class="col-sm-9">
-                                @if (p.IsRequired)
-                                {
-                                    <input id="@p.Name" class="form-control" maxlength="@p.MaxLength" value="@GetProfileValue(p.Name, p.DefaultValue)" required @onchange="@(e => ProfileChanged(e, p.Name))" />
-                                }
-                                else
-                                {
-                                    <input id="@p.Name" class="form-control" maxlength="@p.MaxLength" value="@GetProfileValue(p.Name, p.DefaultValue)" @onchange="@(e => ProfileChanged(e, p.Name))" />
-                                }
-                            </div>
-                        </div>
-                    }
+                    <UserProfileComponent Profiles="profiles" Settings="settings" />
                 </div>
             </div>
         }

--- a/Oqtane.Client/Modules/Controls/UserProfileComponent.razor
+++ b/Oqtane.Client/Modules/Controls/UserProfileComponent.razor
@@ -1,0 +1,77 @@
+@namespace Oqtane.Modules.Controls
+@inherits LocalizableComponent
+@inject ISettingService SettingService
+
+@foreach (Profile profile in profiles)
+{
+    var p = profile;
+    if (!p.IsPrivate || UserSecurity.IsAuthorized(PageState.User, RoleNames.Admin))
+    {
+        if (p.Category != category)
+        {
+            <div class="col text-center pb-2">
+                @p.Category
+            </div>
+            category = p.Category;
+        }
+        <div class="row mb-1 align-items-center">
+            <Label Class="col-sm-3" For="@p.Name" HelpText="@p.Description">@p.Title</Label>
+            <div class="col-sm-9">
+                @if (!string.IsNullOrEmpty(p.Options))
+                {
+                    <select id="@p.Name" class="form-select" @onchange="@(e => ProfileChanged(e, p.Name))">
+                        @foreach (var option in p.Options.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
+                        {
+                            @if (GetProfileValue(p.Name, "") == option || (GetProfileValue(p.Name, "") == "" && p.DefaultValue == option))
+                            {
+                                <option value="@option" selected>@option</option>
+                            }
+                            else
+                            {
+                                <option value="@option">@option</option>
+                            }
+                        }
+                    </select>
+                }
+                else
+                {
+                    @if (p.IsRequired)
+                    {
+                        <input id="@p.Name" class="form-control" maxlength="@p.MaxLength" value="@GetProfileValue(p.Name, p.DefaultValue)" required @onchange="@(e => ProfileChanged(e, p.Name))" />
+                    }
+                    else
+                    {
+                        <input id="@p.Name" class="form-control" maxlength="@p.MaxLength" value="@GetProfileValue(p.Name, p.DefaultValue)" @onchange="@(e => ProfileChanged(e, p.Name))" />
+                    }
+                }
+            </div>
+        </div>
+    }
+}
+
+@code {
+    private List<Profile> profiles;
+    private Dictionary<string, string> settings;
+    private string category = string.Empty;
+
+    [Parameter]
+    public List<Profile> Profiles { get; set; }
+
+    [Parameter]
+    public Dictionary<string, string> Settings { get; set; }
+
+    protected override void OnInitialized()
+    {
+        profiles = Profiles;
+        settings = Settings;
+    }
+
+    private string GetProfileValue(string SettingName, string DefaultValue)
+    => SettingService.GetSetting(settings, SettingName, DefaultValue);
+
+    private void ProfileChanged(ChangeEventArgs e, string SettingName)
+    {
+        var value = (string)e.Value;
+        settings = SettingService.SetSetting(settings, SettingName, value);
+    }
+}

--- a/Oqtane.Server/Pages/_Host.cshtml.cs
+++ b/Oqtane.Server/Pages/_Host.cshtml.cs
@@ -65,16 +65,22 @@ namespace Oqtane.Pages
                 var alias = _tenantManager.GetAlias();
                 if (alias != null)
                 {
-                    // if culture not specified
+                    // if culture not specified (cookie .AspNetCore.Culture)
                     if (HttpContext.Request.Cookies[CookieRequestCultureProvider.DefaultCookieName] == null)
                     {
-                        // set default language for site if the culture is not supported
                         var languages = _languages.GetLanguages(alias.SiteId);
-                        if (languages.Any() && languages.All(l => l.Code != CultureInfo.CurrentUICulture.Name))
+                        // set language to current ui culture if supported (listed in languages)
+                        if (languages.Any() && languages.Any(l => l.Code == CultureInfo.CurrentUICulture.Name))
+                        {
+                            SetLocalizationCookie(CultureInfo.CurrentUICulture.Name);
+                        }
+                        // set language to default language if current ui culture not supported (not listed in languages)
+                        else if (languages.Any() && languages.All(l => l.Code != CultureInfo.CurrentUICulture.Name))
                         {
                             var defaultLanguage = languages.Where(l => l.IsDefault).SingleOrDefault() ?? languages.First();
                             SetLocalizationCookie(defaultLanguage.Code);
                         }
+                        // set default language (from appsettings.json) if no language defined for current Site
                         else
                         {
                             SetLocalizationCookie(_localizationManager.GetDefaultCulture());


### PR DESCRIPTION
The ui localization should respect the browser language settings if ever possible.

With the current code in _Host.cshtml the browser language will never be respected - even if it's listed as a supported site langauge:

```c#
if (languages.Any() && languages.All(l => l.Code != CultureInfo.CurrentUICulture.Name))
..
else
..
```

The proposal for the new options (priorities) is:

1. Respect the browser language if supported by the site.
2. If not supported, take the default site language if available.
3. If no site default language available, take the system (Oqtane) default language.

The proposal is based on subsequent suppositions:

* Within the affected code *CultureInfo.CurrentCulture* is (always) the user browser language setting.
* The options 1 and 2 are based on the Site language(s). They are only available if defined by *Admin Dashboard.. Language Management*.
* Option 3 takes the language from appsettings.json only.
