### PR TITLE
Module Creator allow punctuation in Description field

### DIFF
--- a/Oqtane.Client/Modules/Admin/ModuleDefinitions/Create.razor
+++ b/Oqtane.Client/Modules/Admin/ModuleDefinitions/Create.razor
@@ -156,7 +156,7 @@
     private bool IsValidXML(string description)
     {
         // must contain letters, digits, or spaces
-        return Regex.IsMatch(description, "^[A-Za-z0-9 ]+$");
+        return Regex.IsMatch(description, "^[A-Za-z0-9 .,!?]+$");
     }
 
     private void TemplateChanged(ChangeEventArgs e)


### PR DESCRIPTION
Modified the Regex to all punctuation in the description. "^[A-Za-z0-9 .,!?]+$")