### PR TITLE
fix #1272 - add support for refs folder in package installation

### DIFF
--- a/Oqtane.Server/Infrastructure/InstallationManager.cs
+++ b/Oqtane.Server/Infrastructure/InstallationManager.cs
@@ -125,6 +125,9 @@ namespace Oqtane.Infrastructure
                                 case "ref": // ref/net*/...
                                     filename = ExtractFile(entry, Path.Combine(binPath, "ref"), 2);
                                     break;
+                                case "refs": // refs/net*/...
+                                    filename = ExtractFile(entry, Path.Combine(binPath, "refs"), 2);
+                                    break;
                             }
 
                             if (filename != "")


### PR DESCRIPTION
Please add support also for `refs` folder in package installation.

My understanding is that Microsoft AspNetCore dependencies that are stored in the "refs" folder are an essential part of the default compilation context to support run-time compilation scenarios in https://github.com/2sic/2sxc/ or any other module or app that targets standard Microsoft.NET.Sdk.Web.

In oqtane source development environment, "refs" are deployed by default when `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` nuget is included as project reference and property `PreserveCompilationContext` is set in `csproj`.

For oqtane release standalone installations, we need to manually deploy "refs" and that is the reason why it will be great to include it as part of 2sxc oqtane module nuget, and that will make life easier for anyone installing https://github.com/2sic/2sxc/.