### PR TITLE
Fix for Installed packages not being removed correctly

### DIFF
--- a/Oqtane.Server/Infrastructure/InstallationManager.cs
+++ b/Oqtane.Server/Infrastructure/InstallationManager.cs
@@ -211,7 +211,7 @@ namespace Oqtane.Infrastructure
                             File.Delete(filepath);
                             if (!Directory.EnumerateFiles(Path.GetDirectoryName(filepath)).Any())
                             {
-                                Directory.Delete(Path.GetDirectoryName(filepath));
+                                Directory.Delete(Path.GetDirectoryName(filepath), true);
                             }
                         }
                     }


### PR DESCRIPTION
When a package is remove in some instance the system complains that a file still exists in the deleting directory but there is not file.
Added true parameter to the Directory delete for force the removal. 
Directory.Delete(Path.GetDirectoryName(filepath), true);