### PR TITLE
[FIX] - Page disappears if you unpublish and publish a module

### DIFF
--- a/Oqtane.Client/Themes/Controls/Container/ModuleActionsBase.cs
+++ b/Oqtane.Client/Themes/Controls/Container/ModuleActionsBase.cs
@@ -139,11 +139,11 @@ namespace Oqtane.Themes.Controls
             var permissions = pagemodule.Module.PermissionList;
             if (!permissions.Any(item => item.PermissionName == PermissionNames.View && item.RoleName == RoleNames.Everyone))
             {
-                permissions.Add(new Permission(ModuleState.SiteId, EntityNames.Page, pagemodule.PageId, PermissionNames.View, RoleNames.Everyone, null, true));
+                permissions.Add(new Permission(ModuleState.SiteId, EntityNames.Module, pagemodule.ModuleId, PermissionNames.View, RoleNames.Everyone, null, true));
             }
             if (!permissions.Any(item => item.PermissionName == PermissionNames.View && item.RoleName == RoleNames.Registered))
             {
-                permissions.Add(new Permission(ModuleState.SiteId, EntityNames.Page, pagemodule.PageId, PermissionNames.View, RoleNames.Registered, null, true));
+                permissions.Add(new Permission(ModuleState.SiteId, EntityNames.Module, pagemodule.ModuleId, PermissionNames.View, RoleNames.Registered, null, true));
             }
             pagemodule.Module.PermissionList = permissions;
             await ModuleService.UpdateModuleAsync(pagemodule.Module);


### PR DESCRIPTION
The Publish Method was Publishing the Page instead of the Module which were removing permissions
Fix for #3033 