### PR TITLE
Fixes #3863 - refreshes page if site name is updated in site settings.

### DIFF
--- a/Oqtane.Client/Modules/Admin/Site/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Site/Index.razor
@@ -582,7 +582,13 @@
                         bool refresh = false;
                         bool reload = false;
 
+						// title
+						if (site.Name != _name)
+						{
+							refresh = true; // needs to be refreshed on client
+						}
                         site.Name = _name;
+
                         site.HomePageId = (_homepageid != "-" ? int.Parse(_homepageid) : null);
                         site.IsDeleted = (_isdeleted == null ? true : Boolean.Parse(_isdeleted));
 


### PR DESCRIPTION
Fixes #3863 - 
Adds if statement to check if the name of the site has been updated, and if so to set the boolean to refresh the page in the `SaveSite() `method.

### Additional Context

It looks like we are moving in the direction of a complete page reload on the SaveSite and SavePage methods relating logic.

I have removed the refresh/reload logic and done this both ways now.  Wondering now which would be the acceptable way as they both deliver similar results?

`NavigationManager.NavigateTo(NavigateUrl(), true); // refresh/reload`
						
or
						
`NavigationManager.NavigateTo(NavigateUrl(true), true); // refresh/reload`

Last is how to properly supply a boolean on if to display a message at the top on a reload stating site settings have been saved?

`AddModuleMessage(Localizer["Success.Settings.SaveSite"], MessageType.Success);`

If anything would be the issue to work out.  Otherwise the page refreshing and noticing the form is updated along with any appearances should be verification enough.
