### PR TITLE
Add support for new language translation values for #2732.

### DIFF
--- a/Oqtane.Client/Resources/SharedResources.resx
+++ b/Oqtane.Client/Resources/SharedResources.resx
@@ -342,4 +342,55 @@
   <data name="Oqtane.Marketplace" xml:space="preserve">
     <value>Please note that the third party extensions displayed above have been registered in the &lt;a href="https://www.oqtane.net" target="_new"&gt;Oqtane Marketplace&lt;/a&gt; which enables them to be seamlessly downloaded and installed into the framework.</value>
   </data>
+  <data name="Home" xml:space="preserve">
+  <value>Home</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="Apply" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Select" xml:space="preserve">
+    <value>Select</value>
+  </data>
+  <data name="Next" xml:space="preserve">
+    <value>Next</value>
+  </data>
+  <data name="Previous" xml:space="preserve">
+    <value>Previous</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Submit</value>
+  </data>
+  <data name="Refresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="Back" xml:space="preserve">
+    <value>Back</value>
+  </data>
+  <data name="Return" xml:space="preserve">
+    <value>Return</value>
+  </data>
+  <data name="New" xml:space="preserve">
+    <value>New</value>
+  </data>
+  <data name="View" xml:space="preserve">
+    <value>View</value>
+  </data>
+  <data name="Confirm" xml:space="preserve">
+    <value>Confirm</value>
+  </data>
+  <data name="Error Message" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="Success Message" xml:space="preserve">
+    <value>Success</value>
+  </data>
+  <data name="Warning Message" xml:space="preserve">
+    <value>Warning</value>
+  </data>
 </root>


### PR DESCRIPTION
This PR simply adds some very common new language translation values to Oqtane Framework` SharedResources.rex` file to help developers and site administrators have one common shared place to edit these very common types of key values.

This should not introduce a breaking change however if you feel it will I understand and we can close the issue and PR.

Thank you.

Fixes #2732