### PR TITLE
[ENHANCE] - Moved `SetImage()` before the OnSelect fires so that the …

### DIFF
--- a/Oqtane.Client/Modules/Controls/FileManager.razor
+++ b/Oqtane.Client/Modules/Controls/FileManager.razor
@@ -271,13 +271,10 @@
     {
         _message = string.Empty;
         FileId = int.Parse((string)e.Value);
-        if (FileId != -1)
-        {
-            await OnSelect.InvokeAsync(FileId);
-        }
-
         await SetImage();
+        await OnSelect.InvokeAsync(FileId);
         StateHasChanged();
+
     }
 
     private async Task SetImage()


### PR DESCRIPTION
…Parent can retrieve the Image from `fileManager` rather then calling `FileService` to retrieve again