### PR TITLE
Fix for missing Resx entries #2215

### DIFF
--- a/Oqtane.Client/Resources/Modules/Admin/UserProfile/Index.resx
+++ b/Oqtane.Client/Resources/Modules/Admin/UserProfile/Index.resx
@@ -219,4 +219,10 @@
   <data name="DeleteAllNotifications.Text" xml:space="preserve">
     <value>Delete ALL Notifications</value>
   </data>
+  <data name="Notifications.Heading" xml:space="preserve">
+    <value>Notifications</value>
+  </data>
+  <data name="Profile.Heading" xml:space="preserve">
+    <value>Profile</value>
+  </data>
 </root>


### PR DESCRIPTION
Updated the Resx File with the missing entries.  

However the UserProfile\Add cant be Localized at present as the IStringLocalizer is not loaded when that property assignment is executed.