### PR TITLE
Fix for  #3497 Module Settings Container setting not saving.

### DIFF
--- a/Oqtane.Client/Modules/Admin/Pages/Add.razor
+++ b/Oqtane.Client/Modules/Admin/Pages/Add.razor
@@ -306,11 +306,11 @@
     private void ThemeChanged(ChangeEventArgs e)
     {
         _themetype = (string)e.Value;
+        _containers = ThemeService.GetContainerControls(PageState.Site.Themes, _themetype);
+        _containertype = _containers.First().TypeName;
         if (ThemeService.GetTheme(PageState.Site.Themes, _themetype)?.ThemeName != ThemeService.GetTheme(PageState.Site.Themes, PageState.Site.DefaultThemeType)?.ThemeName)
         {
             AddModuleMessage(Localizer["ThemeChanged.Message"], MessageType.Warning);
-            _containers = ThemeService.GetContainerControls(PageState.Site.Themes, _themetype);
-            _containertype = _containers.First().TypeName;
             ThemeSettings();
             StateHasChanged();
         }

--- a/Oqtane.Client/Modules/Admin/Pages/Edit.razor
+++ b/Oqtane.Client/Modules/Admin/Pages/Edit.razor
@@ -447,11 +447,11 @@
     private void ThemeChanged(ChangeEventArgs e)
     {
         _themetype = (string)e.Value;
+        _containers = ThemeService.GetContainerControls(PageState.Site.Themes, _themetype);
+        _containertype = _containers.First().TypeName;
         if (ThemeService.GetTheme(PageState.Site.Themes, _themetype)?.ThemeName != ThemeService.GetTheme(PageState.Site.Themes, PageState.Site.DefaultThemeType)?.ThemeName)
         {
             AddModuleMessage(Localizer["ThemeChanged.Message"], MessageType.Warning);
-            _containers = ThemeService.GetContainerControls(PageState.Site.Themes, _themetype);
-            _containertype = _containers.First().TypeName;
             ThemeSettings();
             StateHasChanged();
         }


### PR DESCRIPTION
In the Add and Edit of Pages the Container was not being set, but only set if the Theme wasn't equal the default but not if the Theme was set back to the Default.