### PR TITLE
Update Oqtane.Client\Modules\Admin\Profiles\Edit.razor to fix breaking changes

### DIFF
--- a/Oqtane.Client/Modules/Admin/Profiles/Edit.razor
+++ b/Oqtane.Client/Modules/Admin/Profiles/Edit.razor
@@ -34,7 +34,7 @@
         <div class="row mb-1 align-items-center">
             <Label Class="col-sm-3" For="order" HelpText="The index order of where this profile item should be displayed" ResourceKey="Order">Order: </Label>
             <div class="col-sm-9">
-                <input id="order" class="form-control" @bind="@_vieworder" min="0" max="99" type="number" required />
+                <input id="order" class="form-control" @bind="@_vieworder" min="0" max="9999" type="number" required />
             </div>
         </div>
         <div class="row mb-1 align-items-center">
@@ -46,7 +46,7 @@
         <div class="row mb-1 align-items-center">
             <Label Class="col-sm-3" For="rows" HelpText="The number of rows for text entry (one is the default)" ResourceKey="Rows">Rows: </Label>
             <div class="col-sm-9">
-                <input id="rows" class="form-control" @bind="@_rows" min="1" max="10" type="number" required />
+                <input id="rows" class="form-control" @bind="@_rows" min="1" max="99" type="number" required />
             </div>
         </div>
         <div class="row mb-1 align-items-center">


### PR DESCRIPTION
Prior functionality allowed 4 characters for "order" which now causes validation errors for any order value > 99.  This change allows a value of up to 9999 which is consistent with the prior 4 character length value.

Prior functionality allowed 2 characters for "rows" which now causes validattion error for any row count > 10.  This change allows a value up to 99 which is consistent with the prior 2 character length value.