### PR TITLE
Module Creator Owner/Name + Notification Help Text Includes Warning Not To Use The Word "Oqtane".  Fixes #3597

### DIFF
--- a/Oqtane.Client/Modules/Admin/ModuleDefinitions/Create.razor
+++ b/Oqtane.Client/Modules/Admin/ModuleDefinitions/Create.razor
@@ -13,13 +13,13 @@
     <form @ref="form" class="@(validated ? "was-validated" : "needs-validation")" novalidate>
         <div class="container">
             <div class="row mb-1 align-items-center">
-                <Label Class="col-sm-3" For="owner" HelpText="Enter the name of the organization who is developing this module. It should not contain spaces or punctuation." ResourceKey="OwnerName">Owner Name: </Label>
+                <Label Class="col-sm-3" For="owner" HelpText="Enter the name of the organization who is developing this module. It should not contain spaces or punctuation or the word oqtane." ResourceKey="OwnerName">Owner Name: </Label>
                 <div class="col-sm-9">
                     <input id="owner" class="form-control" @bind="@_owner" required />
                 </div>
             </div>
             <div class="row mb-1 align-items-center">
-                <Label Class="col-sm-3" For="module" HelpText="Enter a name for this module. It should not contain spaces or punctuation." ResourceKey="ModuleName">Module Name: </Label>
+                <Label Class="col-sm-3" For="module" HelpText="Enter a name for this module. It should not contain spaces or punctuation or the word oqtane." ResourceKey="ModuleName">Module Name: </Label>
                 <div class="col-sm-9">
                     <input id="module" class="form-control" @bind="@_module" required />
                 </div>

--- a/Oqtane.Client/Resources/Modules/Admin/ModuleDefinitions/Create.resx
+++ b/Oqtane.Client/Resources/Modules/Admin/ModuleDefinitions/Create.resx
@@ -130,16 +130,16 @@
     <value>Please Note That The Module Creator Is Only Intended To Be Used In A Development Environment</value>
   </data>
   <data name="Message.Require.ValidName" xml:space="preserve">
-    <value>You Must Provide A Valid Owner Name And Module Name ( ie. No Punctuation Or Spaces And The Values Cannot Be The Same ) And Choose A Template</value>
+    <value>You Must Provide A Valid Owner Name And Module Name ( ie. No Punctuation Or Spaces And The Values Cannot Be The Same Or Contain The Word "Oqtane" ) And Choose A Template</value>
   </data>
   <data name="Message.Require.ValidDescription" xml:space="preserve">
     <value>You Must Provide A Valid Description (ie. No Punctuation)</value>
   </data>
   <data name="OwnerName.HelpText" xml:space="preserve">
-    <value>Enter the name of the organization who is developing this module. It should not contain spaces or punctuation.</value>
+    <value>Enter the name of the organization who is developing this module. It should not contain spaces or punctuation or contain the word "Oqtane".</value>
   </data>
   <data name="ModuleName.HelpText" xml:space="preserve">
-    <value>Enter a name for this module. It should not contain spaces or punctuation.</value>
+    <value>Enter a name for this module. It should not contain spaces or punctuation or contain the word "Oqtane".</value>
   </data>
   <data name="Description.HelpText" xml:space="preserve">
     <value>Enter a short description for the module</value>

--- a/Oqtane.Client/Resources/Modules/Admin/ModuleDefinitions/Create.resx
+++ b/Oqtane.Client/Resources/Modules/Admin/ModuleDefinitions/Create.resx
@@ -136,10 +136,10 @@
     <value>You Must Provide A Valid Description (ie. No Punctuation)</value>
   </data>
   <data name="OwnerName.HelpText" xml:space="preserve">
-    <value>Enter the name of the organization who is developing this module. It should not contain spaces or punctuation or contain the word "Oqtane".</value>
+    <value>Enter the name of the organization who is developing this module. It should not contain spaces or punctuation or contain the word "oqtane".</value>
   </data>
   <data name="ModuleName.HelpText" xml:space="preserve">
-    <value>Enter a name for this module. It should not contain spaces or punctuation or contain the word "Oqtane".</value>
+    <value>Enter a name for this module. It should not contain spaces or punctuation or contain the word "oqtane".</value>
   </data>
   <data name="Description.HelpText" xml:space="preserve">
     <value>Enter a short description for the module</value>


### PR DESCRIPTION
Fixes #3597

This PR adds the information to the help text and notification to not use module owner or names that contain the word "oqtane".

It should help resolve issues as shown in #3597 while trying to create a module with a module name that contains "Oqtane" word in it.

This would need to be edited to inform the module name and owner is not allowed to start with the word "Oqtane" if current modifications being tested allow this without experiencing namespace conflicts in the framework itself.  This is being discussed in #3597 

Additional Context Relating To Documentation:
Another option to help enhance on-boarding module creators in this area is to have a link to Oqtane Module Creator Documentation for additional online support.  I have an [enhanced documentation outline](https://github.com/oqtane/oqtane.docs/issues/16) proposed that would have a place to put a page or section dedicated to module development.  This could also explain what you can/can't do such as using the word "oqtane" for module owner and name along with the best practices mentioned in #3597 for Oqtane Module Developers.

I can edit this PR for any updates  to be merged relating or you may close this and rewrite things as needed if works best.

Cheers!