### PR TITLE
ThemeBuilder.cs Head indentations and new lines for HeadContent and FavIcon link elements - Fixes #3232 p2

### DIFF
--- a/Oqtane.Client/UI/ThemeBuilder.razor
+++ b/Oqtane.Client/UI/ThemeBuilder.razor
@@ -40,7 +40,7 @@
             favicon = Utilities.FileUrl(PageState.Alias, PageState.Site.FaviconFileId.Value);
             favicontype = favicon.Substring(favicon.LastIndexOf(".") + 1);
         }
-        headcontent += $"<link id=\"app-favicon\" rel=\"shortcut icon\" type=\"image/{favicontype}\" href=\"{favicon}\" />\n";
+        headcontent += $"\n\t<link id=\"app-favicon\" rel=\"shortcut icon\" type=\"image/{favicontype}\" href=\"{favicon}\" />\n";
 
         // head content
         AddHeadContent(headcontent, PageState.Site.HeadContent);
@@ -76,7 +76,7 @@
                 {
                     if (!headcontent.Contains(element))
                     {
-                        headcontent += element + "\n";
+                        headcontent += element + "\n\t";
                     }
                 }
                 index = content.IndexOf("<", index + 1);


### PR DESCRIPTION
Fixes #3232 

This PR along with #3233 will add line breaks and indentation to `HeadContent` and  `FavIcon` HTML head elements making them easier to review page source while creating themes and modules.