### PR TITLE
Added login cookie expiration time functionality.

### DIFF
--- a/Oqtane.Client/Modules/Admin/Login/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Login/Index.razor
@@ -36,10 +36,13 @@
 						</div>
 					</div>
 					<div class="form-group mt-2">
+						@if (!_alwaysremember)
+						{
 						<div class="form-check">
 							<input id="remember" type="checkbox" class="form-check-input" @bind="@_remember" />
 							<Label Class="control-label" For="remember" HelpText="Specify if you would like to be signed back in automatically the next time you visit this site" ResourceKey="Remember">Remember Me?</Label>
 						</div>
+						}
 					</div>
 					<button type="button" class="btn btn-primary" @onclick="Login">@SharedLocalizer["Login"]</button>
 					<button type="button" class="btn btn-secondary" @onclick="Cancel">@SharedLocalizer["Cancel"]</button>
@@ -78,6 +81,7 @@
     private string _passwordtype = "password";
     private string _togglepassword = string.Empty;
     private bool _remember = false;
+    private bool _alwaysremember = false;
     private string _code = string.Empty;
 
     private string _returnUrl = string.Empty;
@@ -151,6 +155,10 @@
                     AddModuleMessage(Localizer["ExternalLoginStatus." + PageState.QueryString["status"]], MessageType.Info);
                 }
             }
+            if (PageState.Site.Settings.TryGetValue("LoginOptions:AlwaysRemember", out string alwaysRememberStr))
+            {
+                _alwaysremember = Convert.ToBoolean(alwaysRememberStr);
+            }
         }
         catch (Exception ex)
         {
@@ -185,7 +193,14 @@
                 var user = new User { SiteId = PageState.Site.SiteId, Username = _username, Password = _password, LastIPAddress = SiteState.RemoteIPAddress};
 
                 if (!twofactor)
-                {
+                { 
+                    bool alwaysRemember = false;
+                    if (PageState.Site.Settings.TryGetValue("LoginOptions:AlwaysRemember", out string alwaysRememberStr))
+                    {
+                        alwaysRemember = Convert.ToBoolean(alwaysRememberStr);
+                    }
+                    bool remember = alwaysRemember || _remember;
+                    _remember = remember;
                     user = await UserService.LoginUserAsync(user, hybrid, _remember);
                 }
                 else

--- a/Oqtane.Client/Modules/Admin/Users/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Users/Index.razor
@@ -104,6 +104,15 @@ else
 								<input id="cookieexpiration" class="form-control" @bind="@_cookieexpiration" />
 							</div>
 						</div>
+						<div class="row mb-1 align-items-center">
+							<Label Class="col-sm-3" For="alwaysremember" HelpText="Automatically sign in users the next time they visit the site (Remebered for the timespan defined in setting 'Cookie Expiration Timespan' or 14 days if not defined). Forces cookie expiration instead of session timespan." ResourceKey="AlwaysRemember">Always Remember User:</Label>
+							<div class="col-sm-9">
+								<select id="allowsitelogin" class="form-select" @bind="@_alwaysremember">
+									<option value="true">@SharedLocalizer["Yes"]</option>
+									<option value="false">@SharedLocalizer["No"]</option>
+								</select>
+							</div>
+						</div>
 					}
 				</Section>
 				@if (UserSecurity.IsAuthorized(PageState.User, RoleNames.Host))
@@ -394,6 +403,7 @@ else
     private string _twofactor;
     private string _cookiename;
     private string _cookieexpiration;
+    private string _alwaysremember;
 
     private string _minimumlength;
     private string _uniquecharacters;
@@ -454,6 +464,7 @@ else
             _twofactor = SettingService.GetSetting(settings, "LoginOptions:TwoFactor", "false");
             _cookiename = SettingService.GetSetting(settings, "LoginOptions:CookieName", ".AspNetCore.Identity.Application");
             _cookieexpiration = SettingService.GetSetting(settings, "LoginOptions:CookieExpiration", "");
+            _alwaysremember = SettingService.GetSetting(settings, "LoginOptions:AlwaysRemember", "false");
 
             _minimumlength = SettingService.GetSetting(settings, "IdentityOptions:Password:RequiredLength", "6");
             _uniquecharacters = SettingService.GetSetting(settings, "IdentityOptions:Password:RequiredUniqueChars", "1");
@@ -546,6 +557,7 @@ else
 				settings = SettingService.SetSetting(settings, "LoginOptions:TwoFactor", _twofactor, false);
 				settings = SettingService.SetSetting(settings, "LoginOptions:CookieName", _cookiename, true);
 				settings = SettingService.SetSetting(settings, "LoginOptions:CookieExpiration", _cookieexpiration, true);
+				settings = SettingService.SetSetting(settings, "LoginOptions:AlwaysRemember", _alwaysremember, false);
 
 				settings = SettingService.SetSetting(settings, "IdentityOptions:Password:RequiredLength", _minimumlength, true);
 				settings = SettingService.SetSetting(settings, "IdentityOptions:Password:RequiredUniqueChars", _uniquecharacters, true);

--- a/Oqtane.Client/Modules/Admin/Users/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Users/Index.razor
@@ -98,6 +98,12 @@ else
 								<input id="cookiename" class="form-control" @bind="@_cookiename" />
 							</div>
 						</div>
+						<div class="row mb-1 align-items-center">
+							<Label Class="col-sm-3" For="cookieexpiration" HelpText="You can choose to use a custom authentication cookie expiration timespan for each site (e.g. '08:00:00' for 8 hours). Default is 14 days if not declared." ResourceKey="CookieExpiration">Cookie Expiration Timespan:</Label>
+							<div class="col-sm-9">
+								<input id="cookieexpiration" class="form-control" @bind="@_cookieexpiration" />
+							</div>
+						</div>
 					}
 				</Section>
 				@if (UserSecurity.IsAuthorized(PageState.User, RoleNames.Host))
@@ -387,6 +393,7 @@ else
     private string _allowsitelogin;
     private string _twofactor;
     private string _cookiename;
+    private string _cookieexpiration;
 
     private string _minimumlength;
     private string _uniquecharacters;
@@ -446,6 +453,7 @@ else
         {
             _twofactor = SettingService.GetSetting(settings, "LoginOptions:TwoFactor", "false");
             _cookiename = SettingService.GetSetting(settings, "LoginOptions:CookieName", ".AspNetCore.Identity.Application");
+            _cookieexpiration = SettingService.GetSetting(settings, "LoginOptions:CookieExpiration", "");
 
             _minimumlength = SettingService.GetSetting(settings, "IdentityOptions:Password:RequiredLength", "6");
             _uniquecharacters = SettingService.GetSetting(settings, "IdentityOptions:Password:RequiredUniqueChars", "1");
@@ -537,6 +545,7 @@ else
 			{
 				settings = SettingService.SetSetting(settings, "LoginOptions:TwoFactor", _twofactor, false);
 				settings = SettingService.SetSetting(settings, "LoginOptions:CookieName", _cookiename, true);
+				settings = SettingService.SetSetting(settings, "LoginOptions:CookieExpiration", _cookieexpiration, true);
 
 				settings = SettingService.SetSetting(settings, "IdentityOptions:Password:RequiredLength", _minimumlength, true);
 				settings = SettingService.SetSetting(settings, "IdentityOptions:Password:RequiredUniqueChars", _uniquecharacters, true);

--- a/Oqtane.Server/Extensions/OqtaneSiteAuthenticationBuilderExtensions.cs
+++ b/Oqtane.Server/Extensions/OqtaneSiteAuthenticationBuilderExtensions.cs
@@ -31,6 +31,12 @@ namespace Oqtane.Extensions
             builder.AddSiteNamedOptions<CookieAuthenticationOptions>(Constants.AuthenticationScheme, (options, alias, sitesettings) =>
             {
                 options.Cookie.Name = sitesettings.GetValue("LoginOptions:CookieName", ".AspNetCore.Identity.Application");
+                string cookieExpStr = sitesettings.GetValue("LoginOptions:CookieExpiration", "");
+                if (!string.IsNullOrEmpty(cookieExpStr) && TimeSpan.TryParse(cookieExpStr, out TimeSpan cookieExpTS))
+                {
+                    options.Cookie.Expiration = cookieExpTS;
+                    options.ExpireTimeSpan = cookieExpTS;
+                }
             });
 
             // site OpenId Connect options


### PR DESCRIPTION
Added functinality to always remember user login. Provides the option to force login cookie expiration and dont fallback on the session timespan that is used as default when users dont choose the option 'Remember me'.
Added login cookie expiration time. Added setting in user settings to declare custom cookie expiration time. Cookie expiration time overwrites default expiration time of 14 days (if not session timespan is used).
These settings are optional.

Background info: We use oqtane as a framework that hosts our angular applications. The angular applications use a login system with login cookie expiration of 8 hours. Oqtane uses cookie session timespan. So when the login cookies in our application run out oqtane might still be logged in, which causes incompatibility between our applications and oqtane. We need the opportunity to declare the cookie expiration in oqtane and also tell it to force use this expiration time (the 'alwaysremember' functionality should ensure this, even for an oauth login).