### PR TITLE
[RootFolder] was missing from Release.cmd

### DIFF
--- a/Oqtane.Server/wwwroot/Modules/Templates/External/Package/release.cmd
+++ b/Oqtane.Server/wwwroot/Modules/Templates/External/Package/release.cmd
@@ -1,3 +1,3 @@
 "..\..\[RootFolder]\oqtane.package\nuget.exe" pack [Owner].[Module].nuspec 
-XCOPY "*.nupkg" "..\..\oqtane.framework\Oqtane.Server\Packages\" /Y
+XCOPY "*.nupkg" "..\..\[RootFolder]\Oqtane.Server\Packages\" /Y
 


### PR DESCRIPTION
One of the replace tokens was not added to the second command line.