### PR TITLE
Fix handling of returnurl parameter in UserProfile component - Fixes #3825

### DIFF
--- a/Oqtane.Client/Themes/Controls/Theme/UserProfile.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/UserProfile.razor
@@ -31,7 +31,16 @@
 
     protected override void OnParametersSet()
     {
-        _returnurl = WebUtility.UrlEncode(PageState.Route.PathAndQuery);
+		if (!PageState.QueryString.ContainsKey("returnurl"))
+		{
+			// remember current url
+			_returnurl += WebUtility.UrlEncode(PageState.Route.PathAndQuery);
+		}
+		else
+		{
+			// use existing value
+			_returnurl += PageState.QueryString["returnurl"];
+		}
     }
 }
 


### PR DESCRIPTION
This pull request fixes the handling of the returnurl parameter in the UserProfile component. Previously, the returnurl parameter was being incorrectly appended multiple times in the URL, leading to unintended behavior. The issue has been addressed by properly checking for the existence of the returnurl parameter and appending it only once if necessary.

Changes Made:
- Modified the `OnParametersSet` method in the `UserProfile` UI control component to handle the `returnurl` parameter correctly
- Ensured that the returnurl parameter is appended only once, preventing duplication in the URL

Resolves: #3825
