### PR TITLE
Save file extension settings if set in UI to database Closes #3656 #3663

### DIFF
--- a/Oqtane.Client/Modules/Admin/Site/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Site/Index.razor
@@ -665,8 +665,13 @@
                         settings = SettingService.SetSetting(settings, "NotificationRetention", _retention.ToString(), true);
 
                         // file extensions
-                        settings = SettingService.SetSetting(settings, "ImageFiles", (_ImageFiles != Constants.ImageFiles) ? _ImageFiles.Replace(" ", "") : "", false);
-                        settings = SettingService.SetSetting(settings, "UploadableFiles", (_UploadableFiles != Constants.UploadableFiles) ? _UploadableFiles.Replace(" ", "") : "", false);
+                        // Check if _ImageFiles is null or empty, then use the constant
+                        settings = SettingService.SetSetting(settings, "ImageFiles",
+                            string.IsNullOrWhiteSpace(_ImageFiles) ? Constants.ImageFiles : _ImageFiles.Replace(" ", ""), false);
+
+                        // Check if _UploadableFiles is null or empty, then use the constant
+                        settings = SettingService.SetSetting(settings, "UploadableFiles",
+                            string.IsNullOrWhiteSpace(_UploadableFiles) ? Constants.UploadableFiles : _UploadableFiles.Replace(" ", ""), false);
 
 						await SettingService.UpdateSiteSettingsAsync(settings, site.SiteId);
 


### PR DESCRIPTION
This pr closes #3656 and #3663 and possibly #3560 (First issue reported with file uploads)

## Description

This updates the Admin\Site\Index.razor component to save settings shown in the UI into the related fields when clicking the "Save" button calling the `SaveSite()` method.


## Test

I tested the following scenarios with behaviors as described below:

- Empty String Save Site Settings : Behavior was Constants were used.
- String with default constants populated during save site settings : Behavior The defaults are in the UI and saved into the database whatever the constants are.  These are then used and saved into database which is used by the framework alraedy anytime it has a value.
- all different strings saved results in those comma separated values of extensions being allowed.
- set to file extension settings to something like `donotallow` and no files are allowed to be uploaded except those to lock down a site from allowing uploads if desired.

While testing these different scenarios check the settings in the database and review how they are saved.  Then review how the framework handles these settings saved by uploading files in both the site settings area and the User Profile page.

## Screenshots

## Additional Information

I believe in the past "known issues" and workarounds are posted in release notes for the DNN community:

Maybe a good idea to add this one to the [Oqtane Framework version 5.0.1 release notes](https://github.com/oqtane/oqtane.framework/releases/tag/v5.0.1)?

The workaround is to manually copy and paste the default constants into the database, or upgrade to the new patched version.  

Some upgrade logic may need executed to fix currently bugged sites.  Or at least a note again about having to save site settings once will resolve the issue.  The controller can handle this potentially by using constants handling null or empty as well resulting in added defensive logic.
