### PR TITLE
Modified Registration to display the Password requirments

### DIFF
--- a/Oqtane.Client/Modules/Admin/Register/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Register/Index.razor
@@ -1,6 +1,5 @@
 @namespace Oqtane.Modules.Admin.Register
 @inherits ModuleBase
-@using System.Resources;
 @inject NavigationManager NavigationManager
 @inject IUserService UserService
 @inject IStringLocalizer<Index> Localizer

--- a/Oqtane.Client/Modules/Admin/Register/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Register/Index.razor
@@ -16,7 +16,7 @@
             <ModuleMessage Message="@Localizer["Info.Registration.Exists"]" Type="MessageType.Info" />
         </Authorized>
         <NotAuthorized>
-            <ModuleMessage Message="@Localizer["Info.Registration.InvalidEmail"]" Type="MessageType.Info" />
+            <ModuleMessage Message="@_passwordconstruction" Type="MessageType.Info" />
             <form @ref="form" class="@(validated ? "was-validated" : "needs-validation")" novalidate>
                 <div class="container">
                     <div class="row mb-1 align-items-center">
@@ -25,14 +25,14 @@
                             <input id="username" class="form-control" @bind="@_username" maxlength="256" required />
                         </div>
                     </div>
-                    <div class="row mb-1 align-items-center">
+@*                    <div class="row mb-1 align-items-center">
                         <div class="col-sm-3"></div>
                         <div class="col-sm-9">
                             <div class="alert alert-info mb-0 mt-1" role="alert">
                                 <small>@_passwordconstruction</small>
                             </div>
                         </div>
-                    </div>
+                    </div>*@
                     <div class="row mb-1 align-items-center">
                         <Label Class="col-sm-3" For="password" HelpText="Please choose a sufficiently secure password and enter it here" ResourceKey="Password"></Label>
                         <div class="col-sm-9">
@@ -101,23 +101,24 @@ else
     protected override async Task OnInitializedAsync()
     {
         var settings = await SettingService.GetSiteSettingsAsync(PageState.Site.SiteId);
+        var emailaddress = Localizer["Info.Registration.InvalidEmail"];
+        string passwordValidationCriteriaTemplate = Localizer["Password.ValidationCriteria"];
+        
         _minimumlength = SettingService.GetSetting(settings, "IdentityOptions:Password:RequiredLength", "6");
         _uniquecharacters = SettingService.GetSetting(settings, "IdentityOptions:Password:RequiredUniqueChars", "1");
         _requiredigit = bool.Parse(SettingService.GetSetting(settings, "IdentityOptions:Password:RequireDigit", "true"));
         _requireupper = bool.Parse(SettingService.GetSetting(settings, "IdentityOptions:Password:RequireUppercase", "true"));
         _requirelower = bool.Parse(SettingService.GetSetting(settings, "IdentityOptions:Password:RequireLowercase", "true"));
         _requirepunctuation = bool.Parse(SettingService.GetSetting(settings, "IdentityOptions:Password:RequireNonAlphanumeric", "true"));
-
-        string passwordValidationCriteriaTemplate = Localizer["Password.ValidationCriteria"];
-
+        
         // Replace the placeholders with the actual values of the variables
         string digitRequirement = _requiredigit ? Localizer["Password.DigitRequirement"] + ", " : "";
         string uppercaseRequirement = _requireupper ? Localizer["Password.UppercaseRequirement"] + ", " : "";
         string lowercaseRequirement = _requirelower ? Localizer["Password.LowercaseRequirement"] + ", " : "";
         string punctuationRequirement = _requirepunctuation ? Localizer["Password.PunctuationRequirement"] + ", " : "";
-
+ 
         // Replace the placeholders with the actual values of the variables
-        _passwordconstruction = string.Format(passwordValidationCriteriaTemplate,
+        _passwordconstruction = emailaddress + "<br />" + string.Format(passwordValidationCriteriaTemplate,
             _minimumlength, _uniquecharacters, digitRequirement, uppercaseRequirement, lowercaseRequirement, punctuationRequirement);
     }
 

--- a/Oqtane.Client/Modules/Admin/Register/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Register/Index.razor
@@ -1,9 +1,11 @@
 @namespace Oqtane.Modules.Admin.Register
 @inherits ModuleBase
+@using System.Resources;
 @inject NavigationManager NavigationManager
 @inject IUserService UserService
 @inject IStringLocalizer<Index> Localizer
 @inject IStringLocalizer<SharedResources> SharedLocalizer
+@inject ISettingService SettingService
 
 @if (PageState.Site.AllowRegistration)
 {
@@ -22,6 +24,14 @@
                         <Label Class="col-sm-3" For="username" HelpText="Your username. Note that this field can not be modified once it is saved." ResourceKey="Username"></Label>
                         <div class="col-sm-9">
                             <input id="username" class="form-control" @bind="@_username" maxlength="256" required />
+                        </div>
+                    </div>
+                    <div class="row mb-1 align-items-center">
+                        <div class="col-sm-3"></div>
+                        <div class="col-sm-9">
+                            <div class="alert alert-info mb-0 mt-1" role="alert">
+                                <small>@_passwordconstruction</small>
+                            </div>
                         </div>
                     </div>
                     <div class="row mb-1 align-items-center">
@@ -68,21 +78,54 @@ else
 }
 
 @code {
-	private string _username = string.Empty;
-	private ElementReference form;
-	private bool validated = false;
-	private string _password = string.Empty;
-	private string _passwordtype = "password";
-	private string _togglepassword = string.Empty;
-	private string _confirm = string.Empty;
-	private string _email = string.Empty;
-	private string _displayname = string.Empty;
+    private string _username = string.Empty;
+    private ElementReference form;
+    private bool validated = false;
+    private string _password = string.Empty;
+    private string _passwordtype = "password";
+    private string _togglepassword = string.Empty;
+    private string _confirm = string.Empty;
+    private string _email = string.Empty;
+    private string _displayname = string.Empty;
 
-	public override SecurityAccessLevel SecurityAccessLevel => SecurityAccessLevel.Anonymous;
+    //Password construction
+    private string _minimumlength;
+    private string _uniquecharacters;
+    private bool _requiredigit;
+    private bool _requireupper;
+    private bool _requirelower;
+    private bool _requirepunctuation;
+    private string _passwordconstruction;
 
-	protected override void OnParametersSet()
+    public override SecurityAccessLevel SecurityAccessLevel => SecurityAccessLevel.Anonymous;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var settings = await SettingService.GetSiteSettingsAsync(PageState.Site.SiteId);
+        _minimumlength = SettingService.GetSetting(settings, "IdentityOptions:Password:RequiredLength", "6");
+        _uniquecharacters = SettingService.GetSetting(settings, "IdentityOptions:Password:RequiredUniqueChars", "1");
+        _requiredigit = bool.Parse(SettingService.GetSetting(settings, "IdentityOptions:Password:RequireDigit", "true"));
+        _requireupper = bool.Parse(SettingService.GetSetting(settings, "IdentityOptions:Password:RequireUppercase", "true"));
+        _requirelower = bool.Parse(SettingService.GetSetting(settings, "IdentityOptions:Password:RequireLowercase", "true"));
+        _requirepunctuation = bool.Parse(SettingService.GetSetting(settings, "IdentityOptions:Password:RequireNonAlphanumeric", "true"));
+
+        string passwordValidationCriteriaTemplate = Localizer["Password.ValidationCriteria"];
+
+        // Replace the placeholders with the actual values of the variables
+        string digitRequirement = _requiredigit ? Localizer["Password.DigitRequirement"] + ", " : "";
+        string uppercaseRequirement = _requireupper ? Localizer["Password.UppercaseRequirement"] + ", " : "";
+        string lowercaseRequirement = _requirelower ? Localizer["Password.LowercaseRequirement"] + ", " : "";
+        string punctuationRequirement = _requirepunctuation ? Localizer["Password.PunctuationRequirement"] + ", " : "";
+
+        // Replace the placeholders with the actual values of the variables
+        _passwordconstruction = string.Format(passwordValidationCriteriaTemplate,
+            _minimumlength, _uniquecharacters, digitRequirement, uppercaseRequirement, lowercaseRequirement, punctuationRequirement);
+    }
+
+    protected override void OnParametersSet()
 	{
 		_togglepassword = SharedLocalizer["ShowPassword"];
+        
 	}
 
     private async Task Register()

--- a/Oqtane.Client/Resources/Modules/Admin/Register/Index.resx
+++ b/Oqtane.Client/Resources/Modules/Admin/Register/Index.resx
@@ -177,4 +177,19 @@
   <data name="Username.Text" xml:space="preserve">
     <value>Username:</value>
   </data>
+  <data name="Password.ValidationCriteria" xml:space="preserve">
+    <value>To ensure a strong and secure password, the password construction should meet the following criteria: it should have a minimum length of {0} characters, including at least {1} unique character(s), {2}{3}{4}{5} to meet the requirements.</value>
+  </data>
+  <data name="Password.DigitRequirement" xml:space="preserve">
+    <value>at least one digit</value>
+  </data>
+  <data name="Password.LowercaseRequirement" xml:space="preserve">
+    <value>at least one lowercase letter</value>
+  </data>
+  <data name="Password.PunctuationRequirement" xml:space="preserve">
+    <value>at least one punctuation mark</value>
+  </data>
+  <data name="Password.UppercaseRequirement" xml:space="preserve">
+    <value>at least one uppercase letter</value>
+  </data>
 </root>


### PR DESCRIPTION
Generating a password can generate a lot of errors and leading to frustration when trying to Register on an Oqtane site.  This is manly due to the visitor not knowing the Password Requirements.  This has been addressed in this PR.

The Password requirements are now displayed to the visitor.

![image](https://user-images.githubusercontent.com/9447612/227512697-3408b4e0-41c8-4864-8249-4e6bf5f65d0d.png)
