### PR TITLE
Made the default SQL Server and App Service provisioned Basic Tier

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -4,7 +4,7 @@
   "parameters": {
     "sqlDatabaseEditionTierDtuCapacity": {
       "type": "string",
-      "defaultValue": "Standard-S1-20-250",
+      "defaultValue": "Basic-Basic-5-2",
       "allowedValues": [
         "Basic-Basic-5-2",
         "Standard-S0-10-250",


### PR DESCRIPTION
I have made the SQL Server database and the AppServices which is provisioned to be basic tier as per your suggestion by @sbwalker 