### PR TITLE
Ensure "login" route is included in login URL construction. Fixes #3766

### DIFF
--- a/Oqtane.Client/Themes/Controls/Theme/LoginBase.cs
+++ b/Oqtane.Client/Themes/Controls/Theme/LoginBase.cs
@@ -52,7 +52,7 @@ namespace Oqtane.Themes.Controls
             else
             {
                 // use existing value
-                loginurl = "?returnurl=" + PageState.QueryString["returnurl"];
+                loginurl += "?returnurl=" + PageState.QueryString["returnurl"];
             }
 
             // set logout url


### PR DESCRIPTION
Fixes #3766

This change ensures that the login URL construction in the `LoginBase` class properly includes the `login` route when appropriate. Previously, the login URL was missing the "login" part, leading to incorrect navigation behavior. By using `+=` instead of `=`, we preserve the login button control appended "login" route to the existing return URL, resolving the issue.