### PR TITLE
Add missing settings excluded from Fix #2727

### DIFF
--- a/Oqtane.Server/Pages/Sitemap.cshtml.cs
+++ b/Oqtane.Server/Pages/Sitemap.cshtml.cs
@@ -67,6 +67,7 @@ namespace Oqtane.Pages
                                 {
                                     try
                                     {
+                                        pageModule.Module.Settings = _settings.GetSettings(EntityNames.Module, pageModule.ModuleId).ToDictionary(x => x.SettingName, x => x.SettingValue);
                                         var moduleobject = ActivatorUtilities.CreateInstance(_serviceProvider, moduletype);
                                         var urls = ((ISitemap)moduleobject).GetUrls(_alias.Path, page.Path, pageModule.Module);
                                         foreach (var url in urls)


### PR DESCRIPTION
Fixes #2787 

Seems I excluded this one line while modifying the GetOn method in PR in the final update commit.

This PR will re-add the missing settings line of code back to the Sitemap.cshtml.cs file from @leigh-pointer prior pull request.