### PR TITLE
Added web.Release.config to include remove WebDAV during the publish stage of a release

### DIFF
--- a/Oqtane.Server/web.Release.config
+++ b/Oqtane.Server/web.Release.config
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- To customize the asp.net core module uncomment and edit the following section. 
+  For more info see https://go.microsoft.com/fwlink/?linkid=838655 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+    <location>
+        <system.webServer>
+            <modules xdt:Transform="InsertIfMissing">
+                <remove name="WebDAVModule" xdt:Transform="InsertIfMissing"/>
+            </modules>
+            <handlers xdt:Transform="InsertIfMissing">
+                <remove name="WebDAV" xdt:Transform="InsertIfMissing" />
+            </handlers>
+        </system.webServer>
+    </location>
+</configuration>


### PR DESCRIPTION
Transformations to the web.config file can be applied automatically when an app is published based on Build configuration.

I decided to make this pull request after reading the following discussion: https://github.com/oqtane/oqtane.framework/discussions/1952

