### PR TITLE
Removed unintended space added from PR #3692.

### DIFF
--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
@@ -99,7 +99,7 @@ div.app-moduleactions a.dropdown-toggle, div.app-moduleactions div.dropdown-menu
 @media (max-width: 767px) {
 
     .app-menu {
-        width: 100% ;
+        width: 100%;
     }
 
     .navbar {


### PR DESCRIPTION
#3692 adds an unnecessary space when adding the semi-colon to the width.

This pull request removes that space from the theme.css file.