### PR TITLE
if site login is disabled redirect Login to external identity provider

### DIFF
--- a/Oqtane.Client/Modules/Admin/Login/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Login/Index.razor
@@ -93,22 +93,15 @@
     {
         try
         {
+            _allowexternallogin = (SettingService.GetSetting(PageState.Site.Settings, "ExternalLogin:ProviderType", "") != "") ? true : false;
+            _allowsitelogin = bool.Parse(SettingService.GetSetting(PageState.Site.Settings, "LoginOptions:AllowSiteLogin", "true"));
+
+            _togglepassword = SharedLocalizer["ShowPassword"];
+
             if (PageState.QueryString.ContainsKey("returnurl"))
             {
                 _returnUrl = PageState.QueryString["returnurl"];
             }
-
-            _allowexternallogin = (SettingService.GetSetting(PageState.Site.Settings, "ExternalLogin:ProviderType", "") != "") ? true : false;
-            _allowsitelogin = bool.Parse(SettingService.GetSetting(PageState.Site.Settings, "LoginOptions:AllowSiteLogin", "true"));
-
-            if (_allowexternallogin && !_allowsitelogin)
-            {
-                // redirect to external login
-                NavigationManager.NavigateTo(Utilities.TenantUrl(PageState.Alias, "/pages/external?returnurl=" + _returnUrl), true);
-                return;
-            }
-
-            _togglepassword = SharedLocalizer["ShowPassword"];
 
             if (PageState.QueryString.ContainsKey("name"))
             {

--- a/Oqtane.Client/Themes/Controls/Theme/LoginBase.cs
+++ b/Oqtane.Client/Themes/Controls/Theme/LoginBase.cs
@@ -23,8 +23,23 @@ namespace Oqtane.Themes.Controls
 
         protected void LoginUser()
         {
+            var allowexternallogin = (SettingService.GetSetting(PageState.Site.Settings, "ExternalLogin:ProviderType", "") != "") ? true : false;
+            var allowsitelogin = bool.Parse(SettingService.GetSetting(PageState.Site.Settings, "LoginOptions:AllowSiteLogin", "true"));
+
             Route route = new Route(PageState.Uri.AbsoluteUri, PageState.Alias.Path);
-            NavigationManager.NavigateTo(NavigateUrl("login", "?returnurl=" + WebUtility.UrlEncode(route.PathAndQuery)));
+            var returnurl = WebUtility.UrlEncode(route.PathAndQuery);
+
+            if (allowexternallogin && !allowsitelogin)
+            {
+                // external login
+                NavigationManager.NavigateTo(Utilities.TenantUrl(PageState.Alias, "/pages/external?returnurl=" + returnurl), true);
+            }
+            else
+            {
+                // local login
+                NavigationManager.NavigateTo(NavigateUrl("login", "?returnurl=" + returnurl));
+            }
+
         }
 
         protected async Task LogoutUser()


### PR DESCRIPTION
this logoic was mistakenly refactored in #3319 which resulted in an infinite loop in the scenario where External Login is enabled, Site Login is disabled, and a user clicks a link from their "External Login Linkage" email