### PR TITLE
remove Blazor Hybrid from Hosting Models selection as it is not actually a hosting model

### DIFF
--- a/Oqtane.Client/Modules/Admin/Site/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Site/Index.razor
@@ -300,7 +300,6 @@
                             <select id="runtime" class="form-select" @bind="@_runtime" required>
                                 <option value="Server">@SharedLocalizer["BlazorServer"]</option>
                                 <option value="WebAssembly">@SharedLocalizer["BlazorWebAssembly"]</option>
-                                <option value="Hybrid">@SharedLocalizer["BlazorHybrid"]</option>
                             </select>
                         </div>
                     </div>

--- a/Oqtane.Client/Modules/Admin/Sites/Add.razor
+++ b/Oqtane.Client/Modules/Admin/Sites/Add.razor
@@ -76,7 +76,6 @@ else
                     <select id="runtime" class="form-select" @bind="@_runtime" required>
                         <option value="Server">@SharedLocalizer["BlazorServer"]</option>
                         <option value="WebAssembly">@SharedLocalizer["BlazorWebAssembly"]</option>
-						<option value="Hybrid">@SharedLocalizer["BlazorHybrid"]</option>
 					</select>
                 </div>
             </div>


### PR DESCRIPTION
a dedicated option should be added  to enable Blazor Hybrid