### PR TITLE
Unhandled error when creating module instance on page due to missing ModuleDefinition in Module table 

### DIFF
--- a/Oqtane.Client/UI/SiteRouter.razor
+++ b/Oqtane.Client/UI/SiteRouter.razor
@@ -403,7 +403,9 @@
 			if ((module.PageId == page.PageId || module.ModuleId == moduleid))
 			{
 				var typename = Constants.ErrorModule;
-				if (module.ModuleDefinition != null && (module.ModuleDefinition.Runtimes == "" || module.ModuleDefinition.Runtimes.Contains(Runtime)))
+			    //ModuleDefinition is always initialized in the controller with default values, so it is not null
+			    //but if the module is not present in the ModuleDefinitions table, ModuleDefinitionId is 0 
+				if (module.ModuleDefinition != null && module.ModuleDefinition.ModuleDefinitionId != 0 && (module.ModuleDefinition.Runtimes == "" || module.ModuleDefinition.Runtimes.Contains(Runtime)))
 				{
 					typename = module.ModuleDefinition.ControlTypeTemplate;
 


### PR DESCRIPTION
When a module is defined in the Module table but does not have a corresponding definition in the ModuleDefinition table, the program will cause an unhandled error. The module.ModuleDefinition is initialized with default values in the controller and it is not possible to create an instance of the type. This error occurs during the creation of module instances on the page.