### PR TITLE
Updates Page.ModifiedOn in PageModuleController methods

### DIFF
--- a/Oqtane.Server/Controllers/PageModuleController.cs
+++ b/Oqtane.Server/Controllers/PageModuleController.cs
@@ -79,6 +79,9 @@ namespace Oqtane.Controllers
                 _syncManager.AddSyncEvent(_alias.TenantId, EntityNames.PageModule, pageModule.PageModuleId, SyncEventActions.Create);
                 _syncManager.AddSyncEvent(_alias.TenantId, EntityNames.Site, _alias.SiteId, SyncEventActions.Refresh);
                 _logger.Log(LogLevel.Information, this, LogFunction.Create, "Page Module Added {PageModule}", pageModule);
+                _pages.UpdatePage(page);
+                _syncManager.AddSyncEvent(_alias.TenantId, EntityNames.Page, page.PageId, SyncEventActions.Update);
+                _logger.Log(LogLevel.Information, this, LogFunction.Update, "Page ModifiedOn Updated {Page}", page);
             }
             else
             {
@@ -101,6 +104,7 @@ namespace Oqtane.Controllers
                 _syncManager.AddSyncEvent(_alias.TenantId, EntityNames.PageModule, pageModule.PageModuleId, SyncEventActions.Update);
                 _syncManager.AddSyncEvent(_alias.TenantId, EntityNames.Site, _alias.SiteId, SyncEventActions.Refresh);
                 _logger.Log(LogLevel.Information, this, LogFunction.Update, "Page Module Updated {PageModule}", pageModule);
+                _pages.UpdatePage(page);
             }
             else
             {
@@ -134,6 +138,9 @@ namespace Oqtane.Controllers
                 }
                 _syncManager.AddSyncEvent(_alias.TenantId, EntityNames.Site, _alias.SiteId, SyncEventActions.Refresh);
                 _logger.Log(LogLevel.Information, this, LogFunction.Update, "Page Module Order Updated {PageId} {Pane}", pageid, pane);
+                _pages.UpdatePage(page);
+                _syncManager.AddSyncEvent(_alias.TenantId, EntityNames.Page, page.PageId, SyncEventActions.Update);
+                _logger.Log(LogLevel.Information, this, LogFunction.Update, "Page ModifiedOn Updated {Page}", page);
             }
             else
             {
@@ -154,6 +161,13 @@ namespace Oqtane.Controllers
                 _syncManager.AddSyncEvent(_alias.TenantId, EntityNames.PageModule, pagemodule.PageModuleId, SyncEventActions.Delete);
                 _syncManager.AddSyncEvent(_alias.TenantId, EntityNames.Site, _alias.SiteId, SyncEventActions.Refresh);
                 _logger.Log(LogLevel.Information, this, LogFunction.Delete, "Page Module Deleted {PageModuleId}", id);
+
+                Page page = _pages.GetPage(pagemodule.PageId);
+                if (page != null)
+                {
+                    _pages.UpdatePage(page);
+                    _logger.Log(LogLevel.Information, this, LogFunction.Update, "Page ModifiedOn Updated {PageId}", page.PageId);
+                }
             }
             else
             {


### PR DESCRIPTION
Fixes #2764 

Fix this up as needed if it looks like it will work.  Using` _pages.UpdatePage(page)` was able to update the sitemap and modified on date for pages when a module is moved/deleted/updated/modified(settings).

I am curious however if we should do this as well in the ModuleController.cs file as well for when modules are deleted, updating all pages `ModifiedOn` property to reflect the changes which I had fixed up but found a better path down the road that may be a solution.  I was not sure if this should be logged... so adjust it as you like :)  I hope this helps!

For updating module content I used another approach in the HtmlText updating it in the repository, however I can play with that more as well see if I can work a better solution once I get more feedback here.

The logging and things not related to the `UpdatePage();` function I was not 100% sure was needed so this can be removed as desired I will let you make adjustments if you find this somewhat acceptable.

Thank you!