### PR TITLE
Sets responsive breakpoint match 767.98px = Bootstrap md - Fixes #3762

### DIFF
--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.BlazorTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.BlazorTheme/Theme.css
@@ -197,7 +197,7 @@
     }
 }
 
-@media (max-width: 767px) {
+@media (max-width: 767.98px) {
     .app-logo {
         height: 80px;
         display: flex;

--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
@@ -96,7 +96,7 @@ div.app-moduleactions a.dropdown-toggle, div.app-moduleactions div.dropdown-menu
     z-index: 1000;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 767.98px) {
 
     .app-menu {
         width: 100%;

--- a/Oqtane.Server/wwwroot/Themes/Templates/External/Client/wwwroot/Themes/[Owner].Theme.[Theme]/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Templates/External/Client/wwwroot/Themes/[Owner].Theme.[Theme]/Theme.css
@@ -90,7 +90,7 @@ div.app-moduleactions a.dropdown-toggle, div.app-moduleactions div.dropdown-menu
   mix-blend-mode: difference;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 767.98px) {
 
     .app-menu {
         width: 100%;


### PR DESCRIPTION
Closes #3762

This PR will set the break point for all CSS themes and theme creator to bootstrap md max-width of 767.98px.