### PR TITLE
fix #1987 Nuspec to include 'content'

### DIFF
--- a/Oqtane.Server/Infrastructure/InstallationManager.cs
+++ b/Oqtane.Server/Infrastructure/InstallationManager.cs
@@ -128,6 +128,12 @@ namespace Oqtane.Infrastructure
                                 case "refs": // refs/net*/...
                                     filename = ExtractFile(entry, Path.Combine(binPath, "refs"), 2);
                                     break;
+                                case "content": // ...
+                                    filename = ExtractFile(entry, contentRootPath, 1);
+                                    break;
+                                case "contentFiles": // ...
+                                    filename = ExtractFile(entry, contentRootPath, 3);
+                                    break;
                             }
 
                             if (filename != "")

--- a/Oqtane.Server/Infrastructure/InstallationManager.cs
+++ b/Oqtane.Server/Infrastructure/InstallationManager.cs
@@ -128,11 +128,8 @@ namespace Oqtane.Infrastructure
                                 case "refs": // refs/net*/...
                                     filename = ExtractFile(entry, Path.Combine(binPath, "refs"), 2);
                                     break;
-                                case "content": // ...
-                                    filename = ExtractFile(entry, contentRootPath, 1);
-                                    break;
-                                case "contentFiles": // ...
-                                    filename = ExtractFile(entry, contentRootPath, 3);
+                                case "content": // content/...
+                                    filename = ExtractFile(entry, contentRootPath, 0);
                                     break;
                             }
 


### PR DESCRIPTION
Oqtane Server **InstallationManager** is extended to recognize and support in nuspec new **file target** `content` that is part of [nuget specification](https://docs.microsoft.com/en-gb/nuget/reference/nuspec#including-content-files).

```xml
  <files>
      <file src="myconfig.json" target="content" />
  </files>
```

The reason is to include in Oqtane Module **nuget** additional content files, that are not stored in `wwwroot` as better explained in https://github.com/oqtane/oqtane.framework/issues/1987.