### PR TITLE
Fixes #3412 input used for profile fields when rows are less than or equal to 1

### DIFF
--- a/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
+++ b/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
@@ -123,7 +123,7 @@ else
                                     }
                                     else
                                     {
-                                        @if (p.Rows == 1)
+                                        @if (p.Rows <= 1)
                                         {
                                             @if (p.IsRequired)
                                             {


### PR DESCRIPTION
This pr fixes #3412 and sets input form element instead of textarea for element when rows are 1 or less for a profile field.