### PR TITLE
Rework to #1848 RawHTML not being saved

### DIFF
--- a/Oqtane.Client/Modules/Controls/RichTextEditor.razor
+++ b/Oqtane.Client/Modules/Controls/RichTextEditor.razor
@@ -120,11 +120,6 @@
         new Resource { ResourceType = ResourceType.Script, Bundle = "Quill", Url = "js/quill-interop.js" }
     };
 
-    protected override void OnInitialized()
-    {
-        _content = Content; // raw HTML
-    }
-
     protected override async Task OnParametersSetAsync()
     {
         _content = Content; // raw HTML

--- a/Oqtane.Client/Modules/Controls/RichTextEditor.razor
+++ b/Oqtane.Client/Modules/Controls/RichTextEditor.razor
@@ -120,18 +120,24 @@
         new Resource { ResourceType = ResourceType.Script, Bundle = "Quill", Url = "js/quill-interop.js" }
     };
 
-    protected override void OnParametersSet()
+    protected override void OnInitialized()
     {
         _content = Content; // raw HTML
     }
 
+    protected override async Task OnParametersSetAsync()
+    {
+        _content = Content; // raw HTML
+        await RefreshRichText();
+    }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-       var interop = new RichTextEditorInterop(JSRuntime);
-       
-       if (firstRender)
+        var interop = new RichTextEditorInterop(JSRuntime);
+        if (firstRender)
         {
             await base.OnAfterRenderAsync(firstRender);
+
 
             await interop.CreateEditor(
                 _editorElement,
@@ -140,15 +146,14 @@
                 Placeholder,
                 Theme,
                 DebugLevel);
+
+            await interop.LoadEditorContent(_editorElement, Content);
+
+            _content = Content; // raw HTML
+
         }
-
-        await interop.LoadEditorContent(_editorElement, Content);
-
-        _content = Content; // raw HTML
-
-        // preserve a copy of the rich text content ( Quill sanitizes content so we need to retrieve it from the editor )
-        _original = await interop.GetHtml(_editorElement);
-
+            // preserve a copy of the rich text content ( Quill sanitizes content so we need to retrieve it from the editor )
+            _original = await interop.GetHtml(_editorElement);
     }
 
     public void CloseFileManager()


### PR DESCRIPTION
Restructured the execution of code.
RawHTML now works as it did in previous versions as well as the new functionality.