### PR TITLE
Fixes #3736 Navbar bootstrap lg size responsive Theme CSS and MenuHorizontal.razor Theme UI Component

### DIFF
--- a/Oqtane.Client/Themes/Controls/Theme/MenuHorizontal.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/MenuHorizontal.razor
@@ -4,12 +4,12 @@
 
 @if (MenuPages.Any())
 {
-    <span class="app-menu-toggler navbar-expand-md">
+    <span class="app-menu-toggler navbar-expand-lg">
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#Menu" aria-controls="Menu" aria-expanded="false" aria-label="Toggle Navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
     </span>
-    <div class="app-menu navbar-expand-md">
+    <div class="app-menu navbar-expand-lg">
         <div class="collapse navbar-collapse navbar-nav-scroll" id="Menu">
             <MenuItemsHorizontal ParentPage="null" Pages="MenuPages" />
         </div>

--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
@@ -96,7 +96,7 @@ div.app-moduleactions a.dropdown-toggle, div.app-moduleactions div.dropdown-menu
     z-index: 1000;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 991.98px) {
 
     .app-menu {
         width: 100%;

--- a/Oqtane.Server/wwwroot/Themes/Templates/External/Client/wwwroot/Themes/[Owner].Theme.[Theme]/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Templates/External/Client/wwwroot/Themes/[Owner].Theme.[Theme]/Theme.css
@@ -90,7 +90,7 @@ div.app-moduleactions a.dropdown-toggle, div.app-moduleactions div.dropdown-menu
   mix-blend-mode: difference;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 991.98px) {
 
     .app-menu {
         width: 100%;


### PR DESCRIPTION
Fixes #3736

# Pull Request
The MenuHorizontal.razor theme UI component needs to allow more pages than 2 for a menu to even be worth having a horizontal menu for a feature by default.

Setting to the bootstrap `navbar-expand-lg` allows the menu to hold more page menu items prior to causing the menu items to fall into a new line making some page content less discoverable.

Also setting the CSS of the Oqtane Theme and Theme Creator Template to `@media (max-width: 991.98px) { ... }` will set the responsive behavior to the same as bootstrap defaults.

## Screenshots
This demonstrates the changes that this pull request introduces
![image](https://github.com/oqtane/oqtane.framework/assets/13577556/feaf4d3f-10f5-4df8-88fe-c5c4d42a0e90)

![image](https://github.com/oqtane/oqtane.framework/assets/13577556/62ef8402-42e9-4219-b931-4cc6971abf8d)

This demonstrates the changes that this pull request introduces.

The MenuHorizontal.razor theme UI component needs to allow more pages than 2 for a menu to even be worth having this feature.


## Additional Context
We should consider introducing parameter to set this from a theme if this is a breaking change.

`<MenuHorizontal Breakpoint="LG" />`

And

`<Menu Orientation="Horizontal" Breakpoint="LG" />`

For examples.

Or if developers are expected to create their own UI controls for their themes this should not be a breaking change, otherwise it will be.

We can at least set the break points to 767.98px for the media max-width to match bootstrap in the Theme.css files so the navbar will respond more as expected.