### PR TITLE
upated LanguageSwitcher with end padding

### DIFF
--- a/Oqtane.Client/Themes/Controls/Theme/LanguageSwitcher.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/LanguageSwitcher.razor
@@ -8,7 +8,7 @@
 
 @if (_supportedCultures?.Count() > 1)
 {
-    <div class="btn-group" role="group">
+    <div class="btn-group pe-1" role="group">
         <button id="btnCultures" type="button" class="btn btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <span class="oi oi-globe"></span>
         </button>


### PR DESCRIPTION
When the LanguageSwitcher is dsiplayed the wsa no end padding on the button so it appeared flush with the following button.  Adding "pe-1" to the class corrects the issue