### PR TITLE
Fix for #1797 Breadcrumbs render clickable

### DIFF
--- a/Oqtane.Client/Themes/Controls/Theme/Breadcrumbs.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/Breadcrumbs.razor
@@ -16,7 +16,15 @@
                 else
                 {
                     <li class="breadcrumb-item">
-                        <a href="@NavigateUrl(p.Path)">@p.Name</a>
+                        @if(p.IsClickable)
+                        {
+                            <a href="@NavigateUrl(p.Path)">@p.Name</a>
+                        }
+                        else
+                        {
+                            @p.Name
+                        }
+
                     </li>
                 }
             }


### PR DESCRIPTION
This fixes the issue when the page property IsClickable is set to false the breadcrum for the page is not clickable.