### PR TITLE
Handle missing/deleted themes and default to default theme #3801

### DIFF
--- a/Oqtane.Client/Modules/Admin/Pages/Edit.razor
+++ b/Oqtane.Client/Modules/Admin/Pages/Edit.razor
@@ -397,6 +397,10 @@
                 }
                 _themes = ThemeService.GetThemeControls(PageState.Site.Themes);
                 _containers = ThemeService.GetContainerControls(PageState.Site.Themes, _themetype);
+                if (_containers == null)
+                {
+                    _containers = new List<ThemeControl>();   
+                }
                 _containertype = _page.DefaultContainerType;
                 if (string.IsNullOrEmpty(_containertype))
                 {

--- a/Oqtane.Server/Components/App.razor
+++ b/Oqtane.Server/Components/App.razor
@@ -169,6 +169,8 @@
                         page.ThemeType = site.DefaultThemeType;
                     }
                     var theme = themes.FirstOrDefault(item => item.Themes.Any(item => item.TypeName == page.ThemeType));
+                    if (theme == null)
+                        theme = themes.First();
                     if (theme?.Resources != null)
                     {
                         resources.AddRange(theme.Resources);


### PR DESCRIPTION
Changes to App.razor: when theme is missing/deleted use the default/first theme
changes to  edit page: handle null containers list to keep the page working for admin to switch to another theme