### PR TITLE
Url Path Change NavigateTo Fix - Fixes #3229

### DIFF
--- a/Oqtane.Client/Modules/Admin/Pages/Edit.razor
+++ b/Oqtane.Client/Modules/Admin/Pages/Edit.razor
@@ -613,15 +613,16 @@
                     }
 
                     await logger.LogInformation("Page Saved {Page}", _page);
-                    if (currentPath != _page.Path)
-                    {
-                        string newPageUrl = NavigateUrl(_page.Path);
 
-                        NavigationManager.NavigateTo(newPageUrl);
-                        return;
-                    }
                     if (!string.IsNullOrEmpty(PageState.ReturnUrl))
-                    {
+                    {                    
+                    if (currentPath != _page.Path)
+                        {
+                            string newPageUrl = NavigateUrl(_page.Path);
+    
+                            NavigationManager.NavigateTo(newPageUrl);
+                            return;
+                        }
                         NavigationManager.NavigateTo(PageState.ReturnUrl);
                     }
                     else

--- a/Oqtane.Client/Modules/Admin/Pages/Edit.razor
+++ b/Oqtane.Client/Modules/Admin/Pages/Edit.razor
@@ -613,6 +613,13 @@
                     }
 
                     await logger.LogInformation("Page Saved {Page}", _page);
+                    if (currentPath != _page.Path)
+                    {
+                        string newPageUrl = NavigateUrl(_page.Path);
+
+                        NavigationManager.NavigateTo(newPageUrl);
+                        return;
+                    }
                     if (!string.IsNullOrEmpty(PageState.ReturnUrl))
                     {
                         NavigationManager.NavigateTo(PageState.ReturnUrl);

--- a/Oqtane.Client/Modules/Admin/Pages/Edit.razor
+++ b/Oqtane.Client/Modules/Admin/Pages/Edit.razor
@@ -616,8 +616,7 @@
 
                     if (!string.IsNullOrEmpty(PageState.ReturnUrl))
                     {                    
-                        PageState.ReturnUrl = _page.Path;
-                        NavigationManager.NavigateTo(PageState.ReturnUrl);
+                        NavigationManager.NavigateTo(_page.Path);
                     }
                     else
                     {

--- a/Oqtane.Client/Modules/Admin/Pages/Edit.razor
+++ b/Oqtane.Client/Modules/Admin/Pages/Edit.razor
@@ -616,13 +616,7 @@
 
                     if (!string.IsNullOrEmpty(PageState.ReturnUrl))
                     {                    
-                    if (currentPath != _page.Path)
-                        {
-                            string newPageUrl = NavigateUrl(_page.Path);
-    
-                            NavigationManager.NavigateTo(newPageUrl);
-                            return;
-                        }
+                        PageState.ReturnUrl = _page.Path;
                         NavigationManager.NavigateTo(PageState.ReturnUrl);
                     }
                     else


### PR DESCRIPTION
Fixes #3229 

This PR is a solution that fixes the issue with navigation to the new page path URL when is it updated in location or when `Url Path` form field property is updated.

Added logic for when there is a `ReturnUrl` to check if the `currentPath` is the same as the `_page.Path` after being updated in the Admin/Pages/Edit.razor component.

If the _page.Path is different to use that instead of the `ReturnUrl` that has been passed.

The final commit simplifies it the most and just always sets the return url to the path.  So either solution works on my end.  I am going to leave it with the most simple version let you decide. 

Hope this helps!

       