### PR TITLE
Resolve Profile Photo Url Issue Fixes #3569

### DIFF
--- a/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
+++ b/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
@@ -16,7 +16,7 @@
 {
     @if (PageState.User != null && photo != null)
     {
-        <img src="@ImageUrl(photofileid, 400, 400)" alt="@displayname" style="max-width: 400px" class="rounded-circle mx-auto d-block">
+        <img src="@photo.Url" alt="@displayname" style="max-width: 400px" class="rounded-circle mx-auto d-block">
     }
     else
     {


### PR DESCRIPTION
Fixes #3569

This pull request changes the source attribute of the image element to use `@photo.Url` to set the correct path for the profile photo property to be viewed at the top of the user profile page.

Unless there is some caching or resizing large images going on with the other method of `ImageUrl` that needs to be worked out this maybe acceptable solution.