### PR TITLE
Fix #1837 RichTextEditor Content not re-Rendering

### DIFF
--- a/Oqtane.Client/Modules/Controls/RichTextEditor.razor
+++ b/Oqtane.Client/Modules/Controls/RichTextEditor.razor
@@ -120,18 +120,18 @@
         new Resource { ResourceType = ResourceType.Script, Bundle = "Quill", Url = "js/quill-interop.js" }
     };
 
-    protected override void OnInitialized()
+    protected override void OnParametersSet()
     {
         _content = Content; // raw HTML
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
+       var interop = new RichTextEditorInterop(JSRuntime);
+       
+       if (firstRender)
         {
             await base.OnAfterRenderAsync(firstRender);
-
-            var interop = new RichTextEditorInterop(JSRuntime);
 
             await interop.CreateEditor(
                 _editorElement,
@@ -140,14 +140,15 @@
                 Placeholder,
                 Theme,
                 DebugLevel);
-
-            await interop.LoadEditorContent(_editorElement, Content);
-
-            _content = Content; // raw HTML
-
-            // preserve a copy of the rich text content ( Quill sanitizes content so we need to retrieve it from the editor )
-            _original = await interop.GetHtml(_editorElement);
         }
+
+        await interop.LoadEditorContent(_editorElement, Content);
+
+        _content = Content; // raw HTML
+
+        // preserve a copy of the rich text content ( Quill sanitizes content so we need to retrieve it from the editor )
+        _original = await interop.GetHtml(_editorElement);
+
     }
 
     public void CloseFileManager()


### PR DESCRIPTION
Change to the OnAfterRenderAsync method and changed OnInitialized to OnParametersSet