### PR TITLE
Fixes null reference permissions issue: Fixes #2724 

### DIFF
--- a/Oqtane.Server/Repository/PermissionRepository.cs
+++ b/Oqtane.Server/Repository/PermissionRepository.cs
@@ -36,7 +36,7 @@ namespace Oqtane.Repository
                     {
                         if (permission.RoleId != null && string.IsNullOrEmpty(permission.RoleName))
                         {
-                            permission.RoleName = roles.Find(item => item.RoleId == permission.RoleId).Name;
+                            permission.RoleName = roles.Find(item => item.RoleId == permission.RoleId)?.Name;
                         }
                     }
                     entry.SlidingExpiration = TimeSpan.FromMinutes(30);


### PR DESCRIPTION
 Permissions for Role Name is null causing child sites to fail to load creating an exception error. #2724 
 
 I tried to clear cache in other areas like at the top of GetPermissions and LoadModuleDefnitions however did not resolve the issue of trying to access sites created from the master site.
 
 This fix presented in this PR should... allow Oqtane to continue to run while accessing alias sites.
 
 This is probably not the fix as I seen errors now in the event log for the site:
 
 Unauthorized Folder Get Attempt {Path} For Site {SiteId}
 
 however I logged out and back in and no error.
 
But then after browsing user profile I would get notification errors popping up 
 
`Log Message: Unauthorized Folder Get Attempt Users\1\ For Site 2`
 
 So need further testing.  This probably should not be returning a null but some reason it is.