### PR TITLE
Retention controls and data should be number / int not string

### DIFF
--- a/Oqtane.Client/Modules/Admin/Jobs/Edit.razor
+++ b/Oqtane.Client/Modules/Admin/Jobs/Edit.razor
@@ -45,7 +45,7 @@
         <div class="row mb-1 align-items-center">
             <Label Class="col-sm-3" For="retention" HelpText="Number of log entries to retain for this job" ResourceKey="RetentionLog">Retention Log (Items): </Label>
             <div class="col-sm-9">
-                <input id="retention" class="form-control" @bind="@_retentionHistory" maxlength="4" required />
+                <input id="retention" type="number" min="0" step ="1" class="form-control" @bind="@_retentionHistory" maxlength="4" required />
             </div>
         </div>
         <div class="row mb-1 align-items-center">

--- a/Oqtane.Client/Modules/Admin/Logs/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Logs/Index.razor
@@ -81,7 +81,7 @@ else
 				<div class="row mb-1 align-items-center">
 					<Label Class="col-sm-3" For="retention" HelpText="Number of days of events to retain" ResourceKey="Retention">Retention (Days): </Label>
 					<div class="col-sm-9">
-						<input id="retention" class="form-control" @bind="@_retention" />
+                        <input id="retention" type="number" min="0" step="1" class="form-control" @bind="@_retention" />
 					</div>
 				</div>
 			</div>
@@ -97,7 +97,7 @@ else
 	private string _rows = "10";
 	private int _page = 1;
 	private List<Log> _logs;
-	private string _retention = "";
+	private int _retention = 30;
 
 	public override string UrlParametersTemplate => "/{level}/{function}/{rows}/{page}";
 	public override SecurityAccessLevel SecurityAccessLevel => SecurityAccessLevel.Host;
@@ -126,7 +126,7 @@ else
             await GetLogs();
 
 			var settings = await SettingService.GetSiteSettingsAsync(PageState.Site.SiteId);
-			_retention = SettingService.GetSetting(settings, "LogRetention", "30");
+			_retention = int.Parse( SettingService.GetSetting(settings, "LogRetention", "30"));
         }
         catch (Exception ex)
         {
@@ -218,7 +218,7 @@ else
 		try
 		{
 			var settings = await SettingService.GetSiteSettingsAsync(PageState.Site.SiteId);
-			settings = SettingService.SetSetting(settings, "LogRetention", _retention, true);
+			settings = SettingService.SetSetting(settings, "LogRetention", _retention.ToString(), true);
             await SettingService.UpdateSiteSettingsAsync(settings, PageState.Site.SiteId);
 
 			AddModuleMessage(Localizer["Success.SaveSiteSettings"], MessageType.Success);

--- a/Oqtane.Client/Modules/Admin/Site/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Site/Index.razor
@@ -207,7 +207,7 @@
                 <div class="row mb-1 align-items-center">
 					<Label Class="col-sm-3" For="retention" HelpText="Number of days of notifications to retain" ResourceKey="Retention">Retention (Days): </Label>
 					<div class="col-sm-9">
-						<input id="retention" class="form-control" @bind="@_retention" />
+                        <input id="retention" class="form-control" type="number" min="0" step="1" @bind="@_retention" />
 					</div>
                 </div>
                 <button type="button" class="btn btn-secondary" @onclick="SendEmail">@Localizer["Smtp.TestConfig"]</button>
@@ -378,7 +378,7 @@
     private string _smtpsender = string.Empty;
     private string _smtprelay = "False";
     private string _smtpenabled = "True";
-    private string _retention = string.Empty;
+    private int _retention = 30;
     private string _pwaisenabled;
     private int _pwaappiconfileid = -1;
     private FileManager _pwaappiconfilemanager;
@@ -461,7 +461,7 @@
                 _smtpsender = SettingService.GetSetting(settings, "SMTPSender", string.Empty);
                 _smtprelay = SettingService.GetSetting(settings, "SMTPRelay", "False");
                 _smtpenabled = SettingService.GetSetting(settings, "SMTPEnabled", "True");
-                _retention = SettingService.GetSetting(settings, "NotificationRetention", "30");
+                _retention = int.Parse(SettingService.GetSetting(settings, "NotificationRetention", "30"));
 
                 // aliases
                 await GetAliases();
@@ -622,7 +622,7 @@
 						settings = SettingService.SetSetting(settings, "SMTPRelay", _smtprelay, true);
                         settings = SettingService.SetSetting(settings, "SMTPEnabled", _smtpenabled, true);
                         settings = SettingService.SetSetting(settings, "SiteGuid", _siteguid, true);
-                        settings = SettingService.SetSetting(settings, "NotificationRetention", _retention, true);
+                        settings = SettingService.SetSetting(settings, "NotificationRetention", _retention.ToString(), true);
 						await SettingService.UpdateSiteSettingsAsync(settings, site.SiteId);
 
 						await logger.LogInformation("Site Settings Saved {Site}", site);

--- a/Oqtane.Client/Modules/Admin/Visitors/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Visitors/Index.razor
@@ -78,7 +78,7 @@ else
 				<div class="row mb-1 align-items-center">
 					<Label Class="col-sm-3" For="retention" HelpText="Number of days of visitor activity to retain" ResourceKey="Retention">Retention (Days): </Label>
 					<div class="col-sm-9">
-						<input id="retention" class="form-control" @bind="@_retention" />
+                        <input id="retention" class="form-control" type="number" min="0" step="1" @bind="@_retention" />
 					</div>
 				</div>
 				<div class="row mb-1 align-items-center">
@@ -104,7 +104,7 @@ else
 	private List<Visitor> _visitors;
 	private string _tracking;
 	private string _filter = "";
-	private string _retention = "";
+	private int _retention = 30;
 	private string _correlation = "true";
 
 	public override SecurityAccessLevel SecurityAccessLevel => SecurityAccessLevel.Admin;
@@ -129,7 +129,7 @@ else
 		_tracking = PageState.Site.VisitorTracking.ToString();
 		var settings = await SettingService.GetSiteSettingsAsync(PageState.Site.SiteId);
 		_filter = SettingService.GetSetting(settings, "VisitorFilter", Constants.DefaultVisitorFilter);
-		_retention = SettingService.GetSetting(settings, "VisitorRetention", "30");
+		_retention = int.Parse(SettingService.GetSetting(settings, "VisitorRetention", "30"));
 		_correlation = SettingService.GetSetting(settings, "VisitorCorrelation", "true");
 	}
 
@@ -180,7 +180,7 @@ else
 
 			var settings = await SettingService.GetSiteSettingsAsync(PageState.Site.SiteId);
 			settings = SettingService.SetSetting(settings, "VisitorFilter", _filter, true);
-			settings = SettingService.SetSetting(settings, "VisitorRetention", _retention, true);
+			settings = SettingService.SetSetting(settings, "VisitorRetention", _retention.ToString(), true);
 			settings = SettingService.SetSetting(settings, "VisitorCorrelation", _correlation, true);
             await SettingService.UpdateSiteSettingsAsync(settings, PageState.Site.SiteId);
 


### PR DESCRIPTION
The Retention input controls in Log, Visitors and Notifications allowed text to be saved.  Modified all controls to accept only number.