### PR TITLE
Fixed first render js bug

### DIFF
--- a/Oqtane.Client/Modules/ModuleBase.cs
+++ b/Oqtane.Client/Modules/ModuleBase.cs
@@ -46,22 +46,19 @@ namespace Oqtane.Modules
 
         // base lifecycle method for handling JSInterop script registration
 
-        protected override async Task OnAfterRenderAsync(bool firstRender)
+        protected override async Task OnInitializedAsync()
         {
-            if (firstRender)
+            if (Resources != null && Resources.Exists(item => item.ResourceType == ResourceType.Script))
             {
-                if (Resources != null && Resources.Exists(item => item.ResourceType == ResourceType.Script))
+                var scripts = new List<object>();
+                foreach (Resource resource in Resources.Where(item => item.ResourceType == ResourceType.Script && item.Declaration != ResourceDeclaration.Global))
                 {
-                    var scripts = new List<object>();
-                    foreach (Resource resource in Resources.Where(item => item.ResourceType == ResourceType.Script && item.Declaration != ResourceDeclaration.Global))
-                    {
-                        scripts.Add(new { href = resource.Url, bundle = resource.Bundle ?? "", integrity = resource.Integrity ?? "", crossorigin = resource.CrossOrigin ?? "" });
-                    }
-                    if (scripts.Any())
-                    {
-                        var interop = new Interop(JSRuntime);
-                        await interop.IncludeScripts(scripts.ToArray());
-                    }
+                    scripts.Add(new { href = resource.Url, bundle = resource.Bundle ?? "", integrity = resource.Integrity ?? "", crossorigin = resource.CrossOrigin ?? "" });
+                }
+                if (scripts.Any())
+                {
+                    var interop = new Interop(JSRuntime);
+                    await interop.IncludeScripts(scripts.ToArray());
                 }
             }
         }


### PR DESCRIPTION
Solve the problem that when the page is rendered for the first time and JS is executed, the reference to the JS file has not been successful, and the page is abnormally wrong


### Message
```
An Unexpected Error Has Occurred In DNNGo.Gallery, DNNGo.Gallery.Client.Oqtane: Could not find 'Radzen.preventArrows' ('Radzen' was undefined).
Error: Could not find 'Radzen.preventArrows' ('Radzen' was undefined).
    at http://oqtane.dnntest.com/_framework/blazor.server.js:1:497
    at Array.forEach (<anonymous>)
    at i.findFunction (http://oqtane.dnntest.com/_framework/blazor.server.js:1:465)
    at E (http://oqtane.dnntest.com/_framework/blazor.server.js:1:2606)
    at http://oqtane.dnntest.com/_framework/blazor.server.js:1:3494
    at new Promise (<anonymous>)
    at Tt.beginInvokeJSFromDotNet (http://oqtane.dnntest.com/_framework/blazor.server.js:1:3475)
    at http://oqtane.dnntest.com/_framework/blazor.server.js:1:71773
    at Array.forEach (<anonymous>)
    at Tt._invokeClientMethod (http://oqtane.dnntest.com/_framework/blazor.server.js:1:71759)

```



### Exception
```
Microsoft.JSInterop.JSException: Could not find 'Radzen.preventArrows' ('Radzen' was undefined).
Error: Could not find 'Radzen.preventArrows' ('Radzen' was undefined).
    at http://oqtane.dnntest.com/_framework/blazor.server.js:1:497
    at Array.forEach (<anonymous>)
    at i.findFunction (http://oqtane.dnntest.com/_framework/blazor.server.js:1:465)
    at E (http://oqtane.dnntest.com/_framework/blazor.server.js:1:2606)
    at http://oqtane.dnntest.com/_framework/blazor.server.js:1:3494
    at new Promise (<anonymous>)
    at Tt.beginInvokeJSFromDotNet (http://oqtane.dnntest.com/_framework/blazor.server.js:1:3475)
    at http://oqtane.dnntest.com/_framework/blazor.server.js:1:71773
    at Array.forEach (<anonymous>)
    at Tt._invokeClientMethod (http://oqtane.dnntest.com/_framework/blazor.server.js:1:71759)
   at Microsoft.JSInterop.JSRuntime.InvokeAsync[TValue](Int64 targetInstanceId, String identifier, Object[] args)
   at Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync(IJSRuntime jsRuntime, String identifier, Object[] args)
   at Radzen.Blazor.RadzenDropDown`1.OnAfterRenderAsync(Boolean firstRender)
   at Microsoft.AspNetCore.Components.RenderTree.Renderer.GetErrorHandledTask(Task taskToHandle, ComponentState owningComponentState)

```