### PR TITLE
GetTenant{} returns null in some Blazor server scenario cases 

### DIFF
--- a/Oqtane.Server/Infrastructure/TenantManager.cs
+++ b/Oqtane.Server/Infrastructure/TenantManager.cs
@@ -62,7 +62,7 @@ namespace Oqtane.Infrastructure
 
         public Tenant GetTenant()
         {
-            var alias = _siteState?.Alias;
+            var alias = _siteState?.Alias ?? GetAlias();
             if (alias != null)
             {
                 // return tenant details


### PR DESCRIPTION
Because SiteState.Alias is null.