### PR TITLE
User profiles notifications return url fix

### DIFF
--- a/Oqtane.Client/Modules/Admin/UserProfile/Add.razor
+++ b/Oqtane.Client/Modules/Admin/UserProfile/Add.razor
@@ -12,25 +12,25 @@
     <div class="row mb-1 align-items-center">
         <Label Class="col-sm-3" For="to" HelpText="Enter the username you wish to send a message to" ResourceKey="To">To: </Label>
         <div class="col-sm-9">
-            <input id="to" class="form-control" @bind="@username" />
+            <input id="to" class="form-control" @bind="username" />
         </div> 
     </div>
     <div class="row mb-1 align-items-center">
         <Label Class="col-sm-3" For="subject" HelpText="Enter the subject of the message" ResourceKey="Subject">Subject: </Label>
         <div class="col-sm-9">
-            <input id="subject" class="form-control" @bind="@subject" />
+            <input id="subject" class="form-control" @bind="subject" />
         </div>
     </div>
     <div class="row mb-1 align-items-center">
         <Label Class="col-sm-3" For="message" HelpText="Enter the message" ResourceKey="Message">Message: </Label>
         <div class="col-sm-9">
-            <textarea id="message" class="form-control" @bind="@body" rows="5" />
+            <textarea id="message" class="form-control" @bind="body" rows="5" />
         </div>
     </div>
 </div>
 <br/>
     <button type="button" class="btn btn-primary" @onclick="Send">@SharedLocalizer["Send"]</button>
-    <NavLink class="btn btn-secondary" href="@NavigateUrl()">@SharedLocalizer["Cancel"]</NavLink>
+    <NavLink class="btn btn-secondary" href="@(NavigateUrl() + "?tab=Notifications")">@SharedLocalizer["Cancel"]</NavLink>
 }
 
 @code {
@@ -52,7 +52,7 @@
                 var notification = new Notification(PageState.Site.SiteId, PageState.User, user, subject, body);
                 notification = await NotificationService.AddNotificationAsync(notification);
                 await logger.LogInformation("Notification Created {NotificationId}", notification.NotificationId);
-                NavigationManager.NavigateTo(NavigateUrl());
+                NavigationManager.NavigateTo(NavigateUrl() + "?tab=Notifications");
             }
             else
             {

--- a/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
+++ b/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
@@ -28,14 +28,14 @@ else
                 <div class="row mb-1 align-items-center">
                     <Label Class="col-sm-3" For="username" HelpText="Your username. Note that this field can not be modified." ResourceKey="Username"></Label>
                     <div class="col-sm-9">
-                        <input id="username" class="form-control" @bind="@username" readonly />
+                        <input id="username" class="form-control" @bind="username" readonly />
                     </div>
                 </div>
                 <div class="row mb-1 align-items-center">
                     <Label Class="col-sm-3" For="password" HelpText="If you wish to change your password you can enter it here. Please choose a sufficiently secure password." ResourceKey="Password"></Label>
 					<div class="col-sm-9">
                         <div class="input-group">
-						    <input id="password" type="@_passwordtype" class="form-control" @bind="@_password" autocomplete="new-password" />
+						    <input id="password" type="@_passwordtype" class="form-control" @bind="_password" autocomplete="new-password" />
                             <button type="button" class="btn btn-secondary" @onclick="@TogglePassword" tabindex="-1">@_togglepassword</button>
 					    </div>
                     </div>
@@ -44,7 +44,7 @@ else
                     <Label Class="col-sm-3" For="confirm" HelpText="If you are changing your password you must enter it again to confirm it matches" ResourceKey="Confirm"></Label>
                     <div class="col-sm-9">
                         <div class="input-group">
-							<input id="confirm" type="@_passwordtype" class="form-control" @bind="@confirm" autocomplete="new-password" />
+							<input id="confirm" type="@_passwordtype" class="form-control" @bind="confirm" autocomplete="new-password" />
                             <button type="button" class="btn btn-secondary" @onclick="@TogglePassword" tabindex="-1">@_togglepassword</button>
 					    </div>
                     </div>
@@ -54,7 +54,7 @@ else
 					<div class="row mb-1 align-items-center">
 						<Label Class="col-sm-3" For="twofactor" HelpText="Indicates if you are using two factor authentication. Two factor authentication requires you to enter a verification code sent via email after you sign in." ResourceKey="TwoFactor"></Label>
 						<div class="col-sm-9">
-							<select id="twofactor" class="form-select" @bind="@twofactor" required>
+							<select id="twofactor" class="form-select" @bind="twofactor" required>
 								<option value="True">@SharedLocalizer["Yes"]</option>
 								<option value="False">@SharedLocalizer["No"]</option>
 							</select>
@@ -64,13 +64,13 @@ else
                 <div class="row mb-1 align-items-center">
                     <Label Class="col-sm-3" For="email" HelpText="Your email address where you wish to receive notifications" ResourceKey="Email"></Label>
                     <div class="col-sm-9">
-                        <input id="email" class="form-control" @bind="@email" />
+                        <input id="email" class="form-control" @bind="email" />
                     </div>
                 </div>
                 <div class="row mb-1 align-items-center">
                     <Label Class="col-sm-3" For="displayname" HelpText="Your full name" ResourceKey="DisplayName"></Label>
                     <div class="col-sm-9">
-                        <input id="displayname" class="form-control" @bind="@displayname" />
+                        <input id="displayname" class="form-control" @bind="displayname" />
                     </div>
                 </div>
                 <div class="row mb-1 align-items-center">

--- a/Oqtane.Client/Modules/Admin/UserProfile/View.razor
+++ b/Oqtane.Client/Modules/Admin/UserProfile/View.razor
@@ -14,13 +14,13 @@
             @if (title == "From")
             {
                 <div class="col-sm-3">
-                    <input class="form-control" @bind="@username" readonly />
+                    <input class="form-control" @bind="username" readonly />
                 </div>
             }
             @if (title == "To")
             {
                 <div class="col-sm-3">
-                    <input class="form-control" @bind="@username" />
+                    <input class="form-control" @bind="username" />
                 </div>
             }
         </div>
@@ -29,13 +29,13 @@
             @if (title == "From")
             {
                 <div class="col-sm-3">
-                    <input class="form-control" @bind="@subject" readonly />
+                    <input class="form-control" @bind="subject" readonly />
                 </div>
             }
             @if (title == "To")
             {
                 <div class="col-sm-3">
-                    <input class="form-control" @bind="@subject" />
+                    <input class="form-control" @bind="subject" />
                 </div>
             }
         </div>
@@ -46,7 +46,7 @@
             <div class="row mb-1 align-items-center">
                 <label class="col-sm-3">@Localizer["Date"] </label>
                 <div class="col-sm-9">
-                    <input class="form-control" @bind="@createdon" readonly />
+                    <input class="form-control" @bind="createdon" readonly />
                 </div>
             </div>
         }
@@ -55,7 +55,7 @@
                 <div class="row mb-1 align-items-center">
                     <label class="col-sm-3">@Localizer["Message"] </label>
                     <div class="col-sm-9">
-                        <textarea id="txtFrom" class="form-control" @bind="@body" rows="5" readonly />
+                        <textarea id="txtFrom" class="form-control" @bind="body" rows="5" readonly />
                     </div>
                 </div>
 
@@ -66,7 +66,7 @@
                 <div class="row mb-1 align-items-center">
                     <label class="col-sm-3">@Localizer["Message"] </label>
                     <div class="col-sm-9">
-                    <textarea id="txtTo" class="form-control" @bind="@body" rows="5" />
+                    <textarea id="txtTo" class="form-control" @bind="body" rows="5" />
                     </div>
                 </div>
 
@@ -86,14 +86,14 @@
             <button type="button" class="btn btn-primary" @onclick="Reply">@Localizer["Reply"]</button>
         }
     }
-    <NavLink class="btn btn-secondary" href="@NavigateUrl()">@SharedLocalizer["Cancel"]</NavLink>
+    <NavLink class="btn btn-secondary" href="@(NavigateUrl() + "?tab=Notifications")">@SharedLocalizer["Cancel"]</NavLink>
     <br />
     <br />
     @if (title == "To")
     {
         <div class="control-group">
             <label class="control-label">@Localizer["OriginalMessage"] </label>
-            <textarea id="txtReply" class="form-control" @bind="@reply" rows="5" readonly />
+            <textarea id="txtReply" class="form-control" @bind="reply" rows="5" readonly />
         </div>
     }
 }
@@ -184,7 +184,7 @@
                 var notification = new Notification(PageState.Site.SiteId, PageState.User, user, subject, body, notificationid);
                 notification = await NotificationService.AddNotificationAsync(notification);
                 await logger.LogInformation("Notification Created {NotificationId}", notification.NotificationId);
-                NavigationManager.NavigateTo(NavigateUrl());
+                NavigationManager.NavigateTo(NavigateUrl() + "?tab=Notifications");
             }
             else
             {


### PR DESCRIPTION
Fixes #3417 

- Adds ` + "?tab=Notifications"` to return urls to keep the Notifications tab in focus after sending. canceling and replying to notifications.

(Admin Modal Close Button X is still an issue as it will take a user back to the default tab)

- Simplifies the `@bind` directive in UserPofile components.

Probably not going to like the simplification, I can put these back in the latest PR's.  Since two-way binding only needs the @bind directive I seen no purpose to having these extra @ characters.

Since we are using Blazor and now .NET 8 I just thought it would be good to see the code as it would be expected.  The @variable inside a @bind directive had me a bit confused as to why it was there.  I see no purpose for it so a simplification was made while working on these files.  Since this can be simplified I did include this but I expect it might not allowable and I am ready to change these back if so, no worries.

There maybe a reason for the @ prior to variables when using @binding in forms?  If not I suggest we start removing them for an expected variable without the @.  I did add the Index.razor file to simplify this in the entire UserProfiles components in this PR and the Profile Management so these two admin components will be done in regards to this simplification while I am working on these files.

Also generally most variables used for UI start with `_` and are `_camelCase` and of course this is entirely up to any developer as both ways are acceptable.  Not anytime soon but maybe around .NET 9 preview 1 or Oqtane 5.0.2 we can go through and put files to these naming conventions we may want to adhere to if any to help keep code readability standard throughout the framework.

Not looking to do the entire framework anytime soon, but it would be nice to see more of what is expected today while developing.

This simplification proposed makes no behavior changes as 2-way binding still works in Blazor this way and in no way affect the code-behind logic and introduce no breaking changes.

Again if you like to keep the @bind variables with an @ in front of them in these elements I can put them back.  I will only do this when I am working on a PR with a file that has them for now if it's OK.