### PR TITLE
Maui app connectivity error message enhancement.  Fixes #3583

### DIFF
--- a/Oqtane.Maui/wwwroot/css/app.css
+++ b/Oqtane.Maui/wwwroot/css/app.css
@@ -196,20 +196,113 @@ app {
 }
 
 #blazor-error-ui {
-    background: lightyellow;
-    bottom: 0;
-    box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
-    display: none;
-    left: 0;
-    padding: 0.6rem 1.25rem 0.7rem 1.25rem;
     position: fixed;
-    width: 100%;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    max-width: 90%;
+    width:100%;
+    height: 90%;
+    padding: 10px;
+    background-color: #f8d7da;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+    border-radius: 10px;
+    display: none;
     z-index: 1000;
 }
 
-#blazor-error-ui .dismiss {
-    cursor: pointer;
-    position: absolute;
-    right: 0.75rem;
-    top: 0.5rem;
+    #blazor-error-ui .logo {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+        #blazor-error-ui .logo img {
+            max-width: 300px;
+            max-height: 150px;
+            height: auto;
+            display: block;
+            margin: 0 auto;
+            padding: 10px;
+        }
+
+    #blazor-error-ui .image {
+        text-align: center;
+        margin-top: 20px;
+    }
+
+        #blazor-error-ui .image img {
+            width: 90px;
+            height: auto;
+        }
+
+    #blazor-error-ui .heading {
+        color: #f44336;
+        margin-top: 10px;
+        font-size: 1.5em;
+    }
+
+    #blazor-error-ui .message {
+        font-size: 1em;
+        max-width: 720px;
+        margin: 20px auto;
+        padding: 10px;
+        align-content: center;
+        transition: opacity 0.3s ease;
+    }
+
+    #blazor-error-ui .reload {
+        display: block;
+        margin: 20px auto;
+        width: 200px;
+        padding: 15px 20px;
+        font-size: 1.2em;
+        background-color: #2a9fd6;
+        color: white;
+        border: none;
+        border-radius: 8px;
+        cursor: pointer;
+        transition: background-color 0.3s ease;
+    }
+        #blazor-error-ui .reload:hover {
+            background-color: #247aa8;
+        }
+
+    #blazor-error-ui .dismiss {
+        cursor: pointer;
+        position: absolute;
+        right: 0.75rem;
+        top: 0.5rem;
+    }
+
+@media (min-width: 600.01px) {
+    #blazor-error-ui .logo img {
+        max-width: 400px;
+        max-height: 200px;
+    }
+
+    #blazor-error-ui .heading {
+        font-size: 2em;
+    }
+
+    #blazor-error-ui .message {
+        font-size: 1.5em;
+    }
+
+    #blazor-error-ui .reload {
+        font-size: 1.7em;
+    }
+}
+
+@media (max-width: 600px) {
+    #blazor-error-ui {
+        max-width: 100%;
+        height: 100%;
+    }
+
+        #blazor-error-ui .reload {
+            width: 100%;
+            border-radius: 0px;
+        }
 }

--- a/Oqtane.Maui/wwwroot/css/app.css
+++ b/Oqtane.Maui/wwwroot/css/app.css
@@ -323,7 +323,7 @@ app {
         margin-top: 0;
     }
 
-    #blazor-error-ui .error-message {
+    #blazor-error-ui .message {
         max-width: 100%;
     }
 }

--- a/Oqtane.Maui/wwwroot/css/app.css
+++ b/Oqtane.Maui/wwwroot/css/app.css
@@ -256,7 +256,7 @@ app {
         display: block;
         margin: 20px auto;
         width: 200px;
-        padding: 15px 20px;
+        padding: 15px 0;
         font-size: 1.2em;
         background-color: #2a9fd6;
         color: white;

--- a/Oqtane.Maui/wwwroot/css/app.css
+++ b/Oqtane.Maui/wwwroot/css/app.css
@@ -306,3 +306,24 @@ app {
             border-radius: 0px;
         }
 }
+
+@media (max-height: 420px) {
+    #blazor-error-ui .reload {
+        position: fixed;
+        bottom: 0;
+    }
+}
+
+@media (max-height: 520px) {
+    #blazor-error-ui .image {
+        display: none;
+    }
+
+    #blazor-error-ui .heading {
+        margin-top: 0;
+    }
+
+    #blazor-error-ui .error-message {
+        max-width: 100%;
+    }
+}

--- a/Oqtane.Maui/wwwroot/index.html
+++ b/Oqtane.Maui/wwwroot/index.html
@@ -20,9 +20,17 @@
 	<div id="app">Loading...</div>
 
 	<div id="blazor-error-ui">
-		An unhandled error has occurred.
+		<div class="logo">
+			<img src="images/logo-black.png" alt="Logo">
+		</div>
+		<div class="image">
+			<img src="images/error.png" alt="Error">
+		</div>
+		<h1 class="heading">Connectivity Issue</h1>
+		<p class="error-message">
+			We apologize for the inconvenience, but it seems there is a temporary interruption in our service. This could be due to network issues on your end or maintenance on our servers.  Please ensure your network is stable, and if the issue persists, try again later.
+		</p>
 		<a href="" class="reload">Reload</a>
-		<a class="dismiss">🗙</a>
 	</div>
 
 	<script src="js/interop.js"></script>

--- a/Oqtane.Maui/wwwroot/index.html
+++ b/Oqtane.Maui/wwwroot/index.html
@@ -19,18 +19,18 @@
 
 	<div id="app">Loading...</div>
 
-	<div id="blazor-error-ui">
+	<div id="blazor-error-ui" role="alert" aria-live="assertive" tabindex="0">
 		<div class="logo">
 			<img src="images/logo-black.png" alt="Logo">
 		</div>
 		<div class="image">
 			<img src="images/error.png" alt="Error">
 		</div>
-		<h1 class="heading">Connectivity Issue</h1>
-		<p class="error-message">
+		<h1 id="error-heading" class="heading"  tabindex="0">Connectivity Issue</h1>
+		<p id="error-message" class="message"  tabindex="0">
 			We apologize for the inconvenience, but it seems there is a temporary interruption in our service. This could be due to network issues on your end or maintenance on our servers.  Please ensure your network is stable, and if the issue persists, try again later.
 		</p>
-		<a href="" class="reload">Reload</a>
+		<a href="" class="reload" role="button" aria-label="Reload" tabindex="0">Reload</a>
 	</div>
 
 	<script src="js/interop.js"></script>


### PR DESCRIPTION
Fixes #3583

This resolves the unhandled exception issue by giving a more clear path to an end user on what to do and why the issue may be happening in the first place.

Notes:
could be a work in progress...  
I am trying to understand how everything loads and if it can be improved upon out of the box.
The background color could be set to default black like the default Oqtane theme.

![image](https://github.com/oqtane/oqtane.framework/assets/13577556/00f05e9e-3c5d-4459-9f8e-9c8a505dba24)

![image](https://github.com/oqtane/oqtane.framework/assets/13577556/e7a41449-e2f9-4a89-9d98-d8783bba57fe)

This has the following features:
1. Is responsive
2. Is accessible
3. Utilizes stock images and resources
4. Removes the dismiss X button since it will leave a user with nothing else to do but close the application.
5. Gives generic simple instructions and reasons for possible troubleshooting actions or other potential causes.

Other feedback relating:
What color should the background be?  Black I am thinking since the app has a black background to start.  So I can add this to match the default Oqtane theme as well if that would be OK or we can leave it white.  The "loading..." goes by so fast you dont notice it... it would be nice to have something more real to look at that goes until the message pops up.

I changed the color from light yellow to this light red to reflect it is an alert that something is wrong.  This can be and maybe should be changed back to the other color background.

If you shut down the server, then navigate to a link the app closes if running the app from desktop, and it will run into a debug stop point if running from debug mode.  It would be nice to resolve them back to this default Index.html.  This is something I am hoping can still get fixed and is looked further into for production.  An app just closing out of the blue isnt good, but it is better than an error I suppose.   I just created an issue for this #3588.