### PR TITLE
Head.razor Title & HeadContent indentation + new lines - Fixes #3232

### DIFF
--- a/Oqtane.Client/Head.razor
+++ b/Oqtane.Client/Head.razor
@@ -33,7 +33,7 @@
                 }
                 break;
             case "HeadContent":
-                var content = "\t" + RemoveScripts(SiteState.Properties.HeadContent) + "\n\t";
+                var content = "\t" + RemoveScripts(SiteState.Properties.HeadContent);
                 if (content != _content)
                 {
                     _content = content;

--- a/Oqtane.Client/Head.razor
+++ b/Oqtane.Client/Head.razor
@@ -25,7 +25,7 @@
         switch (e.PropertyName)
         {
             case "PageTitle":
-                var title = "\n<title>" + SiteState.Properties.PageTitle + "</title>";
+                var title = "\n\t<title>" + SiteState.Properties.PageTitle + "</title>";
                 if (title != _title)
                 {
                     _title = title;
@@ -33,7 +33,7 @@
                 }
                 break;
             case "HeadContent":
-                var content = RemoveScripts(SiteState.Properties.HeadContent) + "\n";
+                var content = "\t" + RemoveScripts(SiteState.Properties.HeadContent) + "\n\t";
                 if (content != _content)
                 {
                     _content = content;


### PR DESCRIPTION
Fixes #3232

Creates indentation and new lines for `Title` and `HeadContent` rendered in the HTML head source. (part 1)

These linked PR's to issue #3232 will help generate the following:

![image](https://github.com/oqtane/oqtane.framework/assets/13577556/d100a278-50b5-468e-869d-347c64a83aab)

Notice the </script> tag still there as the scripts I put into the Head Content of the Page Content leave this behind when scripts are removed from `headcontent`

also the `app-stylesheet-page-xxxx` entries after the first one do not have indentation.

These issues remain and will be dealt with when I (or whomever) can find a solution. I did manage to get everything on it's own new lines.

Noticed this while adding resources to a module I created thought this would be a nice touch for Oqtanes source page head section readability.