### PR TITLE
Clear Module Message Prior To Adding A Message To UI. Fixes #3599

### DIFF
--- a/Oqtane.Client/Modules/ModuleBase.cs
+++ b/Oqtane.Client/Modules/ModuleBase.cs
@@ -266,6 +266,7 @@ namespace Oqtane.Modules
 
         public void AddModuleMessage(string message, MessageType type, string position)
         {
+            ClearModuleMessage();
             ModuleInstance.AddModuleMessage(message, type, position);
         }
 


### PR DESCRIPTION
Fixes #3599

This PR updates the AddModuleMessage() UI method in the ModuleBase.cs file logic to clear the module message prior to displaying one in the event one already exists or was dismissed previously. 