### PR TITLE
Fix for MenuHorizontal #2757

### DIFF
--- a/Oqtane.Client/Themes/Controls/Theme/MenuHorizontal.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/MenuHorizontal.razor
@@ -10,7 +10,7 @@
         </button>
     </span>
     <div class="app-menu navbar-expand-md">
-        <div class="collapse navbar-collapse" id="Menu">
+        <div class="collapse navbar-collapse navbar-nav-scroll" id="Menu">
             <MenuItemsHorizontal ParentPage="null" Pages="MenuPages" />
         </div>
     </div>


### PR DESCRIPTION
Add the css class to MenuHorizontal to handle scrolling when hamburger Menu is in use.