### PR TITLE
Fix for deleting a ModuleDefinition and related records  #2602

### DIFF
--- a/Oqtane.Server/Controllers/ModuleDefinitionController.cs
+++ b/Oqtane.Server/Controllers/ModuleDefinitionController.cs
@@ -15,6 +15,7 @@ using System;
 using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json;
 using System.Net;
+using Oqtane.Modules;
 
 namespace Oqtane.Controllers
 {
@@ -22,6 +23,8 @@ namespace Oqtane.Controllers
     public class ModuleDefinitionController : Controller
     {
         private readonly IModuleDefinitionRepository _moduleDefinitions;
+        private readonly IModuleRepository _modules;
+        private readonly IPageModuleRepository _pagemodules;
         private readonly ITenantRepository _tenants;
         private readonly ISqlRepository _sql;
         private readonly IUserPermissions _userPermissions;
@@ -33,9 +36,11 @@ namespace Oqtane.Controllers
         private readonly ILogManager _logger;
         private readonly Alias _alias;
 
-        public ModuleDefinitionController(IModuleDefinitionRepository moduleDefinitions, ITenantRepository tenants, ISqlRepository sql, IUserPermissions userPermissions, IInstallationManager installationManager, IWebHostEnvironment environment, IServiceProvider serviceProvider, ITenantManager tenantManager, ISyncManager syncManager, ILogManager logger)
+        public ModuleDefinitionController(IModuleDefinitionRepository moduleDefinitions, IModuleRepository module,IPageModuleRepository pageModule, ITenantRepository tenants, ISqlRepository sql, IUserPermissions userPermissions, IInstallationManager installationManager, IWebHostEnvironment environment, IServiceProvider serviceProvider, ITenantManager tenantManager, ISyncManager syncManager, ILogManager logger)
         {
             _moduleDefinitions = moduleDefinitions;
+            _modules = module;
+            _pagemodules = pageModule;
             _tenants = tenants;
             _sql = sql;
             _userPermissions = userPermissions;
@@ -227,6 +232,24 @@ namespace Oqtane.Controllers
                     Directory.Delete(assetpath, true);
                     _logger.Log(LogLevel.Information, this, LogFunction.Delete, "Module Static Resources Folder Removed For {ModuleDefinitionName}", moduledefinition.ModuleDefinitionName);
                 }
+
+                // remove PageModule and Module
+                List<Models.Module> modulesToRemove =  _modules.GetModules(moduledefinition.SiteId).Where(m => m.ModuleDefinitionName == moduledefinition.ModuleDefinitionName).ToList();
+                foreach (Models.Module moduleToRemove in modulesToRemove)
+                {
+                    // Get the PageModule items associated with the Module item to be removed
+                    List<PageModule> pageModulesToRemove = _pagemodules.GetPageModules(moduledefinition.SiteId).Where(pm => pm.ModuleId == moduleToRemove.ModuleId).ToList();
+
+                    foreach(PageModule pageModule in pageModulesToRemove)
+                    {
+                        // Remove the PageModule item
+                        _pagemodules.DeletePageModule(pageModule.PageModuleId);
+                    }
+
+                    // Remove the Module item
+                    _modules.DeleteModule(moduleToRemove.ModuleId);
+                }
+
 
                 // remove module definition
                 _moduleDefinitions.DeleteModuleDefinition(id);


### PR DESCRIPTION
We find all Module items that have a ModuleDefinitionName property that matches the ModuleDefinitionName of the item to be removed, and remove them one by one. For each Module item to be removed, we find the PageModule items associated with it, remove them from the pageModules list, and then remove the Module item itself from the modules list. 