### PR TITLE
Updates Child Page Link Color in Theme Creator Template - Theme.css - Fixes #3278

### DIFF
--- a/Oqtane.Server/wwwroot/Themes/Templates/External/Client/wwwroot/Themes/[Owner].Theme.[Theme]/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Templates/External/Client/wwwroot/Themes/[Owner].Theme.[Theme]/Theme.css
@@ -79,6 +79,10 @@ div.app-moduleactions a.dropdown-toggle, div.app-moduleactions div.dropdown-menu
     color: #000000;
 }
 
+.dropdown-menu span {
+  mix-blend-mode: difference;
+}
+
 @media (max-width: 767px) {
 
     .app-menu {


### PR DESCRIPTION
![image](https://github.com/oqtane/oqtane.framework/assets/13577556/32bbca5d-d76b-4c78-b328-a49fd589f2b5)

This PR should resolve #3278 

This basically inverts the color from the background but this value can be changed on the selected element for child pages as needed.  I believe this selector should do the trick so we can at least see the child pages from the Oqtane default theme creator template.