### PR TITLE
Fixes #3236 - Page Settings Head + Body Scripts Included in Source

### DIFF
--- a/Oqtane.Server/Pages/_Host.cshtml.cs
+++ b/Oqtane.Server/Pages/_Host.cshtml.cs
@@ -202,7 +202,7 @@ namespace Oqtane.Pages
                         HeadResources += ParseScripts(site.HeadContent);
                         HeadResources += ParseScripts(page.HeadContent);
                         BodyResources += ParseScripts(site.BodyContent);
-                        HeadResources += ParseScripts(page.BodyContent);
+                        BodyResources += ParseScripts(page.BodyContent);
                         var scripts = _serverState.GetServerState(alias.SiteKey).Scripts;
                         foreach (var script in scripts)
                         {

--- a/Oqtane.Server/Pages/_Host.cshtml.cs
+++ b/Oqtane.Server/Pages/_Host.cshtml.cs
@@ -200,7 +200,9 @@ namespace Oqtane.Pages
                             PWAScript = CreatePWAScript(alias, site, route);
                         }
                         HeadResources += ParseScripts(site.HeadContent);
+                        HeadResources += ParseScripts(page.HeadContent);
                         BodyResources += ParseScripts(site.BodyContent);
+                        HeadResources += ParseScripts(page.HeadContent);
                         var scripts = _serverState.GetServerState(alias.SiteKey).Scripts;
                         foreach (var script in scripts)
                         {

--- a/Oqtane.Server/Pages/_Host.cshtml.cs
+++ b/Oqtane.Server/Pages/_Host.cshtml.cs
@@ -202,7 +202,7 @@ namespace Oqtane.Pages
                         HeadResources += ParseScripts(site.HeadContent);
                         HeadResources += ParseScripts(page.HeadContent);
                         BodyResources += ParseScripts(site.BodyContent);
-                        HeadResources += ParseScripts(page.HeadContent);
+                        HeadResources += ParseScripts(page.BodyContent);
                         var scripts = _serverState.GetServerState(alias.SiteKey).Scripts;
                         foreach (var script in scripts)
                         {


### PR DESCRIPTION
This should resolve #3236 if approved.  Sorry missed few things making 3 commits after further testing to get it right.

From #3236 conversation the results now look as follows:
Head Scripts:
![image](https://github.com/oqtane/oqtane.framework/assets/13577556/2d3c05fe-a9c6-4e7b-85d0-4055f0ee0cfa)

Body Scripts:

![image](https://github.com/oqtane/oqtane.framework/assets/13577556/faaa4b3a-a35a-4195-a540-4df2c3310476)

_Special Notes:_

I do notice something odd... 
- Put the same script is included in Site and Page Settings Head or Body they ALL get removed instead of leaving the one.
- Put the same script in all 4 places, it didn't show up once.
- Put the same script in the head and body of Page or Settings and both show up.

This is the duplicate removal feature issue and not related to this one so I will report it as another issue.

To take this a little further notice how these scripts i the head are after the Blazor "Prerender" closing `<!--Blazor:{"prerenderId":`

I take it this is why they are removed and the head/body content needs two areas to load, one in the ThemeBuilder.cs file and the other in the _Host.cshtml.cs code behind file.

Must be a reason for not prerendering the scripts in the head I take it?

Well don't feel bad having to refresh to see your changes sometimes in Oqtane... each time I make a change to my original commit I have to refresh to see it after applying the fix in a file on GitHub (billion dollar company) which is a bug maybe someone can report... use the code editor in GitHub to make changes to a file in a PR already submitted and you think it wasn't applied because the content is not refreshed you are viewing after saving changes.

I probably should be using Visual Studio but this should still work here in GitHub.