### PR TITLE
Refreshes Admin Settings Page When User Updates Logo.  Fixes #3582

### DIFF
--- a/Oqtane.Client/Modules/Admin/Site/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Site/Index.razor
@@ -581,7 +581,8 @@
                             site.LogoFileId = logofileid;
                             if (logofileid != _logofileid)
                             {
-                                reload = true;
+                                _logofileid = logofileid;
+                                refresh = true;
                             }
                         }
                         int? faviconFieldId = _faviconfilemanager.GetFileId();

--- a/Oqtane.Client/Modules/Admin/Site/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Site/Index.razor
@@ -582,7 +582,7 @@
                             if (logofileid != _logofileid)
                             {
                                 _logofileid = logofileid;
-                                refresh = true;
+                                refresh = true; // needs to be refreshed on client
                             }
                         }
                         int? faviconFieldId = _faviconfilemanager.GetFileId();

--- a/Oqtane.Client/Modules/Admin/Site/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Site/Index.razor
@@ -673,6 +673,10 @@
 						}
 						else
 						{
+                            if (logofileid != -1 && logofileid != _logofileid)
+                            {
+                                NavigationManager.Refresh();
+                            }
 							AddModuleMessage(Localizer["Success.Settings.SaveSite"], MessageType.Success);
                             await ScrollToPageTop();
                         }

--- a/Oqtane.Client/Modules/Admin/Site/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Site/Index.razor
@@ -677,10 +677,6 @@
 						}
 						else
 						{
-                            if (logofileid != -1 && logofileid != _logofileid)
-                            {
-                                NavigationManager.Refresh();
-                            }
 							AddModuleMessage(Localizer["Success.Settings.SaveSite"], MessageType.Success);
                             await ScrollToPageTop();
                         }

--- a/Oqtane.Client/Modules/Admin/Site/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Site/Index.razor
@@ -581,7 +581,7 @@
                             site.LogoFileId = logofileid;
                             if (logofileid != _logofileid)
                             {
-                                 refresh = true;
+                                reload = true;
                             }
                         }
                         int? faviconFieldId = _faviconfilemanager.GetFileId();

--- a/Oqtane.Client/Modules/Admin/Site/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Site/Index.razor
@@ -579,6 +579,10 @@
                         if (logofileid != -1)
                         {
                             site.LogoFileId = logofileid;
+                            if (logofileid != _logofileid)
+                            {
+                                 refresh = true;
+                            }
                         }
                         int? faviconFieldId = _faviconfilemanager.GetFileId();
                         if (faviconFieldId == -1) faviconFieldId = null;


### PR DESCRIPTION
Fixes: #3582

This PR will simply refreshes the current page in order to view the change of the updated logo.

This is only performed when a logo file id has changed from original loaded on the page it gets on initialization from `logofileid `and compares it with` _logofileid` which is are used for different areas of code logic.  I originally had a new variable set to know it was the original but found one that would serve the same purpose not being used or reset to compare with the one that was updated from the file manager component. 

This all relates to the site settings component during Oqtane administration when a user changes the logo and performs the save button action.

I had a few other "NavigationManager" version to refresh, this one used in commit seemed so simple I used it.

After a few ideas this one is the best I have had so far as I tried `StateHasChanged()` and such but no luck.   Maybe when Oqtane 5.1 rolls out some of this can be handled differently.
