### PR TITLE
 Improved Pager Search Input Text Field Autocomplete Behavior

### DIFF
--- a/Oqtane.Client/Modules/Controls/Pager.razor
+++ b/Oqtane.Client/Modules/Controls/Pager.razor
@@ -8,13 +8,13 @@
 {
     @if (!string.IsNullOrEmpty(SearchProperties))
     {
-        @* <form autocomplete="off"> *@
+        <form autocomplete="off">
             <div class="input-group my-3">
-                <input type="text" autocomplete="off" id="search" class="form-control" placeholder=@string.Format(Localizer["SearchPlaceholder"], FormatSearchProperties()) @bind="@_search" />
+            <input type="text" id="pagersearch" class="form-control" placeholder=@string.Format(Localizer["SearchPlaceholder"], FormatSearchProperties()) @bind="@_search" />
                 <button type="button" class="btn btn-primary" @onclick="Search">@SharedLocalizer["Search"]</button>
                 <button type="button" class="btn btn-secondary" @onclick="Reset">@SharedLocalizer["Reset"]</button>
             </div>
-        @* </form> *@
+        </form>
     }
 
     @if ((Toolbar == "Top" || Toolbar == "Both") && _pages > 0 && Items.Count() > _maxItems)

--- a/Oqtane.Client/Modules/Controls/Pager.razor
+++ b/Oqtane.Client/Modules/Controls/Pager.razor
@@ -8,11 +8,13 @@
 {
     @if (!string.IsNullOrEmpty(SearchProperties))
     {
-        <div class="input-group my-3">
-            <input id="search" class="form-control" placeholder=@string.Format(Localizer["SearchPlaceholder"], FormatSearchProperties()) @bind="@_search" />
-            <button type="button" class="btn btn-primary" @onclick="Search">@SharedLocalizer["Search"]</button>
-            <button type="button" class="btn btn-secondary" @onclick="Reset">@SharedLocalizer["Reset"]</button>
-        </div>
+        @* <form autocomplete="off"> *@
+            <div class="input-group my-3">
+                <input type="text" autocomplete="off" id="search" class="form-control" placeholder=@string.Format(Localizer["SearchPlaceholder"], FormatSearchProperties()) @bind="@_search" />
+                <button type="button" class="btn btn-primary" @onclick="Search">@SharedLocalizer["Search"]</button>
+                <button type="button" class="btn btn-secondary" @onclick="Reset">@SharedLocalizer["Reset"]</button>
+            </div>
+        @* </form> *@
     }
 
     @if ((Toolbar == "Top" || Toolbar == "Both") && _pages > 0 && Items.Count() > _maxItems)


### PR DESCRIPTION
This pull request enhances the behavior of the search input text field by disabling the browser’s autocomplete feature. Here’s why I’ve opted for the <form> tag approach:

**Form-Level Control:**
By placing autocomplete="off" on the <form> tag, we ensure consistent behavior across all input fields within the form. Although only one field, adding it to the Input control gives strange effects across browsers.

**Edge Compatibility:**
As mentioned earlier, Edge 18 has limited support for autocomplete="off".
By setting it at the form level, we address this issue globally for all browsers, including Edge.

**Why This Matters:**
Improved user experience: Users won’t be distracted by irrelevant autofill suggestions.
Consistency: The search input field now behaves uniformly across browsers.

**Note for Edge Users:**
While autocomplete="off" works as expected in Chrome and Firefox, it may have limited support in Edge (specifically Edge 18). Users of Edge 18 are advised to disable autofill from the browser settings directly.