### PR TITLE
Introduce a dropdown menu for authorization response types

### DIFF
--- a/Oqtane.Client/Modules/Admin/Users/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Users/Index.razor
@@ -262,7 +262,22 @@ else
 									<input id="parameters" class="form-control" @bind="@_parameters" />
 								</div>
 							</div>
-							<div class="row mb-1 align-items-center">
+                            <div class="row mb-1 align-items-center">
+                                <Label Class="col-sm-3" For="authresponsetype" HelpText="Specify the authorization response type" ResourceKey="AuthResponseType">Authorization Response Type</Label>
+                                <div class="col-sm-9">
+                                    <select id="authresponsetype" class="form-select" @bind="@_authresponsetype" required>
+                                        <option value="code">@Localizer["AuthFlow.Code"]</option>
+                                        <option value="code id_token">@Localizer["AuthFlow.CodeIdToken"]</option>
+                                        <option value="code id_token token">@Localizer["AuthFlow.CodeIdTokenToken"]</option>
+                                        <option value="code token">@Localizer["AuthFlow.CodeToken"]</option>
+                                        <option value="id_token">@Localizer["AuthFlow.IdToken"]</option>
+                                        <option value="id_token token">@Localizer["AuthFlow.IdTokenToken"]</option>
+                                        <option value="token">@Localizer["AuthFlow.Token"]</option>
+                                        <option value="none">@Localizer["AuthFlow.None"]</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="row mb-1 align-items-center">
 								<Label Class="col-sm-3" For="pkce" HelpText="Indicate if the provider supports Proof Key for Code Exchange (PKCE)" ResourceKey="PKCE">Use PKCE?</Label>
 								<div class="col-sm-9">
 									<select id="pkce" class="form-select" @bind="@_pkce" required>
@@ -400,6 +415,7 @@ else
     private string _scopes;
     private string _parameters;
     private string _pkce;
+    private string _authresponsetype;
     private string _redirecturl;
     private string _identifierclaimtype;
     private string _emailclaimtype;
@@ -458,6 +474,7 @@ else
             _scopes = SettingService.GetSetting(settings, "ExternalLogin:Scopes", "");
             _parameters = SettingService.GetSetting(settings, "ExternalLogin:Parameters", "");
             _pkce = SettingService.GetSetting(settings, "ExternalLogin:PKCE", "false");
+            _authresponsetype = SettingService.GetSetting(settings, "ExternalLogin:AuthResponseType", "code");
             _redirecturl = PageState.Uri.Scheme + "://" + PageState.Alias.Name + "/signin-" + _providertype;
             _identifierclaimtype = SettingService.GetSetting(settings, "ExternalLogin:IdentifierClaimType", "sub");
             _emailclaimtype = SettingService.GetSetting(settings, "ExternalLogin:EmailClaimType", "email");
@@ -579,6 +596,7 @@ else
 				settings = SettingService.SetSetting(settings, "ExternalLogin:Scopes", _scopes, true);
 				settings = SettingService.SetSetting(settings, "ExternalLogin:Parameters", _parameters, true);
 				settings = SettingService.SetSetting(settings, "ExternalLogin:PKCE", _pkce, true);
+                settings = SettingService.SetSetting(settings, "ExternalLogin:AuthResponseType", _authresponsetype, true);
 				settings = SettingService.SetSetting(settings, "ExternalLogin:IdentifierClaimType", _identifierclaimtype, true);
 				settings = SettingService.SetSetting(settings, "ExternalLogin:EmailClaimType", _emailclaimtype, true);
 				settings = SettingService.SetSetting(settings, "ExternalLogin:RoleClaimType", _roleclaimtype, true);

--- a/Oqtane.Client/Resources/Modules/Admin/Users/Index.resx
+++ b/Oqtane.Client/Resources/Modules/Admin/Users/Index.resx
@@ -408,4 +408,31 @@
   <data name="ImportUsers.Text" xml:space="preserve">
     <value>Import Users</value>
   </data>
+  <data name="AuthFlow.Code" xml:space="preserve">
+    <value>code</value>
+  </data>
+  <data name="AuthFlow.CodeIdToken" xml:space="preserve">
+    <value>code id_token</value>
+  </data>
+  <data name="AuthFlow.CodeIdTokenToken" xml:space="preserve">
+    <value>code id_token token</value>
+  </data>
+  <data name="AuthFlow.CodeToken" xml:space="preserve">
+    <value>code token</value>
+  </data>
+  <data name="AuthFlow.IdToken" xml:space="preserve">
+    <value>id_token</value>
+  </data>
+  <data name="AuthFlow.IdTokenToken" xml:space="preserve">
+    <value>id_token token</value>
+  </data>
+  <data name="AuthFlow.None" xml:space="preserve">
+    <value>none</value>
+  </data>
+  <data name="AuthFlow.Token" xml:space="preserve">
+    <value>token</value>
+  </data>
+  <data name="AuthResponseType" xml:space="preserve">
+    <value>Authorization Response Type</value>
+  </data>
 </root>

--- a/Oqtane.Server/Extensions/OqtaneSiteAuthenticationBuilderExtensions.cs
+++ b/Oqtane.Server/Extensions/OqtaneSiteAuthenticationBuilderExtensions.cs
@@ -44,7 +44,7 @@ namespace Oqtane.Extensions
                     options.SaveTokens = false;
                     options.GetClaimsFromUserInfoEndpoint = true;
                     options.CallbackPath = string.IsNullOrEmpty(alias.Path) ? "/signin-" + AuthenticationProviderTypes.OpenIDConnect : "/" + alias.Path + "/signin-" + AuthenticationProviderTypes.OpenIDConnect;
-                    options.ResponseType = OpenIdConnectResponseType.Code; // authorization code flow
+                    options.ResponseType = sitesettings.GetValue("ExternalLogin:AuthResponseType", "code"); // authorization code flow
                     options.ResponseMode = OpenIdConnectResponseMode.FormPost; // recommended as most secure
 
                     // cookie config is required to avoid Correlation Failed errors


### PR DESCRIPTION
Introduce a dropdown menu in the 'External Login' settings area for authentication flow response types. 

I used the response types found in the Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectResponseType class.

For more information take a look at: #3325