### PR TITLE
README - adds marketplace information for issue #3607 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Foqtane%2Foqtane.framework%2Fmaster%2Fazuredeploy.json)
 
+[![Visit Marketplace](https://github.com/oqtane/oqtane.framework/blob/master/Oqtane.Server/wwwroot/icon.png)](https://www.oqtane.net/)
+
 # Oqtane Framework
 
 ![Oqtane](https://github.com/oqtane/framework/blob/master/oqtane.png?raw=true "Oqtane")

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Foqtane%2Foqtane.framework%2Fmaster%2Fazuredeploy.json)
 
-[![Visit Marketplace](https://github.com/oqtane/oqtane.framework/blob/master/Oqtane.Server/wwwroot/icon.png)](https://www.oqtane.net/)
+[![Visit Marketplace](https://github.githubassets.com/images/icons/emoji/unicode/1f3ea.png)](https://www.oqtane.net/)
 
 # Oqtane Framework
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Foqtane%2Foqtane.framework%2Fmaster%2Fazuredeploy.json)
 
 [![Visit Marketplace](https://github.githubassets.com/images/icons/emoji/unicode/1f3ea.png)](https://www.oqtane.net/)
+[Visit Marketplace](https://www.oqtane.net/)
 
 # Oqtane Framework
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [5.0.1](https://github.com/oqtane/oqtane.framework/releases/tag/v5.0.1) was released on Dec 21, 2023 and is a major release targeted at .NET 8. This release includes 67 pull requests by 6 different contributors, pushing the total number of project commits all-time to over 4400. The Oqtane framework continues to evolve at a rapid pace to meet the needs of .NET developers.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Foqtane%2Foqtane.framework%2Fmaster%2Fazuredeploy.json)
-
-[Visit the Oqtane Marketplace](https://www.oqtane.net/)[![Visit Marketplace](https://github.githubassets.com/images/icons/emoji/unicode/1f3ea.png)](https://www.oqtane.net/)
+[![Visit Marketplace](https://github.githubassets.com/images/icons/emoji/unicode/1f3ea.png)](https://www.oqtane.net/)
+[Visit the Oqtane Marketplace](https://www.oqtane.net/)
 
 
 # Oqtane Framework

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Foqtane%2Foqtane.framework%2Fmaster%2Fazuredeploy.json)
 [![Visit Marketplace](https://github.githubassets.com/images/icons/emoji/unicode/1f3ea.png)](https://www.oqtane.net/)
-[Visit the Oqtane Marketplace](https://www.oqtane.net/)
-
 
 # Oqtane Framework
 
@@ -41,6 +39,11 @@ Please note that this project is owned by the .NET Foundation and is governed by
 **Video Series**
 
 - If you are getting started with Oqtane, a [series of videos](https://www.youtube.com/watch?v=JPfUZPlRRCE&list=PLYhXmd7yV0elLNLfQwZBUlM7ZSMYPTZ_f) are available which explain how to install the product, interact with the user interface, and develop custom modules.
+
+# Oqtane Marketplace
+
+Explore and enhance your Oqtane experience by visiting the Oqtane Marketplace. Discover a variety of modules, themes, and extensions contributed by the community. [Visit Oqtane Marketplace](https://www.oqtane.net)
+
 
 # Documentation
 There is a separate [Documentation repository](https://github.com/oqtane/oqtane.docs) which contains a variety of types of documentation for Oqtane, including API documentation that is auto generated using Docfx. The contents of the repository is published to Githib Pages and is available at [https://docs.oqtane.org](https://docs.oqtane.org/)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Foqtane%2Foqtane.framework%2Fmaster%2Fazuredeploy.json)
 
 [![Visit Marketplace](https://github.githubassets.com/images/icons/emoji/unicode/1f3ea.png)](https://www.oqtane.net/)
-[Visit Marketplace](https://www.oqtane.net/)
+[Visit the Oqtane Marketplace](https://www.oqtane.net/)
 
 # Oqtane Framework
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Foqtane%2Foqtane.framework%2Fmaster%2Fazuredeploy.json)
 
-[![Visit Marketplace](https://github.githubassets.com/images/icons/emoji/unicode/1f3ea.png)](https://www.oqtane.net/)
-[Visit the Oqtane Marketplace](https://www.oqtane.net/)
+[Visit the Oqtane Marketplace](https://www.oqtane.net/)[![Visit Marketplace](https://github.githubassets.com/images/icons/emoji/unicode/1f3ea.png)](https://www.oqtane.net/)
+
 
 # Oqtane Framework
 


### PR DESCRIPTION
Fixes #3607 

This adds an icon using github icons (maybe we can make our own later) next to the Deploy To Azure button that links to the marketplace and adds a section to the README file that introduces that Marketplace with a link.

Of course had to play with the markdown for a bit in  GitHub Editor to see what would potentially make this PR acceptable.

And choice of words is optional here as "Visit" "Explore" "Discover" can all be used, but this current pr gives a trifecta approach hitting all three in the words in the first two sentences, then the link.  But if you want a little more weight one way or another there is this to overthink.