### PR TITLE
Content root for Oqtane Private folders is configurable in appsettings.json 

### DIFF
--- a/Oqtane.Server/Controllers/FileController.cs
+++ b/Oqtane.Server/Controllers/FileController.cs
@@ -28,16 +28,16 @@ namespace Oqtane.Controllers
     [Route(ControllerRoutes.ApiRoute)]
     public class FileController : Controller
     {
-        private readonly IWebHostEnvironment _environment;
+        private readonly IContentManager _contentManager;
         private readonly IFileRepository _files;
         private readonly IFolderRepository _folders;
         private readonly IUserPermissions _userPermissions;
         private readonly ILogManager _logger;
         private readonly Alias _alias;
 
-        public FileController(IWebHostEnvironment environment, IFileRepository files, IFolderRepository folders, IUserPermissions userPermissions, ILogManager logger, ITenantManager tenantManager)
+        public FileController(IContentManager contentManager, IFileRepository files, IFolderRepository folders, IUserPermissions userPermissions, ILogManager logger, ITenantManager tenantManager)
         {
-            _environment = environment;
+            _contentManager = contentManager;
             _files = files;
             _folders = folders;
             _userPermissions = userPermissions;
@@ -611,7 +611,7 @@ namespace Oqtane.Controllers
 
         private string GetFolderPath(string folder)
         {
-            return Utilities.PathCombine(_environment.ContentRootPath, folder);
+            return _contentManager.GetContentPath(folder);
         }
 
         private void CreateDirectory(string folderpath)

--- a/Oqtane.Server/Controllers/FolderController.cs
+++ b/Oqtane.Server/Controllers/FolderController.cs
@@ -18,15 +18,15 @@ namespace Oqtane.Controllers
     [Route(ControllerRoutes.ApiRoute)]
     public class FolderController : Controller
     {
-        private readonly IWebHostEnvironment _environment;
+        private readonly IContentManager _contentManager;
         private readonly IFolderRepository _folders;
         private readonly IUserPermissions _userPermissions;
         private readonly ILogManager _logger;
         private readonly Alias _alias;
 
-        public FolderController(IWebHostEnvironment environment, IFolderRepository folders, IUserPermissions userPermissions, ILogManager logger, ITenantManager tenantManager)
+        public FolderController(IContentManager contentManager, IFolderRepository folders, IUserPermissions userPermissions, ILogManager logger, ITenantManager tenantManager)
         {
-            _environment = environment;
+            _contentManager = contentManager;
             _folders = folders;
             _userPermissions = userPermissions;
             _logger = logger;
@@ -242,7 +242,7 @@ namespace Oqtane.Controllers
 
         private string GetFolderPath(Folder folder)
         {
-            return Utilities.PathCombine(_environment.ContentRootPath, "Content", "Tenants", _alias.TenantId.ToString(), "Sites", folder.SiteId.ToString(), folder.Path);
+            return _contentManager.GetContentPath("Content", "Tenants", _alias.TenantId.ToString(), "Sites", folder.SiteId.ToString(), folder.Path);
         }
     }
 }

--- a/Oqtane.Server/Controllers/SystemController.cs
+++ b/Oqtane.Server/Controllers/SystemController.cs
@@ -14,11 +14,13 @@ namespace Oqtane.Controllers
     {
         private readonly IWebHostEnvironment _environment;
         private readonly IConfigManager _configManager;
+        private readonly IContentManager _contentManager;
 
-        public SystemController(IWebHostEnvironment environment, IConfigManager configManager)
+        public SystemController(IWebHostEnvironment environment, IConfigManager configManager, IContentManager contentManager)
         {
             _environment = environment;
             _configManager = configManager;
+            _contentManager = contentManager;
         }
 
         // GET: api/<controller>?type=x
@@ -36,7 +38,7 @@ namespace Oqtane.Controllers
                     systeminfo.Add("MachineName", Environment.MachineName);
                     systeminfo.Add("WorkingSet", Environment.WorkingSet.ToString());
                     systeminfo.Add("TickCount", Environment.TickCount64.ToString());
-                    systeminfo.Add("ContentRootPath", _environment.ContentRootPath);
+                    systeminfo.Add("ContentRootPath", _contentManager.ContentRootPath);
                     systeminfo.Add("WebRootPath", _environment.WebRootPath);
                     systeminfo.Add("ServerTime", DateTime.UtcNow.ToString());
                     var feature = HttpContext.Features.Get<IHttpConnectionFeature>();

--- a/Oqtane.Server/Extensions/OqtaneServiceCollectionExtensions.cs
+++ b/Oqtane.Server/Extensions/OqtaneServiceCollectionExtensions.cs
@@ -71,6 +71,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ISyncManager, SyncManager>();
             services.AddSingleton<IDatabaseManager, DatabaseManager>();
             services.AddSingleton<IConfigManager, ConfigManager>();
+            services.AddSingleton<IContentManager, ContentManager>();
             services.AddSingleton<ILoggerProvider, FileLoggerProvider>();
             services.AddSingleton<AutoValidateAntiforgeryTokenFilter>();
             return services;

--- a/Oqtane.Server/Infrastructure/ContentManager.cs
+++ b/Oqtane.Server/Infrastructure/ContentManager.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections;
+using System.IO;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Oqtane.Shared;
+
+namespace Oqtane.Infrastructure;
+
+public class ContentManager : IContentManager
+{
+    private readonly IConfiguration _config;
+    private readonly IWebHostEnvironment _environment;
+    private string _root;
+
+    public ContentManager(IConfiguration config, IWebHostEnvironment environment)
+    {
+        _config = config;
+        _environment = environment;
+    }
+
+    private string GetContentRoot()
+    {
+        var root = _config.GetValue(SettingKeys.ContentRootKey, String.Empty);
+        if (root.IsNullOrEmpty()) return _environment.ContentRootPath;
+        if (Path.IsPathRooted(root)) return root;
+        return Path.GetFullPath(Path.Combine(_environment.ContentRootPath, root!));
+    }
+
+    public string GetContentPath(params string[] segments)
+    {
+        var p = Path.Combine(ContentRootPath, Utilities.PathCombine(segments));
+        return p;
+    }
+
+    public string ContentRootPath => _root??=GetContentRoot();
+}

--- a/Oqtane.Server/Infrastructure/Interfaces/IContentManager.cs
+++ b/Oqtane.Server/Infrastructure/Interfaces/IContentManager.cs
@@ -1,0 +1,7 @@
+namespace Oqtane.Infrastructure;
+
+public interface IContentManager
+{
+    string GetContentPath(params string[] segments);
+    string ContentRootPath { get; }
+}

--- a/Oqtane.Server/Infrastructure/Logging/FileLogger.cs
+++ b/Oqtane.Server/Infrastructure/Logging/FileLogger.cs
@@ -8,13 +8,13 @@ namespace Oqtane.Infrastructure
     public class FileLogger : ILogger
     {
         protected readonly FileLoggerProvider _FileLoggerProvider;
-        private readonly IWebHostEnvironment _environment;
+        private readonly IContentManager _contentManager;
         private readonly IConfigManager _configManager;
 
-        public FileLogger(FileLoggerProvider FileLoggerProvider, IWebHostEnvironment environment,IConfigManager configManager)
+        public FileLogger(FileLoggerProvider FileLoggerProvider, IContentManager contentManager,IConfigManager configManager)
         {
             _FileLoggerProvider = FileLoggerProvider;
-            _environment = environment;
+            _contentManager = contentManager;
             _configManager = configManager;
         }
 
@@ -44,7 +44,7 @@ namespace Oqtane.Infrastructure
                 return;
             }
 
-            string folder = Path.Combine(_environment.ContentRootPath, "Content", "Log");
+            string folder = _contentManager.GetContentPath("Content", "Log");
             var filepath = Path.Combine(folder, "error.log");
             long size = 0;
 

--- a/Oqtane.Server/Infrastructure/Logging/FileLoggerProvider.cs
+++ b/Oqtane.Server/Infrastructure/Logging/FileLoggerProvider.cs
@@ -9,18 +9,18 @@ namespace Oqtane.Infrastructure
     [ProviderAlias("FileLogger")]
     public class FileLoggerProvider : ILoggerProvider
     {
-        private readonly IWebHostEnvironment _environment;
+        private readonly IContentManager _contentManager;
         private readonly IConfigManager _configManager;
 
-        public FileLoggerProvider(IWebHostEnvironment environment, IConfigManager configManager)
+        public FileLoggerProvider(IContentManager contentManager, IConfigManager configManager)
         {
-            _environment = environment;
+            _contentManager = contentManager;
             _configManager = configManager;
         }
 
         public ILogger CreateLogger(string categoryName)
         {
-            return new FileLogger(this, _environment, _configManager);
+            return new FileLogger(this, _contentManager, _configManager);
         }
 
         public void Dispose()

--- a/Oqtane.Server/Repository/FolderRepository.cs
+++ b/Oqtane.Server/Repository/FolderRepository.cs
@@ -15,13 +15,16 @@ namespace Oqtane.Repository
         private readonly IPermissionRepository _permissions;
         private readonly IWebHostEnvironment _environment;
         private readonly ITenantManager _tenants;
+        private readonly IContentManager _contentManager;
 
-        public FolderRepository(TenantDBContext context, IPermissionRepository permissions,IWebHostEnvironment environment, ITenantManager tenants)
+
+        public FolderRepository(TenantDBContext context, IPermissionRepository permissions,IWebHostEnvironment environment, ITenantManager tenants, IContentManager contentManager)
         {
             _db = context;
             _permissions = permissions;
             _environment = environment;
             _tenants = tenants;
+            _contentManager = contentManager;
         }
 
         public IEnumerable<Folder> GetFolders(int siteId)
@@ -104,7 +107,7 @@ namespace Oqtane.Repository
             switch (folder.Type)
             {
                 case FolderTypes.Private:
-                    path = Utilities.PathCombine(_environment.ContentRootPath, "Content", "Tenants", _tenants.GetTenant().TenantId.ToString(), "Sites", folder.SiteId.ToString(), folder.Path);
+                    path = _contentManager.GetContentPath("Content", "Tenants", _tenants.GetTenant().TenantId.ToString(), "Sites", folder.SiteId.ToString(), folder.Path);
                     break;
                 case FolderTypes.Public:
                     path = Utilities.PathCombine(_environment.WebRootPath, "Content", "Tenants", _tenants.GetTenant().TenantId.ToString(), "Sites", folder.SiteId.ToString(), folder.Path);

--- a/Oqtane.Shared/Shared/SettingKeys.cs
+++ b/Oqtane.Shared/Shared/SettingKeys.cs
@@ -19,5 +19,7 @@ namespace Oqtane.Shared
         public const string DefaultContainerKey = "DefaultContainer";
 
         public const string AvailableDatabasesSection = "AvailableDatabases";
+
+        public const string ContentRootKey = "ContentRoot";
     }
 }


### PR DESCRIPTION
with variable "ContentRoot", path can be absolute or relative.

If null or empty, defaults to WebHostEnvironment.ContentRootPath.

If relative, is relative to WebHostEnvironment.ContentRootPath