### PR TITLE
Enh: Autocomplete Attribute Enhancement

### DIFF
--- a/Oqtane.Client/Installer/Installer.razor
+++ b/Oqtane.Client/Installer/Installer.razor
@@ -71,7 +71,7 @@
                 <div class="row mb-1 align-items-center">
                     <Label Class="col-sm-3" For="username" HelpText="Provide a username for the primary user account" ResourceKey="Username">Username:</Label>
                     <div class="col-sm-9">
-                        <input id="username" type="text" class="form-control" @bind="@_hostUsername" autocomplete="username" />
+                        <input id="username" type="text" class="form-control" @bind="@_hostUsername" />
                     </div>
                 </div>
                 <div class="row mb-1 align-items-center">
@@ -95,7 +95,7 @@
                 <div class="row mb-1 align-items-center">
                     <Label Class="col-sm-3" For="email" HelpText="Provide the email address for the host user account" ResourceKey="Email">Email:</Label>
                     <div class="col-sm-9">
-                        <input type="text" class="form-control" @bind="@_hostEmail" autocomplete="email" />
+                        <input type="text" class="form-control" @bind="@_hostEmail" />
                     </div>
                 </div>
                 <div class="row mb-1 align-items-center">

--- a/Oqtane.Client/Installer/Installer.razor
+++ b/Oqtane.Client/Installer/Installer.razor
@@ -69,9 +69,9 @@
             <h2>@Localizer["ApplicationAdmin"]</h2><br />
             <div class="container">
                 <div class="row mb-1 align-items-center">
-                    <Label Class="col-sm-3" For="username" HelpText="Provide a username for the primary user accountt" ResourceKey="Username">Username:</Label>
+                    <Label Class="col-sm-3" For="username" HelpText="Provide a username for the primary user account" ResourceKey="Username">Username:</Label>
                     <div class="col-sm-9">
-                        <input id="username" type="text" class="form-control" @bind="@_hostUsername" />
+                        <input id="username" type="text" class="form-control" @bind="@_hostUsername" autocomplete="username" />
                     </div>
                 </div>
                 <div class="row mb-1 align-items-center">
@@ -95,7 +95,7 @@
                 <div class="row mb-1 align-items-center">
                     <Label Class="col-sm-3" For="email" HelpText="Provide the email address for the host user account" ResourceKey="Email">Email:</Label>
                     <div class="col-sm-9">
-                        <input type="text" class="form-control" @bind="@_hostEmail" />
+                        <input type="text" class="form-control" @bind="@_hostEmail" autocomplete="email" />
                     </div>
                 </div>
                 <div class="row mb-1 align-items-center">

--- a/Oqtane.Client/Modules/Admin/Profiles/Edit.razor
+++ b/Oqtane.Client/Modules/Admin/Profiles/Edit.razor
@@ -77,9 +77,9 @@
             </div>
         </div>
         <div class="row mb-1 align-items-center">
-            <Label Class="col-sm-3" For="autocomplete" HelpText="Autocomplete setting for the property" ResourceKey="Autocomplete">Autocomplete: </Label>
+            <Label Class="col-sm-3" For="autocomplete" HelpText="The HTML autocomplete attribute allows you to specify browser behavior for automated assistance in filling out form field values, with a character limit of 30 to ensure concise and effective usage." ResourceKey="Autocomplete">Autocomplete: </Label>
             <div class="col-sm-9">
-                <input id="autocomplete" class="form-control" @bind="@_autocomplete" maxlength="50" />
+                <input id="autocomplete" class="form-control" @bind="@_autocomplete" maxlength="30" />
             </div>
         </div>
         <div class="row mb-1 align-items-center">

--- a/Oqtane.Client/Modules/Admin/Profiles/Edit.razor
+++ b/Oqtane.Client/Modules/Admin/Profiles/Edit.razor
@@ -77,6 +77,12 @@
             </div>
         </div>
         <div class="row mb-1 align-items-center">
+            <Label Class="col-sm-3" For="autocomplete" HelpText="Autocomplete setting for the property" ResourceKey="Autocomplete">Autocomplete: </Label>
+            <div class="col-sm-9">
+                <input id="autocomplete" class="form-control" @bind="@_autocomplete" maxlength="50" />
+            </div>
+        </div>
+        <div class="row mb-1 align-items-center">
             <Label Class="col-sm-3" For="private" HelpText="Should this profile item be visible to all users?" ResourceKey="Private">Private? </Label>
             <div class="col-sm-9">
                 <select id="private" class="form-select" @bind="@_isprivate" required>
@@ -89,7 +95,7 @@
     <br />
     <button type="button" class="btn btn-success" @onclick="SaveProfile">@SharedLocalizer["Save"]</button>
     <NavLink class="btn btn-secondary" href="@NavigateUrl()">@SharedLocalizer["Cancel"]</NavLink>
-    @if (PageState.QueryString.ContainsKey("id"))
+        @if (PageState.QueryString.ContainsKey("id"))
     {
         <br />
         <br />
@@ -111,6 +117,7 @@
     private string _defaultvalue = string.Empty;
     private string _options = string.Empty;
     private string _validation = string.Empty;
+    private string _autocomplete = string.Empty;
     private string _isrequired = "False";
     private string _isprivate = "False";
     private string createdby;
@@ -142,6 +149,7 @@
                     _defaultvalue = profile.DefaultValue;
                     _options = profile.Options;
                     _validation = profile.Validation;
+                    _autocomplete = profile.Autocomplete;
                     _isrequired = profile.IsRequired.ToString();
                     _isprivate = profile.IsPrivate.ToString();
                     createdby = profile.CreatedBy;
@@ -187,8 +195,10 @@
                 profile.DefaultValue = _defaultvalue;
                 profile.Options = _options;
                 profile.Validation = _validation;
+                profile.Autocomplete = _autocomplete;
                 profile.IsRequired = (_isrequired == null ? false : Boolean.Parse(_isrequired));
                 profile.IsPrivate = (_isprivate == null ? false : Boolean.Parse(_isprivate));
+
                 if (_profileid != -1)
                 {
                     profile = await ProfileService.UpdateProfileAsync(profile);

--- a/Oqtane.Client/Modules/Admin/Register/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Register/Index.razor
@@ -23,7 +23,7 @@
                     <div class="row mb-1 align-items-center">
                         <Label Class="col-sm-3" For="username" HelpText="Your username. Note that this field can not be modified once it is saved." ResourceKey="Username"></Label>
                         <div class="col-sm-9">
-                            <input id="username" class="form-control" @bind="@_username" maxlength="256" required />
+                            <input id="username" class="form-control" @bind="@_username" maxlength="256" autocomplete="username" required />
                         </div>
                     </div>
                     <div class="row mb-1 align-items-center">
@@ -47,13 +47,13 @@
                     <div class="row mb-1 align-items-center">
                         <Label Class="col-sm-3" For="email" HelpText="Your email address where you wish to receive notifications" ResourceKey="Email"></Label>
                         <div class="col-sm-9">
-							<input id="email" class="form-control" @bind="@_email" maxlength="256" required />
+							<input id="email" class="form-control" @bind="@_email" maxlength="256" autocomplete="email" required />
                         </div>
                     </div>
                     <div class="row mb-1 align-items-center">
                         <Label Class="col-sm-3" For="displayname" HelpText="Your full name" ResourceKey="DisplayName"></Label>
                         <div class="col-sm-9">
-                            <input id="displayname" class="form-control" @bind="@_displayname" maxlength="50" />
+                            <input id="displayname" class="form-control" @bind="@_displayname" maxlength="50" autocomplete="name" />
                         </div>
                     </div>
                 </div>

--- a/Oqtane.Client/Modules/Admin/Register/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Register/Index.razor
@@ -18,7 +18,7 @@
         </Authorized>
         <NotAuthorized>
             <ModuleMessage Message="@_passwordrequirements" Type="MessageType.Info" />
-            <form @ref="form" class="@(validated ? "was-validated" : "needs-validation")" novalidate>
+            <form @ref="form" class="@(validated ? "was-validated" : "needs-validation")" autocomplete="on" novalidate>
                 <div class="container">
                     <div class="row mb-1 align-items-center">
                         <Label Class="col-sm-3" For="username" HelpText="Your username. Note that this field can not be modified once it is saved." ResourceKey="Username"></Label>

--- a/Oqtane.Client/Modules/Admin/Register/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Register/Index.razor
@@ -18,12 +18,12 @@
         </Authorized>
         <NotAuthorized>
             <ModuleMessage Message="@_passwordrequirements" Type="MessageType.Info" />
-            <form @ref="form" class="@(validated ? "was-validated" : "needs-validation")" autocomplete="on" novalidate>
+            <form @ref="form" class="@(validated ? "was-validated" : "needs-validation")" novalidate>
                 <div class="container">
                     <div class="row mb-1 align-items-center">
                         <Label Class="col-sm-3" For="username" HelpText="Your username. Note that this field can not be modified once it is saved." ResourceKey="Username"></Label>
                         <div class="col-sm-9">
-                            <input id="username" class="form-control" @bind="@_username" maxlength="256" autocomplete="username" required />
+                            <input id="username" class="form-control" @bind="@_username" maxlength="256" required />
                         </div>
                     </div>
                     <div class="row mb-1 align-items-center">
@@ -47,13 +47,13 @@
                     <div class="row mb-1 align-items-center">
                         <Label Class="col-sm-3" For="email" HelpText="Your email address where you wish to receive notifications" ResourceKey="Email"></Label>
                         <div class="col-sm-9">
-							<input id="email" class="form-control" @bind="@_email" maxlength="256" autocomplete="email" required />
+							<input id="email" class="form-control" @bind="@_email" maxlength="256" required />
                         </div>
                     </div>
                     <div class="row mb-1 align-items-center">
                         <Label Class="col-sm-3" For="displayname" HelpText="Your full name" ResourceKey="DisplayName"></Label>
                         <div class="col-sm-9">
-                            <input id="displayname" class="form-control" @bind="@_displayname" maxlength="50" autocomplete="name" />
+                            <input id="displayname" class="form-control" @bind="@_displayname" maxlength="50" />
                         </div>
                     </div>
                 </div>

--- a/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
+++ b/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
@@ -602,7 +602,6 @@
             AddModuleMessage(ex.Message, MessageType.Error);
             ModuleInstance.HideProgressIndicator();
         }
-
     }
 
     private void TogglePassword()

--- a/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
+++ b/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
@@ -65,13 +65,13 @@
                 <div class="row mb-1 align-items-center">
                     <Label Class="col-sm-3" For="email" HelpText="Your email address where you wish to receive notifications" ResourceKey="Email"></Label>
                     <div class="col-sm-9">
-                        <input id="email" class="form-control" @bind="@email" autocomplete="email" />
+                        <input id="email" class="form-control" @bind="@email" />
                     </div>
                 </div>
                 <div class="row mb-1 align-items-center">
                     <Label Class="col-sm-3" For="displayname" HelpText="Your full name" ResourceKey="DisplayName"></Label>
                     <div class="col-sm-9">
-                        <input id="displayname" class="form-control" @bind="@displayname" autocomplete="name" />
+                        <input id="displayname" class="form-control" @bind="@displayname" />
                     </div>
                 </div>
                 <div class="row mb-1 align-items-center">

--- a/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
+++ b/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
@@ -36,7 +36,7 @@
                     <Label Class="col-sm-3" For="password" HelpText="If you wish to change your password you can enter it here. Please choose a sufficiently secure password." ResourceKey="Password"></Label>
                     <div class="col-sm-9">
                         <div class="input-group">
-                            <input id="password" type="@_passwordtype" class="form-control" @bind="@_password" autocomplete="new-password" />
+                            <input id="password" name="password " type="@_passwordtype" class="form-control" @bind="@_password" autocomplete="new-password" />
                             <button type="button" class="btn btn-secondary" @onclick="@TogglePassword" tabindex="-1">@_togglepassword</button>
                         </div>
                     </div>
@@ -65,13 +65,13 @@
                 <div class="row mb-1 align-items-center">
                     <Label Class="col-sm-3" For="email" HelpText="Your email address where you wish to receive notifications" ResourceKey="Email"></Label>
                     <div class="col-sm-9">
-                        <input id="email" class="form-control" @bind="@email" />
+                        <input id="email" class="form-control" @bind="@email" autocomplete="email" />
                     </div>
                 </div>
                 <div class="row mb-1 align-items-center">
                     <Label Class="col-sm-3" For="displayname" HelpText="Your full name" ResourceKey="DisplayName"></Label>
                     <div class="col-sm-9">
-                        <input id="displayname" class="form-control" @bind="@displayname" />
+                        <input id="displayname" class="form-control" @bind="@displayname" autocomplete="name" />
                     </div>
                 </div>
                 <div class="row mb-1 align-items-center">
@@ -123,24 +123,52 @@
                                     {
                                         @if (p.Rows == 1)
                                         {
-                                            @if (p.IsRequired)
+                                            if (!string.IsNullOrEmpty(p.Autocomplete))
                                             {
-                                                <input id="@p.Name" class="form-control" maxlength="@p.MaxLength" value="@GetProfileValue(p.Name, p.DefaultValue)" required @onchange="@(e => ProfileChanged(e, p.Name))" />
+                                                @if (p.IsRequired)
+                                                {
+                                                    <input id="@p.Name" class="form-control" maxlength="@p.MaxLength" value="@GetProfileValue(p.Name, p.DefaultValue)" required @onchange="@(e => ProfileChanged(e, p.Name))" autocomplete="@p.Autocomplete" />
+                                                }
+                                                else
+                                                {
+                                                    <input id="@p.Name" class="form-control" maxlength="@p.MaxLength" value="@GetProfileValue(p.Name, p.DefaultValue)" @onchange="@(e => ProfileChanged(e, p.Name))" autocomplete="@p.Autocomplete" />
+                                                }
                                             }
                                             else
                                             {
-                                                <input id="@p.Name" class="form-control" maxlength="@p.MaxLength" value="@GetProfileValue(p.Name, p.DefaultValue)" @onchange="@(e => ProfileChanged(e, p.Name))" />
+                                                @if (p.IsRequired)
+                                                {
+                                                    <input id="@p.Name" class="form-control" maxlength="@p.MaxLength" value="@GetProfileValue(p.Name, p.DefaultValue)" required @onchange="@(e => ProfileChanged(e, p.Name))" />
+                                                }
+                                                else
+                                                {
+                                                    <input id="@p.Name" class="form-control" maxlength="@p.MaxLength" value="@GetProfileValue(p.Name, p.DefaultValue)" @onchange="@(e => ProfileChanged(e, p.Name))" />
+                                                }
                                             }
                                         }
                                         else
                                         {
-                                            @if (p.IsRequired)
+                                            if (!string.IsNullOrEmpty(p.Autocomplete))
                                             {
-                                                <textarea id="@p.Name" class="form-control" maxlength="@p.MaxLength" rows="@p.Rows" value="@GetProfileValue(p.Name, p.DefaultValue)" required @onchange="@(e => ProfileChanged(e, p.Name))"></textarea>
+                                                @if (p.IsRequired)
+                                                {
+                                                    <textarea id="@p.Name" class="form-control" maxlength="@p.MaxLength" rows="@p.Rows" value="@GetProfileValue(p.Name, p.DefaultValue)" required @onchange="@(e => ProfileChanged(e, p.Name))" autocomplete="@p.Autocomplete"></textarea>
+                                                }
+                                                else
+                                                {
+                                                    <textarea id="@p.Name" class="form-control" maxlength="@p.MaxLength" rows="@p.Rows" value="@GetProfileValue(p.Name, p.DefaultValue)" @onchange="@(e => ProfileChanged(e, p.Name))" autocomplete="@p.Autocomplete"></textarea>
+                                                }
                                             }
                                             else
                                             {
-                                                <textarea id="@p.Name" class="form-control" maxlength="@p.MaxLength" rows="@p.Rows" value="@GetProfileValue(p.Name, p.DefaultValue)" @onchange="@(e => ProfileChanged(e, p.Name))"></textarea>
+                                                @if (p.IsRequired)
+                                                {
+                                                    <textarea id="@p.Name" class="form-control" maxlength="@p.MaxLength" rows="@p.Rows" value="@GetProfileValue(p.Name, p.DefaultValue)" required @onchange="@(e => ProfileChanged(e, p.Name))"></textarea>
+                                                }
+                                                else
+                                                {
+                                                    <textarea id="@p.Name" class="form-control" maxlength="@p.MaxLength" rows="@p.Rows" value="@GetProfileValue(p.Name, p.DefaultValue)" @onchange="@(e => ProfileChanged(e, p.Name))"></textarea>
+                                                }
                                             }
                                         }
                                     }
@@ -360,10 +388,10 @@
                     photofileid = -1;
                     photo = null;
                 }
-                var sitesettings = await SettingService.GetSiteSettingsAsync(SiteState.Alias.SiteId);
-                _ImageFiles = SettingService.GetSetting(settings, "ImageFiles", Constants.ImageFiles);
 
                 settings = await SettingService.GetUserSettingsAsync(PageState.User.UserId);
+                var sitesettings = await SettingService.GetSiteSettingsAsync(SiteState.Alias.SiteId);
+                _ImageFiles = SettingService.GetSetting(settings, "ImageFiles", Constants.ImageFiles);
 
                 await LoadNotificationsAsync();
 
@@ -549,7 +577,7 @@
         try
         {
             ModuleInstance.ShowProgressIndicator();
-            foreach(var Notification in notifications)
+            foreach (var Notification in notifications)
             {
                 if (!Notification.IsDeleted)
                 {
@@ -561,12 +589,12 @@
                     await NotificationService.DeleteNotificationAsync(Notification.NotificationId);
                 }
                 await logger.LogInformation("Notification Deleted {Notification}", Notification);
-            } 
+            }
             await logger.LogInformation("Notifications Permanently Deleted");
             await LoadNotificationsAsync();
             ModuleInstance.HideProgressIndicator();
 
-            StateHasChanged();            
+            StateHasChanged();
         }
         catch (Exception ex)
         {
@@ -574,21 +602,20 @@
             AddModuleMessage(ex.Message, MessageType.Error);
             ModuleInstance.HideProgressIndicator();
         }
-    
+
     }
 
     private void TogglePassword()
-	{
-		if (_passwordtype == "password")
-		{
-			_passwordtype = "text";
-			_togglepassword = SharedLocalizer["HidePassword"];
-		}
-		else
-		{
-			_passwordtype = "password";
-			_togglepassword = SharedLocalizer["ShowPassword"];
-		}
-	}
-
+    {
+        if (_passwordtype == "password")
+        {
+            _passwordtype = "text";
+            _togglepassword = SharedLocalizer["HidePassword"];
+        }
+        else
+        {
+            _passwordtype = "password";
+            _togglepassword = SharedLocalizer["ShowPassword"];
+        }
+    }
 }

--- a/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
+++ b/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
@@ -36,7 +36,7 @@
                     <Label Class="col-sm-3" For="password" HelpText="If you wish to change your password you can enter it here. Please choose a sufficiently secure password." ResourceKey="Password"></Label>
                     <div class="col-sm-9">
                         <div class="input-group">
-                            <input id="password" name="password " type="@_passwordtype" class="form-control" @bind="@_password" autocomplete="new-password" />
+                            <input id="password" type="@_passwordtype" class="form-control" @bind="@_password" autocomplete="new-password" />
                             <button type="button" class="btn btn-secondary" @onclick="@TogglePassword" tabindex="-1">@_togglepassword</button>
                         </div>
                     </div>

--- a/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
+++ b/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
@@ -577,7 +577,7 @@
         try
         {
             ModuleInstance.ShowProgressIndicator();
-            foreach (var Notification in notifications)
+            foreach(var Notification in notifications)
             {
                 if (!Notification.IsDeleted)
                 {

--- a/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
+++ b/Oqtane.Client/Modules/Admin/UserProfile/Index.razor
@@ -103,21 +103,40 @@
                             <div class="row mb-1 align-items-center">
                                 <Label Class="col-sm-3" For="@p.Name" HelpText="@p.Description">@p.Title</Label>
                                     <div class="col-sm-9">
-                                        @if (!string.IsNullOrEmpty(p.Options))
+                                    @if (!string.IsNullOrEmpty(p.Options))
                                     {
-                                        <select id="@p.Name" class="form-select" @onchange="@(e => ProfileChanged(e, p.Name))">
-                                            @foreach (var option in p.Options.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
-                                            {
-                                                @if (GetProfileValue(p.Name, "") == option || (GetProfileValue(p.Name, "") == "" && p.DefaultValue == option))
+                                        @if (!string.IsNullOrEmpty(p.Autocomplete))
+                                        {
+                                            <select id="@p.Name" class="form-select" @onchange="@(e => ProfileChanged(e, p.Name))" autocomplete="@p.Autocomplete">
+                                                @foreach (var option in p.Options.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
                                                 {
-                                                    <option value="@option" selected>@option</option>
+                                                    @if (GetProfileValue(p.Name, "") == option || (GetProfileValue(p.Name, "") == "" && p.DefaultValue == option))
+                                                    {
+                                                        <option value="@option" selected>@option</option>
+                                                    }
+                                                    else
+                                                    {
+                                                        <option value="@option">@option</option>
+                                                    }
                                                 }
-                                                else
+                                            </select>
+                                        }
+                                        else
+                                        {
+                                            <select id="@p.Name" class="form-select" @onchange="@(e => ProfileChanged(e, p.Name))">
+                                                @foreach (var option in p.Options.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
                                                 {
-                                                    <option value="@option">@option</option>
+                                                    @if (GetProfileValue(p.Name, "") == option || (GetProfileValue(p.Name, "") == "" && p.DefaultValue == option))
+                                                    {
+                                                        <option value="@option" selected>@option</option>
+                                                    }
+                                                    else
+                                                    {
+                                                        <option value="@option">@option</option>
+                                                    }
                                                 }
-                                            }
-                                        </select>
+                                            </select>
+                                        }
                                     }
                                     else
                                     {

--- a/Oqtane.Client/Resources/Modules/Admin/Profiles/Edit.resx
+++ b/Oqtane.Client/Resources/Modules/Admin/Profiles/Edit.resx
@@ -195,4 +195,10 @@
   <data name="Rows.Text" xml:space="preserve">
     <value>Rows: </value>
   </data>
+    <data name="Autocomplete.HelpText" xml:space="preserve">
+    <value>Autocomplete setting for the property</value>
+  </data>
+  <data name="Autocomplete.Text" xml:space="preserve">
+    <value>Autocomplete: </value>
+  </data>
 </root>

--- a/Oqtane.Client/Resources/Modules/Admin/Profiles/Edit.resx
+++ b/Oqtane.Client/Resources/Modules/Admin/Profiles/Edit.resx
@@ -196,7 +196,7 @@
     <value>Rows: </value>
   </data>
     <data name="Autocomplete.HelpText" xml:space="preserve">
-    <value>Autocomplete setting for the property</value>
+    <value>The HTML autocomplete attribute allows you to specify browser behavior for automated assistance in filling out form field values, with a character limit of 30 to ensure concise and effective usage.</value>
   </data>
   <data name="Autocomplete.Text" xml:space="preserve">
     <value>Autocomplete: </value>

--- a/Oqtane.Server/Migrations/Tenant/05010003_AddProfileAutocomplete.cs
+++ b/Oqtane.Server/Migrations/Tenant/05010003_AddProfileAutocomplete.cs
@@ -17,7 +17,7 @@ namespace Oqtane.Migrations.Tenant
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             var profileEntityBuilder = new ProfileEntityBuilder(migrationBuilder, ActiveDatabase);
-            profileEntityBuilder.AddStringColumn("Autocomplete", 200, true);
+            profileEntityBuilder.AddStringColumn("Autocomplete", 50, true);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/Oqtane.Server/Migrations/Tenant/05010003_AddProfileAutocomplete.cs
+++ b/Oqtane.Server/Migrations/Tenant/05010003_AddProfileAutocomplete.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
+using Oqtane.Migrations.EntityBuilders;
+using Oqtane.Repository;
+
+namespace Oqtane.Migrations.Tenant
+{
+    [DbContext(typeof(TenantDBContext))]
+    [Migration("Tenant.05.00.01.03")]
+    public class AddProfileAutocomplete : MultiDatabaseMigration
+    {
+        public AddProfileAutocomplete(IDatabase database) : base(database)
+        {
+        }
+
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            var profileEntityBuilder = new ProfileEntityBuilder(migrationBuilder, ActiveDatabase);
+            profileEntityBuilder.AddStringColumn("Autocomplete", 200, true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // not implemented
+        }
+    }
+}

--- a/Oqtane.Shared/Models/Profile.cs
+++ b/Oqtane.Shared/Models/Profile.cs
@@ -78,5 +78,11 @@ namespace Oqtane.Models
         /// Optional number of rows (textarea)
         /// </summary>
         public int Rows { get; set; }
+
+        /// <summary>
+        /// Autocomplete setting for the property.
+        /// If set, enable autocomplete for the corresponding input field.
+        /// </summary>
+        public string Autocomplete { get; set; }
     }
 }


### PR DESCRIPTION
# Autocomplete Attribute Enhancement Pull Request

## Description

This PR implements the enhancement proposed in issue #[Issue_Number]: [Link to Enhancement Issue]

## Changes Made

- Added a new setting or property to profile properties to control the `autocomplete` attribute.
- Implemented the logic to conditionally include the `autocomplete` attribute based on the new setting.
- Also Adds the Autocomplete attribute for "name" and "email" to the user profile account tab input elements.

## Related Issue

Closes #3651 

## Screenshots
![image](https://github.com/oqtane/oqtane.framework/assets/13577556/7abfeeef-f126-4053-844f-c9bfb1f892d6)

![image](https://github.com/oqtane/oqtane.framework/assets/13577556/469ef014-2da8-4916-86a7-9ff3dd0bb98b)

## How to Test

1. Visit Profile Management
2. Add text to the autocomplete input
3. Visit your profile and view the source to see the autocomplete attributed added only if you have it set.  Blank will not generate the autocomplete attribute.


## Additional Context
I can set some default autocomplete settings for the default profile properties, or this can be done later or leave it to admins.

The order of where it is on the Profile Edit Form can be changed as well if requested.

This PR also refactored the code in the OnInitializedAsync method of the Index component to obtain user settings earlier, ensuring their availability for subsequent operations. `SettingService.GetUserSettingsAsync`
for input elements:
![image](https://github.com/oqtane/oqtane.framework/assets/13577556/d826b789-ea34-4481-87f6-471dbc9538fd)
for select elements:
![image](https://github.com/oqtane/oqtane.framework/assets/13577556/1616c14d-aa1e-4cf2-b3af-7dfe58e7056c)

If the autocomplete is empty, this is the result for an example:

![image](https://github.com/oqtane/oqtane.framework/assets/13577556/08e41b4b-02f1-4414-a6e3-b9e70a15bf9f)

notice no "autocomplete" attribute included.


Cheers!
