### PR TITLE
Sets Logo max height to 90px plus padding 5px right and left.

### DIFF
--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
@@ -4,6 +4,12 @@ body {
     padding-top: 7rem;
 }
 
+/* App Logo */
+.app-logo .img-fluid {
+    max-height: 90px;
+    padding: 0 5px 0 5px;
+}
+
 .table > :not(caption) > * > * {
     box-shadow: none;
 }

--- a/Oqtane.Server/wwwroot/Themes/Templates/External/Client/wwwroot/Themes/[Owner].Theme.[Theme]/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Templates/External/Client/wwwroot/Themes/[Owner].Theme.[Theme]/Theme.css
@@ -4,6 +4,12 @@ body {
     padding-top: 7rem;
 }
 
+/* App Logo */
+.app-logo .img-fluid {
+    max-height: 90px;
+    padding: 0 5px 0 5px;
+}
+
 .table > :not(caption) > * > * {
     box-shadow: none;
 }

--- a/Oqtane.Server/wwwroot/css/app.css
+++ b/Oqtane.Server/wwwroot/css/app.css
@@ -10,12 +10,6 @@ app {
     flex-direction: column;
 }
 
-/* App Logo */
-.app-logo .img-fluid {
-    max-height: 90px;
-    padding: 0 5px 0 5px;
-}
-
 /* Admin Modal */
 .app-admin-modal .modal {
     position: fixed; /* Stay in place */

--- a/Oqtane.Server/wwwroot/css/app.css
+++ b/Oqtane.Server/wwwroot/css/app.css
@@ -10,6 +10,12 @@ app {
     flex-direction: column;
 }
 
+/* App Logo */
+.app-logo .img-fluid {
+    max-height: 90px;
+    padding: 0 5px 0 5px;
+}
+
 /* Admin Modal */
 .app-admin-modal .modal {
     position: fixed; /* Stay in place */


### PR DESCRIPTION
Fixes #3571 

Sets Logo max height to 90px plus padding 5px right and left.

If even 150px it will cover up content in the admin pages and other places.

It would be worth considering creating variables that adjust logo and content margins.  I set this in the app.css at the top since it is the logo image first thing you see when loading app.  I had also thought this could go in the Oqtane Theme.css however .app-logo is part of the app.  I can produce another PR if this should be in the Oqtane theme.css instead.

I can also explore creating variables that can adjust according to the image height uploaded which was another idea I had but would take more investigating that possibility.