### PR TITLE
Update _Host.cshtml.cs to account for fully qualified type names in theme resources 

### DIFF
--- a/Oqtane.Server/Pages/_Host.cshtml.cs
+++ b/Oqtane.Server/Pages/_Host.cshtml.cs
@@ -505,7 +505,7 @@ namespace Oqtane.Pages
                 {
                     if (resource.Url.StartsWith("~"))
                     {
-                        resource.Url = resource.Url.Replace("~", "/Themes/" + name + "/").Replace("//", "/");
+                        resource.Url = resource.Url.Replace("~", "/Themes/" + Utilities.GetTypeName(name) + "/").Replace("//", "/");
                     }
                     if (!resource.Url.Contains("://") && alias.BaseUrl != "" && !resource.Url.StartsWith(alias.BaseUrl))
                     {


### PR DESCRIPTION
Noticed some spaces showing up in theme resources and tracked it down to this line.  Wrapping the name in a call to Utilities.GetTypeName cleared things up.