### PR TITLE
Page management buttons resizing

### DIFF
--- a/Oqtane.Client/Themes/Controls/Theme/ControlPanel.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/ControlPanel.razor
@@ -63,9 +63,9 @@
 				</div>
 				<div class="row d-flex">
 					<div class="col d-flex justify-content-between">
-						<button type="button" class="btn btn-secondary col-3" data-bs-dismiss="offcanvas" @onclick=@(async () => Navigate("Add"))>@SharedLocalizer["Add"]</button>
-						<button type="button" class="btn btn-secondary col-3" data-bs-dismiss="offcanvas" @onclick=@(async () => Navigate("Edit"))>@SharedLocalizer["Edit"]</button>
-						<button type="button" class="btn btn-danger col-3" @onclick="ConfirmDelete">@SharedLocalizer["Delete"]</button>
+						<button type="button" class="btn btn-secondary col me-1" data-bs-dismiss="offcanvas" @onclick=@(async () => Navigate("Add"))>@SharedLocalizer["Add"]</button>
+						<button type="button" class="btn btn-secondary col" data-bs-dismiss="offcanvas" @onclick=@(async () => Navigate("Edit"))>@SharedLocalizer["Edit"]</button>
+						<button type="button" class="btn btn-danger col ms-1" @onclick="ConfirmDelete">@SharedLocalizer["Delete"]</button>
 					</div>
 				</div>
 				<br />


### PR DESCRIPTION
When the language is changed, in this instance Dutch the buttons are not resized to fit the caption.  This small fix rectifies this.

**before**
![image](https://user-images.githubusercontent.com/9447612/141848146-37105e7b-e4a9-4b3d-8cbd-32f279478383.png)

**after**
![image](https://user-images.githubusercontent.com/9447612/141847797-5db6fa6f-d4da-4326-82d7-ccf427d04b28.png)
