### PR TITLE
Edit languages to set default.

### DIFF
--- a/Oqtane.Client/Modules/Admin/Languages/Add.razor
+++ b/Oqtane.Client/Modules/Admin/Languages/Add.razor
@@ -131,8 +131,6 @@ else
             var interop = new Interop(JSRuntime);
             var localizationCookieValue = CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture));
             await interop.SetCookie(CookieRequestCultureProvider.DefaultCookieName, localizationCookieValue, 360);
-
-            NavigationManager.NavigateTo(NavigationManager.Uri, true);
         }
     }
 

--- a/Oqtane.Client/Modules/Admin/Languages/Edit.razor
+++ b/Oqtane.Client/Modules/Admin/Languages/Edit.razor
@@ -1,0 +1,110 @@
+@namespace Oqtane.Modules.Admin.Languages
+@inherits ModuleBase
+@using System.Globalization
+@using Microsoft.AspNetCore.Localization
+@inject NavigationManager NavigationManager
+@inject ILocalizationService LocalizationService
+@inject ILanguageService LanguageService
+@inject IPackageService PackageService
+@inject IStringLocalizer<Edit> Localizer
+@inject IStringLocalizer<SharedResources> SharedLocalizer
+
+@if (_code == null)
+{
+    <p><em>@SharedLocalizer["Loading"]</em></p>
+}
+else
+{
+    <TabStrip>
+        <TabPanel Name="Manage" ResourceKey="Manage" Heading="Manage">
+            <form @ref="form" class="@(validated ? "was-validated" : "needs-validation")" novalidate>
+                <div class="container">
+				    <div class="row mb-1 align-items-center">
+                        <Label Class="col-sm-3" For="name" HelpText="Name Of The Language" ResourceKey="Name">Name:</Label>
+                        <div class="col-sm-9">
+                            <input id="code" class="form-control" @bind="@_code" readonly/>
+                        </div>
+                    </div>
+                    <div class="row mb-1 align-items-center">
+                        <Label Class="col-sm-3" For="default" HelpText="Indicates Whether Or Not This Language Is The Default For The Site" ResourceKey="IsDefault">Default?</Label>
+                        <div class="col-sm-9">
+                            <select id="default" class="form-select" @bind="@_default" required>
+                                <option value="True">@SharedLocalizer["Yes"]</option>
+                                <option value="False">@SharedLocalizer["No"]</option>
+                            </select>
+                        </div>
+                    </div>
+                </div>
+                <button type="button" class="btn btn-success" @onclick="SaveLanguage">@SharedLocalizer["Save"]</button>
+			    <NavLink class="btn btn-secondary" href="@NavigateUrl()">@SharedLocalizer["Cancel"]</NavLink>
+            </form>
+        </TabPanel>
+    </TabStrip>
+}
+
+@code {
+    private ElementReference form;
+    private bool validated = false;
+    private int _languageId = -1;
+    private string _code = string.Empty;
+    private string _cultureName = string.Empty;
+    private string _default = "False";
+    private List<Language> _languages;
+
+    public override SecurityAccessLevel SecurityAccessLevel => SecurityAccessLevel.Admin;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _languageId = Int32.Parse(PageState.QueryString["id"]);
+        _languages = await LanguageService.GetLanguagesAsync(PageState.Site.SiteId, Constants.ClientId);
+        Language language = _languages.Where(x => x.LanguageId == _languageId).FirstOrDefault();
+        if (language != null)
+        {
+            _code = language.Code;
+            _cultureName = language.Name;
+            _default = language.IsDefault.ToString();
+            if (language.SiteId == null) 
+            {
+                language.SiteId = PageState.Site.SiteId;
+            }
+        };
+    }
+
+	private async Task SaveLanguage()
+	{
+        Language language = _languages.Where(x => x.LanguageId == _languageId).FirstOrDefault();
+        if (language != null)
+        {
+            language.IsDefault = Boolean.Parse(_default);
+			try
+			{
+				await LanguageService.EditLanguageAsync(language);
+
+				if (language.IsDefault)
+				{
+					await SetCultureAsync(language.Code);
+				}
+
+				await logger.LogInformation("Language Edited {Language}", language);
+
+				NavigationManager.NavigateTo(NavigateUrl());
+			}
+			catch (Exception ex)
+			{
+				await logger.LogError(ex, "Error Editing Language {Language} {Error}", language, ex.Message);
+				AddModuleMessage(Localizer["Error.Language.Edit"], MessageType.Error);
+			}
+        };
+	}
+
+    private async Task SetCultureAsync(string culture)
+    {
+        if (culture != CultureInfo.CurrentUICulture.Name)
+        {
+            var interop = new Interop(JSRuntime);
+            var localizationCookieValue = CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture));
+            await interop.SetCookie(CookieRequestCultureProvider.DefaultCookieName, localizationCookieValue, 360);
+        }
+    }
+
+}

--- a/Oqtane.Client/Modules/Admin/Languages/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Languages/Index.razor
@@ -17,6 +17,7 @@ else
     <Pager Items="@_languages" SearchProperties="Name,Code">
         <Header>
             <th style="width: 1px;">&nbsp;</th>
+            <th style="width: 1px;">&nbsp;</th>
             <th>@SharedLocalizer["Name"]</th>
             <th>@Localizer["Code"]</th>
             <th>@Localizer["Default"]</th>
@@ -27,6 +28,12 @@ else
 			}
         </Header>
         <Row>
+            <td>
+            @if (!context.IsDefault)
+            {
+                <ActionLink Action="Edit" Text="Edit" Parameters="@($"id=" + context.LanguageId.ToString())" ResourceKey="EditLanguage" />                    
+            }
+            </td>
             <td><ActionDialog Header="Delete Language" Message="@string.Format(Localizer["Confirm.Language.Delete"], context.Name)" Action="Delete" Security="SecurityAccessLevel.Admin" Class="btn btn-danger" OnClick="@(async () => await DeleteLanguage(context))" Disabled="@((context.IsDefault && _languages.Count > 2) || context.Code == Constants.DefaultCulture)" ResourceKey="DeleteLanguage" /></td>
             <td>@context.Name</td>
             <td>@context.Code</td>

--- a/Oqtane.Client/Resources/Modules/Admin/Languages/Edit.resx
+++ b/Oqtane.Client/Resources/Modules/Admin/Languages/Edit.resx
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Error.Language.Edit" xml:space="preserve">
+    <value>Error Updating Language</value>
+  </data>
+  <data name="Name.HelpText" xml:space="preserve">
+    <value>Name Of The Langauage</value>
+  </data>
+  <data name="IsDefault.HelpText" xml:space="preserve">
+    <value>Indicates Whether Or Not This Language Is The Default For The Site</value>
+  </data>
+  <data name="Name.Text" xml:space="preserve">
+    <value>Name:</value>
+  </data>
+  <data name="IsDefault.Text" xml:space="preserve">
+    <value>Default?</value>
+  </data>
+  <data name="Success.Language.Download" xml:space="preserve">
+    <value>Translation Package Saved Successfully. You Must &lt;a href={0}&gt;Restart&lt;/a&gt; To Complete The Installation.</value>
+  </data>
+  <data name="LanguageUpload.HelpText" xml:space="preserve">
+    <value>Upload one or more translation packages.</value>
+  </data>
+  <data name="LanguageUpload.Text" xml:space="preserve">
+    <value>Translation</value>
+  </data>
+  <data name="Manage.Heading" xml:space="preserve">
+    <value>Manage</value>
+  </data>
+  <data name="Upload.Heading" xml:space="preserve">
+    <value>Upload</value>
+  </data>
+  <data name="Error.Language.Load" xml:space="preserve">
+    <value>Error Loading Language</value>
+  </data>
+</root>

--- a/Oqtane.Client/Services/Interfaces/ILanguageService.cs
+++ b/Oqtane.Client/Services/Interfaces/ILanguageService.cs
@@ -1,6 +1,6 @@
-using Oqtane.Models;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Oqtane.Models;
 
 namespace Oqtane.Services
 {
@@ -38,6 +38,13 @@ namespace Oqtane.Services
         /// <param name="language"></param>
         /// <returns></returns>
         Task<Language> AddLanguageAsync(Language language);
+
+        /// <summary>
+        /// Edits the given language
+        /// </summary>
+        /// <param name="language"></param>
+        /// <returns></returns>
+        Task EditLanguageAsync(Language language);
 
         /// <summary>
         /// Deletes the given language

--- a/Oqtane.Client/Services/LanguageService.cs
+++ b/Oqtane.Client/Services/LanguageService.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Oqtane.Documentation;
@@ -10,7 +9,7 @@ namespace Oqtane.Services
 {
     [PrivateApi("Don't show in the documentation, as everything should use the Interface")]
     public class LanguageService : ServiceBase, ILanguageService
-    {        
+    {
         public LanguageService(HttpClient http, SiteState siteState) : base(http, siteState) { }
 
         private string Apiurl => CreateApiUrl("Language");
@@ -33,6 +32,11 @@ namespace Oqtane.Services
         public async Task<Language> AddLanguageAsync(Language language)
         {
             return await PostJsonAsync<Language>(Apiurl, language);
+        }
+
+        public async Task EditLanguageAsync(Language language)
+        {
+            await PutJsonAsync<Language>(Apiurl, language);
         }
 
         public async Task DeleteLanguageAsync(int languageId)

--- a/Oqtane.Server/Repository/Interfaces/ILanguageRepository.cs
+++ b/Oqtane.Server/Repository/Interfaces/ILanguageRepository.cs
@@ -9,6 +9,8 @@ namespace Oqtane.Repository
 
         Language AddLanguage(Language language);
 
+        void UpdateLanguage(Language language);
+
         Language GetLanguage(int languageId);
 
         void DeleteLanguage(int languageId);

--- a/Oqtane.Server/Repository/LanguageRepository.cs
+++ b/Oqtane.Server/Repository/LanguageRepository.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.EntityFrameworkCore;
 using Oqtane.Models;
 
 namespace Oqtane.Repository
@@ -12,7 +13,7 @@ namespace Oqtane.Repository
         {
             _db = context;
         }
-            
+
         public IEnumerable<Language> GetLanguages(int siteId)
         {
             return _db.Language.Where(l => l.SiteId == siteId);
@@ -33,6 +34,25 @@ namespace Oqtane.Repository
             _db.SaveChanges();
 
             return language;
+        }
+
+        public void UpdateLanguage(Language language)
+        {
+            if (language.LanguageId != 0)
+            {
+                _db.Entry(language).State = EntityState.Modified;
+            }
+            if (language.IsDefault)
+            {
+                // Ensure all other languages are not set to default
+                _db.Language
+                    .Where(l => l.SiteId == language.SiteId &&
+                                l.LanguageId != language.LanguageId)
+                    .ToList()
+                    .ForEach(l => l.IsDefault = false);
+            }
+
+            _db.SaveChanges();
         }
 
         public Language GetLanguage(int languageId)


### PR DESCRIPTION
Currently the Languages module allows to set the default language only when Adding a new Language. This pull request adds and additional edit button if the language is not the default one. On click, the edit button presents an edit windows, similar to the Add Language but without download capabilities. It allows to change only the default checkbox. 