### PR TITLE
1690 User Management Tab needs clicking to render UI when language is not default.

### DIFF
--- a/Oqtane.Client/Modules/Controls/TabPanel.razor
+++ b/Oqtane.Client/Modules/Controls/TabPanel.razor
@@ -38,11 +38,7 @@ else
 
         if (string.IsNullOrEmpty(Heading))
         {
-            Name = Localize(nameof(Name), Name);
-        }
-        else
-        {
-            Heading = Localize(nameof(Heading), Heading);
+            Heading = Localize(nameof(Name), Name);
         }
     }
 


### PR DESCRIPTION
User Management Tab needs clicking to render UI when language is not default.  Modification to the TabPanel fixes the issue without  forcing the Heading property to be populated.