### PR TITLE
Fixes ShouldRender() Null Exception #3617

### DIFF
--- a/Oqtane.Client/Modules/ModuleBase.cs
+++ b/Oqtane.Client/Modules/ModuleBase.cs
@@ -115,7 +115,7 @@ namespace Oqtane.Modules
 
         protected override bool ShouldRender()
         {
-            return PageState.RenderId == ModuleState.RenderId;
+            return PageState != null && ModuleState != null && PageState.RenderId == ModuleState.RenderId;
         }
 
         // path method


### PR DESCRIPTION
Fixes #3617 

This PR fixes the null exception issue when trying to launch debugging on startup of Oqtane Framework.

This may not be the correct solution, but it made Oqtane launch for anyone that needs a workaround.