### PR TITLE
Nav Element "controls-group" class styling - Fixes #3760, #3762

### DIFF
--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.BlazorTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.BlazorTheme/Theme.css
@@ -208,7 +208,7 @@ nav .controls-group {
     }
 }
 
-@media (max-width: 767px) {
+@media (max-width: 767.98px) {
     .app-logo {
         height: 80px;
         display: flex;

--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.BlazorTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.BlazorTheme/Theme.css
@@ -115,6 +115,10 @@ nav .controls-group {
     align-items: center;
 }
 
+    nav .controls-group .app-profile, .controls-group .app-login {
+        margin-right: 5px;
+    }
+
 .content {
     padding-top: 1.1rem;
 }

--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.BlazorTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.BlazorTheme/Theme.css
@@ -108,6 +108,13 @@
     color: white;
 }
 
+nav .controls-group {
+    display: flex;
+    justify-content: flex-end;
+    flex-wrap: nowrap;
+    align-items: center;
+}
+
 .content {
     padding-top: 1.1rem;
 }

--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
@@ -106,7 +106,7 @@ div.app-moduleactions a.dropdown-toggle, div.app-moduleactions div.dropdown-menu
     z-index: 1000;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 767.98px) {
 
     .app-menu {
         width: 100%

--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
@@ -47,7 +47,7 @@ body {
     margin-right: 10px;
 }
 
-nav.controls-group {
+nav .controls-group {
     display: flex;
     justify-content: flex-end;
     align-items: center;

--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
@@ -47,7 +47,7 @@ body {
     margin-right: 10px;
 }
 
-.controls-group {
+nav .controls-group {
     display: flex;
     justify-content: flex-end;
     flex-wrap: nowrap;

--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
@@ -54,6 +54,10 @@ nav .controls-group {
     flex-wrap: nowrap;
 }
 
+    nav .controls-group .app-profile, .controls-group .app-login {
+        margin-right: 5px;
+    }
+
 .app-menu .nav-item {
     font-size: 0.9rem;
     padding-bottom: 0.5rem;

--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
@@ -50,6 +50,7 @@ body {
 nav.controls-group {
     display: flex;
     justify-content: flex-end;
+    align-items: center;
     flex-wrap: nowrap;
 }
 

--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
@@ -47,7 +47,7 @@ body {
     margin-right: 10px;
 }
 
-nav .controls-group {
+nav.controls-group {
     display: flex;
     justify-content: flex-end;
     flex-wrap: nowrap;

--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
@@ -47,6 +47,12 @@ body {
     margin-right: 10px;
 }
 
+.controls-group {
+    display: flex;
+    justify-content: flex-end;
+    flex-wrap: nowrap;
+}
+
 .app-menu .nav-item {
     font-size: 0.9rem;
     padding-bottom: 0.5rem;

--- a/Oqtane.Server/wwwroot/Themes/Templates/External/Client/wwwroot/Themes/[Owner].Theme.[Theme]/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Templates/External/Client/wwwroot/Themes/[Owner].Theme.[Theme]/Theme.css
@@ -45,7 +45,7 @@ body {
     margin-right: 10px;
 }
 
-nav.controls-group {
+nav .controls-group {
     display: flex;
     justify-content: flex-end;
     flex-wrap: nowrap;

--- a/Oqtane.Server/wwwroot/Themes/Templates/External/Client/wwwroot/Themes/[Owner].Theme.[Theme]/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Templates/External/Client/wwwroot/Themes/[Owner].Theme.[Theme]/Theme.css
@@ -51,7 +51,9 @@ nav.controls-group {
     flex-wrap: nowrap;
     align-items: center;
 }
-
+    nav .controls-group .app-profile, .controls-group .app-login {
+        margin-right: 5px;
+    }
 
 .app-menu .nav-item {
     font-size: 0.9rem;

--- a/Oqtane.Server/wwwroot/Themes/Templates/External/Client/wwwroot/Themes/[Owner].Theme.[Theme]/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Templates/External/Client/wwwroot/Themes/[Owner].Theme.[Theme]/Theme.css
@@ -99,7 +99,7 @@ div.app-moduleactions a.dropdown-toggle, div.app-moduleactions div.dropdown-menu
   mix-blend-mode: difference;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 767.98px) {
 
     .app-menu {
         width: 100%

--- a/Oqtane.Server/wwwroot/Themes/Templates/External/Client/wwwroot/Themes/[Owner].Theme.[Theme]/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Templates/External/Client/wwwroot/Themes/[Owner].Theme.[Theme]/Theme.css
@@ -45,6 +45,14 @@ body {
     margin-right: 10px;
 }
 
+nav.controls-group {
+    display: flex;
+    justify-content: flex-end;
+    flex-wrap: nowrap;
+    align-items: center;
+}
+
+
 .app-menu .nav-item {
     font-size: 0.9rem;
     padding-bottom: 0.5rem;


### PR DESCRIPTION
### Pull Request

Closes #3760
Closes #3762

This pull request will style the controls used for login, profile, dashboard and edit buttons along with any relating elements.  This css styling addition will keep the buttons on the same line and to the right side of the mobile screen using Flexbox.

### Screenshots
![image](https://github.com/oqtane/oqtane.framework/assets/13577556/5034b5bc-168a-4829-a396-b5750bd8ef5c)
![image](https://github.com/oqtane/oqtane.framework/assets/13577556/a9f6bda6-8d53-4b90-aaeb-9e48ce8516c0)

### Additional Context

Added a 5px margin on the right side of each of the control spans with the forms to space the buttons apart.

![image](https://github.com/oqtane/oqtane.framework/assets/13577556/d9ca4dab-acef-4e86-9a04-be6c8db7def4)

This PR will also fix this issue with responsive behavior for the navbar md breakpoint.

![image](https://github.com/oqtane/oqtane.framework/assets/13577556/a314bb5a-b659-4b3c-a126-f11eb3bfc313)

This is similar to PR #3736 which is more of an enhancement and will need re-based once discussed further or closed as it works with same files as this PR.  I can redo that one later once discussed as it introduces the "lg" instead of "md"