### PR TITLE
Update moduleDefinitions only if not serverstate.IsMigrated

### DIFF
--- a/Oqtane.Server/Repository/SiteRepository.cs
+++ b/Oqtane.Server/Repository/SiteRepository.cs
@@ -97,16 +97,18 @@ namespace Oqtane.Repository
 
         public Site InitializeSite(Alias alias)
         {
-            var site = GetSite(alias.SiteId);            
+            var site = GetSite(alias.SiteId);
 
-            // load themes and module definitions 
+            // load themes
             site.Themes = _themeRepository.GetThemes().ToList();
-            var moduleDefinitions = _moduleDefinitionRepository.GetModuleDefinitions(alias.SiteId);
 
             // site migrations
             var serverstate = _serverState.GetServerState(alias.SiteId);
             if (!serverstate.IsMigrated)
             {
+                // load module definitions
+                var moduleDefinitions = _moduleDefinitionRepository.GetModuleDefinitions(alias.SiteId);
+
                 // ensure migrations are only executed once
                 lock (_lock)
                 {
@@ -281,7 +283,7 @@ namespace Oqtane.Repository
                     else
                     {
                         site.SiteTemplateType = section.Value;
-                    }                    
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
In the SiteRepository, while doing the Site initialization,
currently the site Themes and modules definitions are read before checking if the server has been migrated.
nevertheless, the loaded modules are only used if the server has not been migrated.

The process to load the modules definition involves a lot of operations, therefore, asumming that the GetModuleDefinitions routine has no side efects, it seems to me that it would be better to do it only we know that the server state is migrated. In that way the Site initialization will be faster in most cases.
