### PR TITLE
improved rendering optimization

### DIFF
--- a/Oqtane.Client/Modules/HtmlText/Index.razor
+++ b/Oqtane.Client/Modules/HtmlText/Index.razor
@@ -21,7 +21,7 @@
     {
         try
         {
-            if (PageState.RenderModuleInstance(ModuleState))
+            if (ShouldRender())
             {
                 var htmltext = await HtmlTextService.GetHtmlTextAsync(ModuleState.ModuleId);
                 if (htmltext != null)

--- a/Oqtane.Client/Modules/ModuleBase.cs
+++ b/Oqtane.Client/Modules/ModuleBase.cs
@@ -113,6 +113,11 @@ namespace Oqtane.Modules
             }
         }
 
+        protected override bool ShouldRender()
+        {
+            return PageState.RenderId == ModuleState.RenderId;
+        }
+
         // path method
 
         public string ModulePath()

--- a/Oqtane.Client/Themes/ContainerBase.cs
+++ b/Oqtane.Client/Themes/ContainerBase.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components;
 using Oqtane.Models;
 
 namespace Oqtane.Themes
@@ -8,5 +8,9 @@ namespace Oqtane.Themes
         [CascadingParameter]
         protected Module ModuleState { get; set; }
 
+        protected override bool ShouldRender()
+        {
+            return PageState.RenderId == ModuleState.RenderId;
+        }
     }
 }

--- a/Oqtane.Client/UI/ContainerBuilder.razor
+++ b/Oqtane.Client/UI/ContainerBuilder.razor
@@ -30,6 +30,11 @@
     [Parameter]
     public Module ModuleState { get; set; }
 
+    protected override bool ShouldRender()
+    {
+        return PageState.RenderId == ModuleState.RenderId;
+    }
+
     protected override void OnInitialized()
     {
         ((INotifyPropertyChanged)SiteState.Properties).PropertyChanged += PropertyChanged;
@@ -52,7 +57,7 @@
             _useadminborder = false;
         }
 
-        if (PageState.RenderModuleInstance(ModuleState))
+        if (ShouldRender())
         {
             ComponentType = Type.GetType(container) ?? Type.GetType(Constants.DefaultContainer);
         }

--- a/Oqtane.Client/UI/ModuleInstance.razor
+++ b/Oqtane.Client/UI/ModuleInstance.razor
@@ -48,10 +48,15 @@ else
 
     private ModuleMessage ModuleMessage { get; set; }
 
+    protected override bool ShouldRender()
+    {
+        return PageState.RenderId == ModuleState.RenderId;
+    }
+
     protected override void OnParametersSet()
     {
         _message = "";
-        if (PageState.RenderModuleInstance(ModuleState))
+        if (ShouldRender())
         {
             if (!string.IsNullOrEmpty(ModuleState.ModuleType))
             {

--- a/Oqtane.Client/UI/PageState.cs
+++ b/Oqtane.Client/UI/PageState.cs
@@ -23,6 +23,7 @@ namespace Oqtane.UI
         public string RemoteIPAddress { get; set; }
         public string ReturnUrl { get; set; }
         public bool IsInternalNavigation { get; set; }
+        public Guid RenderId { get; set; }
 
         public List<Page> Pages
         {
@@ -35,13 +36,6 @@ namespace Oqtane.UI
         public List<Language> Languages
         {
             get { return Site.Languages; }
-        }
-
-
-        // determines if the PageState matches the ModuleState for component rendering purposes
-        public bool RenderModuleInstance(Module ModuleState)
-        {
-            return Page.PageId == ModuleState.PageId && (ModuleId == -1 || ModuleId == ModuleState.ModuleId) && Action == ModuleState.Action;
         }
     }
 }

--- a/Oqtane.Client/UI/Pane.razor
+++ b/Oqtane.Client/UI/Pane.razor
@@ -45,6 +45,9 @@ else
         {
             foreach (Module module in PageState.Modules.Where(item => item.PageId == PageState.Page.PageId))
             {
+                // set renderid - this allows the framework to determine which components should be rendered when PageState changes
+                module.RenderId = PageState.RenderId;
+
                 var pane = module.Pane;
                 if (module.ModuleId == PageState.ModuleId && PageState.Action != Constants.DefaultAction)
                 {

--- a/Oqtane.Client/UI/SiteRouter.razor
+++ b/Oqtane.Client/UI/SiteRouter.razor
@@ -289,7 +289,8 @@
 						VisitorId = VisitorId,
 						RemoteIPAddress = SiteState.RemoteIPAddress,
 						ReturnUrl = returnurl,
-                        IsInternalNavigation = _isInternalNavigation
+                        IsInternalNavigation = _isInternalNavigation,
+                        RenderId = Guid.NewGuid()
                     };
 
                     OnStateChange?.Invoke(_pagestate);
@@ -508,7 +509,6 @@
                 }
 
                 module.PaneModuleIndex = paneindex[module.Pane.ToLower()];
-                module.Action = action;
 
                 // container fallback
                 if (string.IsNullOrEmpty(module.ContainerType))

--- a/Oqtane.Shared/Models/Module.cs
+++ b/Oqtane.Shared/Models/Module.cs
@@ -86,7 +86,7 @@ namespace Oqtane.Models
         [NotMapped]
         public int PaneModuleCount { get; set; }
         [NotMapped]
-        public string Action { get; set; }
+        public Guid RenderId { get; set; }
 
         #endregion
 


### PR DESCRIPTION
this PR introduces a RenderId (GUID) which serves as a unique identifier to detect when a change has occurred to PageState. It is used within the ShouldRender method on components to prevent unnecessary rendering and as a flag to suppress other types of component processing