### PR TITLE
Fix Clearing modules from the Recycle Bin Records are Orphaned #2625

### DIFF
--- a/Oqtane.Client/Modules/Admin/RecycleBin/Index.razor
+++ b/Oqtane.Client/Modules/Admin/RecycleBin/Index.razor
@@ -182,10 +182,8 @@ else
     {
         try
         {
-            await PageModuleService.DeletePageModuleAsync(module.PageModuleId);
-
             // check if there are any remaining module instances in the site
-            if (!_modules.Exists(item => item.ModuleId == module.ModuleId))
+            if (_modules.Exists(item => item.ModuleId == module.ModuleId))
             {
                 await ModuleService.DeleteModuleAsync(module.ModuleId);
             }
@@ -208,10 +206,8 @@ else
             ModuleInstance.ShowProgressIndicator();
 			foreach (Module module in _modules.Where(item => item.IsDeleted))
             {
-                await PageModuleService.DeletePageModuleAsync(module.PageModuleId);
-
                 // check if there are any remaining module instances in the site
-                if (!_modules.Exists(item => item.ModuleId == module.ModuleId))
+                if (_modules.Exists(item => item.ModuleId == module.ModuleId))
                 {
                     await ModuleService.DeleteModuleAsync(module.ModuleId);
                 }

--- a/Oqtane.Server/Repository/ModuleRepository.cs
+++ b/Oqtane.Server/Repository/ModuleRepository.cs
@@ -76,8 +76,8 @@ namespace Oqtane.Repository
         public void DeleteModule(int moduleId)
         {
             Module module = _db.Module.Find(moduleId);
-            _permissions.DeletePermissions(module.SiteId, EntityNames.Module, moduleId);
-            _settings.DeleteSettings(EntityNames.Module, moduleId);
+            //_permissions.DeletePermissions(module.SiteId, EntityNames.Module, moduleId);
+            //_settings.DeleteSettings(EntityNames.Module, moduleId);
             _db.Module.Remove(module);
             _db.SaveChanges();
         }


### PR DESCRIPTION
There was  bug in the Recycle Bin that stopped the module from being deleted.
That is fixed. Also moved the deletion logic to the ModuleController.  Now when a module is deleted the related records are also deleted ; PageModules, Permissions, Settings and finally the Module.