### PR TITLE
fix #1972 Missing Preprocessor Directives during Runtime Compile

### DIFF
--- a/Oqtane.Server/Oqtane.Server.csproj
+++ b/Oqtane.Server/Oqtane.Server.csproj
@@ -16,6 +16,8 @@
     <RepositoryType>Git</RepositoryType>
     <RootNamespace>Oqtane</RootNamespace>
     <IsPackable>true</IsPackable>
+    <DefineConstants>$(DefineConstants);OQTANE;OQTANE3;OQTANE3_0_OR_GREATER </DefineConstants>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="wwwroot\Modules\Templates\**" />


### PR DESCRIPTION
fix https://github.com/oqtane/oqtane.framework/issues/1972, enables again missing preprocessor directives for runtime compile