### PR TITLE
missing translation keys for module names

### DIFF
--- a/Oqtane.Client/Resources/SharedResources.resx
+++ b/Oqtane.Client/Resources/SharedResources.resx
@@ -330,4 +330,10 @@
   <data name="PageOfPages" xml:space="preserve">
     <value>Page {0} of {1}</value>
   </data>
+  <data name="Url Mappings" xml:space="preserve">
+    <value>Url Mappings</value>
+  </data>
+  <data name="Visitor Management" xml:space="preserve">
+    <value>Visitor Management</value>
+  </data>
 </root>


### PR DESCRIPTION
without these keys, following module names are not translating, 

![image](https://user-images.githubusercontent.com/21291112/172099203-b14ecf83-93cb-4198-a148-dcd18112c9bc.png)
