### PR TITLE
Additional Fix For #3868 - Static Render hosting model sets navigation menu items theme control data-enhance-nav attribute to false.

### DIFF
--- a/Oqtane.Client/Themes/Controls/Theme/MenuItemsHorizontal.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/MenuItemsHorizontal.razor
@@ -13,7 +13,7 @@
             {
                 _attributes.Add("target", _target);
             }
-            if (PageState.RenderMode == RenderModes.Static)
+		    if (PageState.RenderMode == RenderModes.Static && PageState.Page.ThemeType != childPage.ThemeType)
             {
                 _attributes.Add("data-enhance-nav", "false");
             }
@@ -50,7 +50,7 @@ else
             {
                 _attributes.Add("target", _target);
             }
-            if (PageState.RenderMode == RenderModes.Static)
+            if (PageState.RenderMode == RenderModes.Static && PageState.Page.ThemeType != childPage.ThemeType)
             {
                 _attributes.Add("data-enhance-nav", "false");
             }

--- a/Oqtane.Client/Themes/Controls/Theme/MenuItemsHorizontal.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/MenuItemsHorizontal.razor
@@ -13,7 +13,7 @@
             {
                 _attributes.Add("target", _target);
             }
-            if (!string.IsNullOrEmpty(childPage.ThemeType))
+            if (PageState.RenderMode == RenderModes.Static)
             {
                 _attributes.Add("data-enhance-nav", "false");
             }
@@ -50,7 +50,7 @@ else
             {
                 _attributes.Add("target", _target);
             }
-            if (!string.IsNullOrEmpty(childPage.ThemeType))
+            if (PageState.RenderMode == RenderModes.Static)
             {
                 _attributes.Add("data-enhance-nav", "false");
             }

--- a/Oqtane.Client/Themes/Controls/Theme/MenuItemsVertical.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/MenuItemsVertical.razor
@@ -12,7 +12,7 @@
         {
             _attributes.Add("target", _target);
         }
-        if (!string.IsNullOrEmpty(childPage.ThemeType))
+        if (PageState.RenderMode == RenderModes.Static)
         {
             _attributes.Add("data-enhance-nav", "false");
         }
@@ -56,7 +56,7 @@ else
             {
                 _attributes.Add("target", _target);
             }
-            if (!string.IsNullOrEmpty(childPage.ThemeType))
+            if (PageState.RenderMode == RenderModes.Static)
             {
                 _attributes.Add("data-enhance-nav", "false");
             }

--- a/Oqtane.Client/Themes/Controls/Theme/MenuItemsVertical.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/MenuItemsVertical.razor
@@ -12,7 +12,7 @@
         {
             _attributes.Add("target", _target);
         }
-        if (PageState.RenderMode == RenderModes.Static)
+        if (PageState.RenderMode == RenderModes.Static && PageState.Page.ThemeType != childPage.ThemeType)
         {
             _attributes.Add("data-enhance-nav", "false");
         }
@@ -56,7 +56,7 @@ else
             {
                 _attributes.Add("target", _target);
             }
-            if (PageState.RenderMode == RenderModes.Static)
+            if (PageState.RenderMode == RenderModes.Static && PageState.Page.ThemeType != childPage.ThemeType)
             {
                 _attributes.Add("data-enhance-nav", "false");
             }


### PR DESCRIPTION
This is a fix on top of #3881 and resolves issues last discussed in issue #3868 by changing the conditional check to render mode rather than if there is a theme on page.  This ensures the page is always refreshed in browser displaying the page theme that is set (or not then use site default) with only the correct css library while logged in administrator/host.

Changes:
`if (!string.IsNullOrEmpty(childPage.ThemeType))`
To:
`if (PageState.RenderMode == RenderModes.Static)`

![image](https://github.com/oqtane/oqtane.framework/assets/13577556/48035968-deed-40c2-ab1f-2bfa5730cc68)

We can come up with a more elaborate conditional, such as if navigating from pages that themes are not the same.  However this solution always ensure the page will be loaded with fresh results if running in static render mode.