### PR TITLE
Oqtane.Maui - Updates To New Namespace For DynamicComponent Type Oqtane.UI.Head - Fixes #3753

### DIFF
--- a/Oqtane.Maui/Head.razor
+++ b/Oqtane.Maui/Head.razor
@@ -1,6 +1,6 @@
 <DynamicComponent Type="@ComponentType"></DynamicComponent>
 
 @code {
-	Type ComponentType = Type.GetType("Oqtane.Head, Oqtane.Client");
+	Type ComponentType = Type.GetType("Oqtane.UI.Head, Oqtane.Client");
 }
 


### PR DESCRIPTION
Closes #3753

This PR updates Oqtane.Maui namespace used for the dynamic component type utilizing the Head.razor component to reflect it's recent namespace change introduced during version 5.0.3 updates.