### PR TITLE
Models/Profile.cs: Sets Rows Default Value Equal to 1 - Fixes #3412

### DIFF
--- a/Oqtane.Shared/Models/Profile.cs
+++ b/Oqtane.Shared/Models/Profile.cs
@@ -77,6 +77,6 @@ namespace Oqtane.Models
         /// <summary>
         /// Optional number of rows (textarea)
         /// </summary>
-        public int Rows { get; set; }
+        public int Rows { get; set; } = 1;
     }
 }


### PR DESCRIPTION
Fixes #3412 

This fix works on both clean installs, and on new sites created.
![image](https://github.com/oqtane/oqtane.framework/assets/13577556/549c87cb-7fcd-4d26-bc0e-ff29aa7c1eaf)

Still I was trying to find the logic that creates a site and sets to 0 or does not set the value. For example if I wanted to create a site template with different profile configuration settings.

I would think this is where the "fix" is but maybe there is a better solution.