### PR TITLE
Updates bootswatch and bootstrap to latest version 5.3.2 Closes #3772

### DIFF
--- a/Oqtane.Client/Themes/OqtaneTheme/ThemeInfo.cs
+++ b/Oqtane.Client/Themes/OqtaneTheme/ThemeInfo.cs
@@ -16,9 +16,9 @@ namespace Oqtane.Themes.OqtaneTheme
             ContainerSettingsType = "Oqtane.Themes.OqtaneTheme.ContainerSettings, Oqtane.Client",
             Resources = new List<Resource>()
             {
-                new Resource { ResourceType = ResourceType.Stylesheet, Url = "https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.0/cyborg/bootstrap.rtl.min.css", Integrity = "sha512-weOvppLcPYEPmC4uewvFOgCaKchw0D988+kEjSWrGHeHqqV9AwWj1M6e8PZAVDBn2WDStDpLm9oAIvoZcQqPZg==", CrossOrigin = "anonymous" },
+                new Resource { ResourceType = ResourceType.Stylesheet, Url = "https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.2/cyborg/bootstrap.rtl.min.css", Integrity = "sha512-weOvppLcPYEPmC4uewvFOgCaKchw0D988+kEjSWrGHeHqqV9AwWj1M6e8PZAVDBn2WDStDpLm9oAIvoZcQqPZg==", CrossOrigin = "anonymous" },
                 new Resource { ResourceType = ResourceType.Stylesheet, Url = "~/Theme.css" },
-                new Resource { ResourceType = ResourceType.Script, Url = "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/js/bootstrap.bundle.min.js", Integrity = "sha512-WW8/jxkELe2CAiE4LvQfwm1rajOS8PHasCCx+knHG0gBHt8EXxS6T6tJRTGuDQVnluuAvMxWF4j8SNFDKceLFg==", CrossOrigin = "anonymous" }
+                new Resource { ResourceType = ResourceType.Script, Url = "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.2/js/bootstrap.bundle.min.js", Integrity = "sha512-WW8/jxkELe2CAiE4LvQfwm1rajOS8PHasCCx+knHG0gBHt8EXxS6T6tJRTGuDQVnluuAvMxWF4j8SNFDKceLFg==", CrossOrigin = "anonymous" }
             }
         };
     }

--- a/Oqtane.Client/Themes/OqtaneTheme/ThemeInfo.cs
+++ b/Oqtane.Client/Themes/OqtaneTheme/ThemeInfo.cs
@@ -16,9 +16,9 @@ namespace Oqtane.Themes.OqtaneTheme
             ContainerSettingsType = "Oqtane.Themes.OqtaneTheme.ContainerSettings, Oqtane.Client",
             Resources = new List<Resource>()
             {
-                new Resource { ResourceType = ResourceType.Stylesheet, Url = "https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.0/cyborg/bootstrap.min.css", Integrity = "sha512-jwIqEv8o/kTBMJVtbNCBrDqhBojl0YSUam+EFpLjVOC86Ci6t4ZciTnIkelFNOik+dEQVymKGcQLiaJZNAfWRg==", CrossOrigin = "anonymous" },
+                new Resource { ResourceType = ResourceType.Stylesheet, Url = "https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.3.0/cyborg/bootstrap.rtl.min.css", Integrity = "sha512-weOvppLcPYEPmC4uewvFOgCaKchw0D988+kEjSWrGHeHqqV9AwWj1M6e8PZAVDBn2WDStDpLm9oAIvoZcQqPZg==", CrossOrigin = "anonymous" },
                 new Resource { ResourceType = ResourceType.Stylesheet, Url = "~/Theme.css" },
-                new Resource { ResourceType = ResourceType.Script, Url = "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/js/bootstrap.bundle.min.js", Integrity = "sha512-VK2zcvntEufaimc+efOYi622VN5ZacdnufnmX7zIhCPmjhKnOi9ZDMtg1/ug5l183f19gG1/cBstPO4D8N/Img==", CrossOrigin = "anonymous" }
+                new Resource { ResourceType = ResourceType.Script, Url = "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/js/bootstrap.bundle.min.js", Integrity = "sha512-WW8/jxkELe2CAiE4LvQfwm1rajOS8PHasCCx+knHG0gBHt8EXxS6T6tJRTGuDQVnluuAvMxWF4j8SNFDKceLFg==", CrossOrigin = "anonymous" }
             }
         };
     }

--- a/Oqtane.Server/wwwroot/Themes/Templates/External/Client/ThemeInfo.cs
+++ b/Oqtane.Server/wwwroot/Themes/Templates/External/Client/ThemeInfo.cs
@@ -17,9 +17,9 @@ namespace [Owner].Theme.[Theme]
             Resources = new List<Resource>()
             {
 		        // obtained from https://cdnjs.com/libraries
-                new Resource { ResourceType = ResourceType.Stylesheet, Url = "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/css/bootstrap.min.css", Integrity = "sha512-t4GWSVZO1eC8BM339Xd7Uphw5s17a86tIZIj8qRxhnKub6WoyhnrxeCIMeAqBPgdZGlCcG2PrZjMc+Wr78+5Xg==", CrossOrigin = "anonymous" },
+                new Resource { ResourceType = ResourceType.Stylesheet, Url = "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.2/css/bootstrap.rtl.min.css", Integrity = "sha512-weOvppLcPYEPmC4uewvFOgCaKchw0D988+kEjSWrGHeHqqV9AwWj1M6e8PZAVDBn2WDStDpLm9oAIvoZcQqPZg==", CrossOrigin = "anonymous" },
                 new Resource { ResourceType = ResourceType.Stylesheet, Url = "~/Theme.css" },
-                new Resource { ResourceType = ResourceType.Script, Url = "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/js/bootstrap.bundle.min.js", Integrity = "sha512-VK2zcvntEufaimc+efOYi622VN5ZacdnufnmX7zIhCPmjhKnOi9ZDMtg1/ug5l183f19gG1/cBstPO4D8N/Img==", CrossOrigin = "anonymous" }
+                new Resource { ResourceType = ResourceType.Script, Url = "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.2/js/bootstrap.bundle.min.js", Integrity = "sha512-WW8/jxkELe2CAiE4LvQfwm1rajOS8PHasCCx+knHG0gBHt8EXxS6T6tJRTGuDQVnluuAvMxWF4j8SNFDKceLFg==", CrossOrigin = "anonymous" }
             }
         };
 

--- a/Oqtane.Server/wwwroot/Themes/Templates/External/Client/ThemeInfo.cs
+++ b/Oqtane.Server/wwwroot/Themes/Templates/External/Client/ThemeInfo.cs
@@ -17,7 +17,7 @@ namespace [Owner].Theme.[Theme]
             Resources = new List<Resource>()
             {
 		        // obtained from https://cdnjs.com/libraries
-                new Resource { ResourceType = ResourceType.Stylesheet, Url = "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.2/css/bootstrap.rtl.min.css", Integrity = "sha512-weOvppLcPYEPmC4uewvFOgCaKchw0D988+kEjSWrGHeHqqV9AwWj1M6e8PZAVDBn2WDStDpLm9oAIvoZcQqPZg==", CrossOrigin = "anonymous" },
+                new Resource { ResourceType = ResourceType.Stylesheet, Url = "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.2/css/bootstrap.min.css", Integrity = "sha512-ZuRTqfQ3jNAKvJskDAU/hxbX1w25g41bANOVd1Co6GahIe2XjM6uVZ9dh0Nt3KFCOA061amfF2VeL60aJXdwwQ==", CrossOrigin = "anonymous" },
                 new Resource { ResourceType = ResourceType.Stylesheet, Url = "~/Theme.css" },
                 new Resource { ResourceType = ResourceType.Script, Url = "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.2/js/bootstrap.bundle.min.js", Integrity = "sha512-WW8/jxkELe2CAiE4LvQfwm1rajOS8PHasCCx+knHG0gBHt8EXxS6T6tJRTGuDQVnluuAvMxWF4j8SNFDKceLFg==", CrossOrigin = "anonymous" }
             }


### PR DESCRIPTION
Closes #3772

Updates bootstrap and bootswatch cyborg to latest 5.3.2 version in Oqtane and Theme Creator themes.

Prior to merging this we need to look into an issue with control-group justified to the left as shown here:

![image](https://github.com/oqtane/oqtane.framework/assets/13577556/5858c985-5a81-463f-98c9-6fecd8ffba7b)

![image](https://github.com/oqtane/oqtane.framework/assets/13577556/8a42a611-39c4-4aca-a88d-b83617bba42e)

I can create another issue if preferred or discuss on this PR or related issue.

All looks good when in responsive screen size below 768px.

![image](https://github.com/oqtane/oqtane.framework/assets/13577556/9bb7577f-f10a-4db1-9f48-03bc16bf09c7)
___

Close Dialog X also

![image](https://github.com/oqtane/oqtane.framework/assets/13577556/498a2182-878e-420a-89ae-54d8c1bc05d4)
