### PR TITLE
Show all themes on page add/edit

### DIFF
--- a/Oqtane.Client/Modules/Admin/Pages/Add.razor
+++ b/Oqtane.Client/Modules/Admin/Pages/Add.razor
@@ -246,7 +246,7 @@
             if (UserSecurity.IsAuthorized(PageState.User, RoleNames.Admin) || (_parent != null && UserSecurity.IsAuthorized(PageState.User, PermissionNames.Edit, _parent.PermissionList)))
             {
                 _themetype = PageState.Site.DefaultThemeType;
-                _themes = ThemeService.GetThemeControls(PageState.Site.Themes, _themetype);
+                _themes = ThemeService.GetThemeControls(PageState.Site.Themes);
                 _containers = ThemeService.GetContainerControls(PageState.Site.Themes, _themetype);
                 _containertype = PageState.Site.DefaultContainerType;
                 _children = PageState.Pages.Where(item => item.ParentId == null).ToList();

--- a/Oqtane.Client/Modules/Admin/Pages/Edit.razor
+++ b/Oqtane.Client/Modules/Admin/Pages/Edit.razor
@@ -359,7 +359,7 @@
                 {
                     _themetype = PageState.Site.DefaultThemeType;
                 }
-                _themes = ThemeService.GetThemeControls(PageState.Site.Themes, _themetype);
+                _themes = ThemeService.GetThemeControls(PageState.Site.Themes);
                 _containers = ThemeService.GetContainerControls(PageState.Site.Themes, _themetype);
                 _containertype = _page.DefaultContainerType;
                 if (string.IsNullOrEmpty(_containertype))

--- a/Oqtane.Server/Infrastructure/Interfaces/IHostResources.cs
+++ b/Oqtane.Server/Infrastructure/Interfaces/IHostResources.cs
@@ -1,11 +1,12 @@
 using Oqtane.Models;
+using System;
 using System.Collections.Generic;
 
 namespace Oqtane.Infrastructure
 {
-    // this interface is for declaring global resources and is useful for scenarios where you want to declare resources in a single location for the entire application
     public interface IHostResources
     {
+        [Obsolete("IHostResources is deprecated. Use module or theme scoped Resources in conjunction with ResourceLevel.Site instead.", false)]
         List<Resource> Resources { get; } // identifies global resources for an application
     }
 }


### PR DESCRIPTION
Found a small typo what would limit the theme dropdowns on page add/edits to show only the default theme. 