### PR TITLE
Updated Dashboard Index

### DIFF
--- a/Oqtane.Client/Modules/Admin/Dashboard/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Dashboard/Index.razor
@@ -22,7 +22,7 @@
 @code {
 	private List<Page> _pages;
 
-	public override SecurityAccessLevel SecurityAccessLevel => SecurityAccessLevel.Anonymous;
+    public override SecurityAccessLevel SecurityAccessLevel => SecurityAccessLevel.Admin;
 
 	protected override void OnInitialized()
 	{

--- a/Oqtane.Client/Modules/Admin/Dashboard/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Dashboard/Index.razor
@@ -22,7 +22,7 @@
 @code {
 	private List<Page> _pages;
 
-    public override SecurityAccessLevel SecurityAccessLevel => SecurityAccessLevel.Admin;
+    public override SecurityAccessLevel SecurityAccessLevel => SecurityAccessLevel.View;
 
 	protected override void OnInitialized()
 	{


### PR DESCRIPTION
This pr updates dashboard index SecurityAccessLevel to match other module pages.  Clarity here maybe needed to understand this override.

I set this to Admin and tested all scenarios where you may have another role with a registered user manage admin/roles and everything worked as expected.  

