### PR TITLE
Handle null or empty formfile in UploadFile Method - Fixes #3646

### DIFF
--- a/Oqtane.Server/Controllers/FileController.cs
+++ b/Oqtane.Server/Controllers/FileController.cs
@@ -360,7 +360,7 @@ namespace Oqtane.Controllers
         [HttpPost("upload")]
         public async Task UploadFile(string folder, IFormFile formfile)
         {
-            if (formfile.Length <= 0)
+            if (formfile == null || formfile.Length <= 0)
             {
                 return;
             }


### PR DESCRIPTION
### Pull Request
Fixes #3646

#### Changes Made
- Added check for null or empty `formfile` in `UploadFile()` method located in `FileController.cs`