### PR TITLE
handle focus error on blazor web assembly when verifying email address

### DIFF
--- a/Oqtane.Client/Modules/Admin/Login/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Login/Index.razor
@@ -166,7 +166,8 @@
     {
         if (firstRender && PageState.User == null && _allowsitelogin)
         {
-            await username.FocusAsync();
+            if(!string.IsNullOrEmpty(username.Id))
+                await username.FocusAsync();
         }
 
         // redirect logged in user to specified page


### PR DESCRIPTION
How to reproduce:
1- set the site render mode to blazor web assembly
2- register as new user 
3- Open the email verification link 

result:
Error : System.AggregateException: One or more errors occurred. (ElementReference has not been configured correctly.)
 ---> System.InvalidOperationException: ElementReference has not been configured correctly.
   at Microsoft.AspNetCore.Components.ElementReferenceExtensions.GetJSRuntime(ElementReference elementReference)
   at Microsoft.AspNetCore.Components.ElementReferenceExtensions.FocusAsync(ElementReference elementReference, Boolean preventScroll)
   at Microsoft.AspNetCore.Components.ElementReferenceExtensions.FocusAsync(ElementReference elementReference)
   at Oqtane.Modules.Admin.Login.Index.OnAfterRenderAsync(Boolean firstRender) in C:\server\opensource\Oqtane\oqtane.framework\Oqtane.Client\Modules\Admin\Login\Index.razor:line 182
   --- End of inner exception stack trace ---

solution for now:
handle the null reference of the username element reference