### PR TITLE
Fixing personalized page created to be UserName if DisplayName is null

### DIFF
--- a/Oqtane.Server/Controllers/PageController.cs
+++ b/Oqtane.Server/Controllers/PageController.cs
@@ -183,7 +183,7 @@ namespace Oqtane.Controllers
                 page = new Page();
                 page.SiteId = parent.SiteId;
                 page.ParentId = parent.PageId;
-                page.Name = user.DisplayName;
+                page.Name = user.DisplayName != null ? user.DisplayName : user.Username;
                 page.Path = parent.Path + "/" + Utilities.GetFriendlyUrl(page.Name);
                 page.Title = page.Name + " - " + parent.Name;
                 page.Order = 0;


### PR DESCRIPTION
Fix for issue #2979 