### PR TITLE
Updates request.status to request.statusText in Interop.js

### DIFF
--- a/Oqtane.Maui/wwwroot/js/interop.js
+++ b/Oqtane.Maui/wwwroot/js/interop.js
@@ -344,7 +344,7 @@ Oqtane.Interop = {
                 };
                 request.upload.onerror = function() {
                     if (progressinfo !== null && progressbar !== null) {
-                        progressinfo.innerHTML = file.name + ' Error: ' + request.status;
+                        progressinfo.innerHTML = file.name + ' Error: ' + request.statusText;
                         progressbar.value = 0;
                     }
                 };

--- a/Oqtane.Server/wwwroot/js/interop.js
+++ b/Oqtane.Server/wwwroot/js/interop.js
@@ -344,7 +344,7 @@ Oqtane.Interop = {
                 };
                 request.upload.onerror = function() {
                     if (progressinfo !== null && progressbar !== null) {
-                        progressinfo.innerHTML = file.name + ' Error: ' + request.status;
+                        progressinfo.innerHTML = file.name + ' Error: ' + request.statusText;
                         progressbar.value = 0;
                     }
                 };


### PR DESCRIPTION
This pull request simply updates the XLMHttpRequest to use `statusText` to provide a more helpful message of the request status instead of `status` which provides a number for the status.