### PR TITLE
extends watching *.dll files

### DIFF
--- a/Oqtane.Server/Oqtane.Server.csproj
+++ b/Oqtane.Server/Oqtane.Server.csproj
@@ -60,4 +60,8 @@
     <Copy SourceFiles="@(ModuleTemplateFiles)" DestinationFiles="@(ModuleTemplateFiles->'$(PublishDir)wwwroot\Modules\Templates\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="false" />
     <Copy SourceFiles="@(ThemeTemplateFiles)" DestinationFiles="@(ThemeTemplateFiles->'$(PublishDir)wwwroot\Themes\Templates\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="false" />
   </Target>
+  <ItemGroup>
+    <!-- extends watching group to include *.dll files and exclude the ones cause an infinite loop -->
+    <Watch Include="**\*.dll" Exclude="**\Microsoft.EntityFrameworkCore.*.dll;**\Oqtane.Database.*.dll;"/>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
extends watching group to include *.dll files and exclude the ones cause an infinite loop.

@sbwalker I need your advice about where I should put the documentation about how to use it.

Hey @vzdesic, could you please help me to finish this as you initiated the issue and provided solution for this.