### PR TITLE
Fixes #3758 Updates Referenced Maui Packages To Latest

### DIFF
--- a/Oqtane.Maui/Oqtane.Maui.csproj
+++ b/Oqtane.Maui/Oqtane.Maui.csproj
@@ -71,8 +71,8 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.1" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Oqtane.Maui/Oqtane.Maui.csproj
+++ b/Oqtane.Maui/Oqtane.Maui.csproj
@@ -72,6 +72,7 @@
     <PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.1" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.6" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="8.0.6" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #3758

Updates Oqtane.Maui packages to the latest versions available.

I noticed when updating these I was also given another package:


```
  <ItemGroup>
    <PackageReference Update="Microsoft.Maui.Controls.Compatibility" Version="8.0.6" />
  </ItemGroup>

```

I went ahead an added    ` <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.6" />` to avoid needing to perform an update to get this included package to latest version.