### PR TITLE
Fix RichTextEditor Content not re-Rendering when changed. #1837

### DIFF
--- a/Oqtane.Client/Modules/Controls/RichTextEditor.razor
+++ b/Oqtane.Client/Modules/Controls/RichTextEditor.razor
@@ -120,9 +120,23 @@
         new Resource { ResourceType = ResourceType.Script, Bundle = "Quill", Url = "js/quill-interop.js" }
     };
 
-    protected override void OnInitialized()
+    protected override async Task OnParametersSetAsync()
     {
-        _content = Content; // raw HTML
+        _content = Content;  // raw HTML
+        try
+        {
+            var interop = new RichTextEditorInterop(JSRuntime);
+            // preserve a copy of the rich text content ( Quill sanitizes content so we need to retrieve it from the editor )
+            _original = await interop.GetHtml(_editorElement);
+
+            await RefreshRichText();
+            await RefreshRawHtml();            
+        }
+        catch(Exception ex)
+        {
+            // Handle the error.
+        }
+
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)


### PR DESCRIPTION
Fix Content property not updating when Value changed.
Updating the field on  async Task OnParametersSetAsync() instead of  void OnInitialized()
This fix required some additional code to be executed to keep it in line with the current way of working.