### PR TITLE
Fix for Version 3 module definitions error #1963

### DIFF
--- a/Oqtane.Client/Modules/Admin/ModuleDefinitions/Index.razor
+++ b/Oqtane.Client/Modules/Admin/ModuleDefinitions/Index.razor
@@ -37,7 +37,7 @@ else
             <td>@context.Name</td>
             <td>@context.Version</td>
             <td>
-                @if(context.AssemblyName == "Oqtane.Client" || PageState.Modules.Where(m => m.ModuleDefinition.ModuleDefinitionId == context.ModuleDefinitionId).Count() > 0)
+                @if(context.AssemblyName == "Oqtane.Client" || PageState.Modules.Where(m => m.ModuleDefinition.ModuleDefinitionId == context.ModuleDefinitionId).FirstOrDefault() != null)
                 {
                     <span>@SharedLocalizer["Yes"]</span>
                 }


### PR DESCRIPTION
The code was assuming that the ModuleDefinitionId exists in the PageState.Modules collection. Instead of using .Count()  code now uses .FirstOrDefault() != null