### PR TITLE
Add many PrivateApi attributes to hide unimportant stuff in docs

### DIFF
--- a/Oqtane.Client/Modules/Admin/ModuleCreator/ModuleInfo.cs
+++ b/Oqtane.Client/Modules/Admin/ModuleCreator/ModuleInfo.cs
@@ -1,7 +1,9 @@
-﻿using Oqtane.Models;
+using Oqtane.Documentation;
+using Oqtane.Models;
 
 namespace Oqtane.Modules.Admin.ModuleCreator
 {
+    [PrivateApi("Mark this as private, since it's not very useful in the public docs")]
     public class ModuleInfo : IModule
     {
         public ModuleDefinition ModuleDefinition => new ModuleDefinition

--- a/Oqtane.Client/Modules/HtmlText/ModuleInfo.cs
+++ b/Oqtane.Client/Modules/HtmlText/ModuleInfo.cs
@@ -1,7 +1,9 @@
+using Oqtane.Documentation;
 using Oqtane.Models;
 
 namespace Oqtane.Modules.HtmlText
 {
+    [PrivateApi("Mark HtmlText classes as private, since it's not very useful in the public docs")]
     public class ModuleInfo : IModule
     {
         public ModuleDefinition ModuleDefinition => new ModuleDefinition

--- a/Oqtane.Client/Modules/HtmlText/Services/HtmlTextService.cs
+++ b/Oqtane.Client/Modules/HtmlText/Services/HtmlTextService.cs
@@ -1,10 +1,12 @@
 using System.Net.Http;
 using System.Threading.Tasks;
+using Oqtane.Documentation;
 using Oqtane.Services;
 using Oqtane.Shared;
 
 namespace Oqtane.Modules.HtmlText.Services
 {
+    [PrivateApi("Mark HtmlText classes as private, since it's not very useful in the public docs")]
     public class HtmlTextService : ServiceBase, IHtmlTextService, IService
     {        
         public HtmlTextService(HttpClient http, SiteState siteState) : base(http, siteState) {}

--- a/Oqtane.Client/Modules/HtmlText/Services/IHtmlTextService.cs
+++ b/Oqtane.Client/Modules/HtmlText/Services/IHtmlTextService.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using Oqtane.Documentation;
 using Oqtane.Modules.HtmlText.Models;
 
 namespace Oqtane.Modules.HtmlText.Services
 {
+    [PrivateApi("Mark HtmlText classes as private, since it's not very useful in the public docs")]
     public interface IHtmlTextService 
     {
         Task<Models.HtmlText> GetHtmlTextAsync(int ModuleId);

--- a/Oqtane.Client/Program.cs
+++ b/Oqtane.Client/Program.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
+using Oqtane.Documentation;
 using Oqtane.Modules;
 using Oqtane.Services;
 using Oqtane.Shared;
@@ -19,6 +20,7 @@ using Oqtane.UI;
 
 namespace Oqtane.Client
 {
+    [PrivateApi("Mark Entry-Program as private, since it's not very useful in the public docs")]
     public class Program
     {
         public static async Task Main(string[] args)

--- a/Oqtane.Client/Themes/BlazorTheme/ThemeInfo.cs
+++ b/Oqtane.Client/Themes/BlazorTheme/ThemeInfo.cs
@@ -1,7 +1,9 @@
-﻿using Oqtane.Models;
+using Oqtane.Documentation;
+using Oqtane.Models;
 
 namespace Oqtane.Themes.BlazorTheme
 {
+    [PrivateApi("Mark Build-In Theme-Info classes as private, since it's not very useful in the public docs")]
     public class ThemeInfo : ITheme
     {
         public Theme Theme => new Theme

--- a/Oqtane.Client/Themes/OqtaneTheme/ThemeInfo.cs
+++ b/Oqtane.Client/Themes/OqtaneTheme/ThemeInfo.cs
@@ -1,7 +1,9 @@
+using Oqtane.Documentation;
 using Oqtane.Models;
 
 namespace Oqtane.Themes.OqtaneTheme
 {
+    [PrivateApi("Mark Build-In Theme-Info classes as private, since it's not very useful in the public docs")]
     public class ThemeInfo : ITheme
     {
         public Theme Theme => new Theme

--- a/Oqtane.Server/Infrastructure/SiteTemplates/DefaultSiteTemplate.cs
+++ b/Oqtane.Server/Infrastructure/SiteTemplates/DefaultSiteTemplate.cs
@@ -6,9 +6,11 @@ using Microsoft.AspNetCore.Hosting;
 using Oqtane.Extensions;
 using Oqtane.Shared;
 using System.IO;
+using Oqtane.Documentation;
 
 namespace Oqtane.SiteTemplates
 {
+    [PrivateApi("Mark Site-Template classes as private, since it's not very useful in the public docs")]
     public class DefaultSiteTemplate : ISiteTemplate
     {
 

--- a/Oqtane.Server/Infrastructure/SiteTemplates/EmptySiteTemplate.cs
+++ b/Oqtane.Server/Infrastructure/SiteTemplates/EmptySiteTemplate.cs
@@ -4,9 +4,11 @@ using System.Collections.Generic;
 using Oqtane.Extensions;
 using Oqtane.Repository;
 using Oqtane.Shared;
+using Oqtane.Documentation;
 
 namespace Oqtane.SiteTemplates
 {
+    [PrivateApi("Mark Site-Template classes as private, since it's not very useful in the public docs")]
     public class EmptySiteTemplate : ISiteTemplate
     {
         public EmptySiteTemplate()

--- a/Oqtane.Server/Modules/HtmlText/Controllers/HtmlTextController.cs
+++ b/Oqtane.Server/Modules/HtmlText/Controllers/HtmlTextController.cs
@@ -7,10 +7,12 @@ using Oqtane.Enums;
 using Oqtane.Infrastructure;
 using Oqtane.Controllers;
 using System.Net;
+using Oqtane.Documentation;
 
 namespace Oqtane.Modules.HtmlText.Controllers
 {
     [Route(ControllerRoutes.ApiRoute)]
+    [PrivateApi("Mark HtmlText classes as private, since it's not very useful in the public docs")]
     public class HtmlTextController : ModuleControllerBase
     {
         private readonly IHtmlTextRepository _htmlText;

--- a/Oqtane.Server/Modules/HtmlText/Manager/HtmlTextManager.cs
+++ b/Oqtane.Server/Modules/HtmlText/Manager/HtmlTextManager.cs
@@ -7,11 +7,13 @@ using Oqtane.Enums;
 using Oqtane.Repository;
 using Oqtane.Shared;
 using Oqtane.Migrations.Framework;
+using Oqtane.Documentation;
 
 // ReSharper disable ConvertToUsingDeclaration
 
 namespace Oqtane.Modules.HtmlText.Manager
 {
+    [PrivateApi("Mark HtmlText classes as private, since it's not very useful in the public docs")]
     public class HtmlTextManager : MigratableModuleBase, IInstallable, IPortable
     {
         private readonly IHtmlTextRepository _htmlText;

--- a/Oqtane.Server/Modules/HtmlText/Migrations/01000000_InitializeModule.cs
+++ b/Oqtane.Server/Modules/HtmlText/Migrations/01000000_InitializeModule.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Oqtane.Databases.Interfaces;
+using Oqtane.Documentation;
 using Oqtane.Migrations;
 using Oqtane.Modules.HtmlText.Migrations.EntityBuilders;
 using Oqtane.Modules.HtmlText.Repository;
@@ -9,6 +10,7 @@ namespace Oqtane.Modules.HtmlText.Migrations
 {
     [DbContext(typeof(HtmlTextContext))]
     [Migration("HtmlText.01.00.00.00")]
+    [PrivateApi("Mark HtmlText classes as private, since it's not very useful in the public docs")]
     public class InitializeModule : MultiDatabaseMigration
     {
         public InitializeModule(IDatabase database) : base(database)

--- a/Oqtane.Server/Modules/HtmlText/Migrations/EntityBuilders/HtmlTextEntityBuilder.cs
+++ b/Oqtane.Server/Modules/HtmlText/Migrations/EntityBuilders/HtmlTextEntityBuilder.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations.Builders;
 using Oqtane.Databases.Interfaces;
+using Oqtane.Documentation;
 using Oqtane.Interfaces;
 using Oqtane.Migrations;
 using Oqtane.Migrations.EntityBuilders;
@@ -11,6 +12,7 @@ using Oqtane.Migrations.EntityBuilders;
 
 namespace Oqtane.Modules.HtmlText.Migrations.EntityBuilders
 {
+    [PrivateApi("Mark HtmlText classes as private, since it's not very useful in the public docs")]
     public class HtmlTextEntityBuilder : AuditableBaseEntityBuilder<HtmlTextEntityBuilder>
     {
         private const string _entityTableName = "HtmlText";

--- a/Oqtane.Server/Modules/HtmlText/Repository/HtmlTextContext.cs
+++ b/Oqtane.Server/Modules/HtmlText/Repository/HtmlTextContext.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using Oqtane.Documentation;
 using Oqtane.Infrastructure;
 using Oqtane.Repository;
 using Oqtane.Repository.Databases.Interfaces;
@@ -9,6 +10,7 @@ using Oqtane.Repository.Databases.Interfaces;
 
 namespace Oqtane.Modules.HtmlText.Repository
 {
+    [PrivateApi("Mark HtmlText classes as private, since it's not very useful in the public docs")]
     public class HtmlTextContext : DBContextBase, IService, IMultiDatabase
     {
         public HtmlTextContext(ITenantManager tenantManager, IHttpContextAccessor httpContextAccessor) : base(tenantManager, httpContextAccessor) { }

--- a/Oqtane.Server/Modules/HtmlText/Repository/HtmlTextRepository.cs
+++ b/Oqtane.Server/Modules/HtmlText/Repository/HtmlTextRepository.cs
@@ -1,9 +1,11 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using System.Linq;
 using Oqtane.Modules.HtmlText.Models;
+using Oqtane.Documentation;
 
 namespace Oqtane.Modules.HtmlText.Repository
 {
+    [PrivateApi("Mark HtmlText classes as private, since it's not very useful in the public docs")]
     public class HtmlTextRepository : IHtmlTextRepository, IService
     {
         private readonly HtmlTextContext _db;

--- a/Oqtane.Server/Modules/HtmlText/Repository/IHtmlTextRepository.cs
+++ b/Oqtane.Server/Modules/HtmlText/Repository/IHtmlTextRepository.cs
@@ -1,7 +1,9 @@
-﻿using Oqtane.Modules.HtmlText.Models;
+using Oqtane.Documentation;
+using Oqtane.Modules.HtmlText.Models;
 
 namespace Oqtane.Modules.HtmlText.Repository
 {
+    [PrivateApi("Mark HtmlText classes as private, since it's not very useful in the public docs")]
     public interface IHtmlTextRepository
     {
         Models.HtmlText GetHtmlText(int moduleId);

--- a/Oqtane.Server/Program.cs
+++ b/Oqtane.Server/Program.cs
@@ -7,9 +7,11 @@ using Oqtane.Infrastructure;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Oqtane.Shared;
+using Oqtane.Documentation;
 
 namespace Oqtane.Server
 {
+    [PrivateApi("Mark Entry-Program as private, since it's not very useful in the public docs")]
     public class Program
     {
         public static void Main(string[] args)

--- a/Oqtane.Shared/Modules/HtmlText/Models/HtmlText.cs
+++ b/Oqtane.Shared/Modules/HtmlText/Models/HtmlText.cs
@@ -2,9 +2,11 @@ using System;
 using Oqtane.Models;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Oqtane.Documentation;
 
 namespace Oqtane.Modules.HtmlText.Models
 {
+    [PrivateApi("Mark HtmlText classes as private, since it's not very useful in the public docs")]
     public class HtmlText : IAuditable
     {
         [Key]


### PR DESCRIPTION
The docs should help people use the Oqtane API as best as possible. As such, we should hide objects which are just for internal work or won't be used as an API. I've added `[PrivateApi]` attributes to ca. 20 classes which clutter up the docs without real benefit to the user. 

As an example, I've removed tagged all the HtmlText classes, since that's not an API I expect others to need in the docs - this removes these entries from the docs:

![image](https://user-images.githubusercontent.com/5321186/141354354-506a44ad-b671-4caf-a34c-9f229d32e6a5.png)

+ a few others, all which I'm convinced serve no benefit in the docs. 

Otherwise no code changes. 