### PR TITLE
Make ActiveDatabase setter public

### DIFF
--- a/Oqtane.Server/Repository/Context/DBContextBase.cs
+++ b/Oqtane.Server/Repository/Context/DBContextBase.cs
@@ -31,7 +31,7 @@ namespace Oqtane.Repository
             _accessor = httpContextAccessor;
         }
 
-        public IDatabase ActiveDatabase { get; private set; }
+        public IDatabase ActiveDatabase { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {


### PR DESCRIPTION
We have two cases where we need to override the active database:  Unit Testing and added GraphQL.  In both of these cases, we have a database context that is in a different scope than the automatically assigned active database during normal Oqtane startup.  Our work-around has been to make this setter public.  Unless there is a better solution to our cases, I feel this change would be useful for others as well.