### PR TITLE
[FIX] - Fixed the ResourceType in Module Settings with correct NameSpace

### DIFF
--- a/Oqtane.Server/wwwroot/Modules/Templates/External/Client/Modules/[Owner].Module.[Module]/Settings.razor
+++ b/Oqtane.Server/wwwroot/Modules/Templates/External/Client/Modules/[Owner].Module.[Module]/Settings.razor
@@ -13,7 +13,7 @@
 </div>
 
 @code {
-    private string resourceType = "[Owner].[Module].Settings, [Owner].[Module].Client.Oqtane"; // for localization
+    private string resourceType = "[Owner].Module.[Module].Settings, [Owner].Module.[Module].Client.Oqtane"; // for localization
     public override string Title => "[Module] Settings";
 
     string _value;


### PR DESCRIPTION
changed 

`private string resourceType = "[Owner].[Module].Settings, [Owner].[Module].Client.Oqtane"; // for localization`

to 

`private string resourceType = "[Owner].Module.[Module].Settings, [Owner].Module.[Module].Client.Oqtane"; // for localization`

to match the correct NameSpace