### PR TITLE
Cleans protocol to check for duplicate alias prior to saving.  Fixes #3647

### DIFF
--- a/Oqtane.Client/Modules/Admin/Site/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Site/Index.razor
@@ -812,41 +812,46 @@
 		}
 	}
 
-	private async Task SaveAlias()
-	{
-		if (UserSecurity.IsAuthorized(PageState.User, RoleNames.Host))
-		{
-			if (!string.IsNullOrEmpty(_aliasname))
-			{
-				var aliases = await AliasService.GetAliasesAsync();
-				var alias = aliases.Where(item => item.Name == _aliasname).FirstOrDefault();
-				bool unique = (alias == null || alias.AliasId == _aliasid);
-				if (unique)
-				{
-					if (_aliasid == 0)
-					{
-						alias = new Alias { SiteId = PageState.Site.SiteId, TenantId = PageState.Site.TenantId, Name = _aliasname, IsDefault = bool.Parse(_defaultalias) };
-						await AliasService.AddAliasAsync(alias);
-					}
-					else
-					{
-						alias = _aliases.Single(item => item.AliasId == _aliasid);
-						alias.Name = _aliasname;
-						alias.IsDefault = bool.Parse(_defaultalias);
-						await AliasService.UpdateAliasAsync(alias);
-					}
-				}
-				else // duplicate alias
-				{
-					AddModuleMessage(Localizer["Message.Aliases.Taken"], MessageType.Warning);
-				}
-			}
-			await GetAliases();
-			_aliasid = -1;
-			_aliasname = "";
-			StateHasChanged();
-		}
-	}
+	    private async Task SaveAlias()
+    {
+        if (UserSecurity.IsAuthorized(PageState.User, RoleNames.Host))
+        {
+            if (!string.IsNullOrEmpty(_aliasname))
+            {
+                // Remove 'http://' and 'https://' from the alias name
+                string cleanedAliasName = _aliasname.Replace("http://", "").Replace("https://", "");
+
+                var aliases = await AliasService.GetAliasesAsync();
+                // Check if the cleaned alias name exists in the database
+                var alias = aliases.Where(item => item.Name == cleanedAliasName).FirstOrDefault();
+                bool unique = (alias == null || alias.AliasId == _aliasid);
+                if (unique)
+                {
+                    if (_aliasid == 0)
+                    {
+                        alias = new Alias { SiteId = PageState.Site.SiteId, TenantId = PageState.Site.TenantId, Name = cleanedAliasName, IsDefault = bool.Parse(_defaultalias) };
+                        await AliasService.AddAliasAsync(alias);
+                    }
+                    else
+                    {
+                        alias = _aliases.Single(item => item.AliasId == _aliasid);
+                        alias.Name = cleanedAliasName;
+                        alias.IsDefault = bool.Parse(_defaultalias);
+                        await AliasService.UpdateAliasAsync(alias);
+                    }
+                }
+                else // duplicate alias
+                {
+                    AddModuleMessage(Localizer["Message.Aliases.Taken"], MessageType.Warning);
+                    await ScrollToPageTop();
+                }
+            }
+            await GetAliases();
+            _aliasid = -1;
+            _aliasname = "";
+            StateHasChanged();
+        }
+    }
 
 	private async Task CancelAlias()
 	{


### PR DESCRIPTION
Fixes #3647

# Pull Request: Clean Protocol and Scroll to Top on Error

## Summary

This pull request includes changes to clean the protocol (HTTP or HTTPS) from the alias before checking for duplicates. It also includes changes to scroll to the top of the page when an error message is displayed.

## Changes

1. **Clean Protocol:** Modified the `SaveAlias` method to remove 'http://' and 'https://' from the alias name before checking for uniqueness in the database. This ensures that the alias is unique even after removing these protocols.

```
string cleanedAliasName = _aliasname.Replace("http://", "").Replace("https://", "");
var alias = aliases.Where(item => item.Name == cleanedAliasName).FirstOrDefault();
```

2. **Scroll to Top on Error:** Added code to scroll to the top of the page when an error message is displayed. This ensures that the user can see the error message even if they are scrolled down on the page.

## Test Plan
Enter an alias with the ‘http://’ or ‘https://’ protocol and save it.
Enter the same alias again with the ‘http://’ or ‘https://’ protocol and try to save it. The application should display an error message and scroll to the top of the page.