### PR TITLE
updating ImageSharp to latest

### DIFF
--- a/Oqtane.Server/Oqtane.Server.csproj
+++ b/Oqtane.Server/Oqtane.Server.csproj
@@ -42,7 +42,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.2" />
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="8.0.2" />


### PR DESCRIPTION
I have spoken to the maintainer of ImageSharp:

"If a user downloads Oqtane, the version of ImageSharp bundled with Oqtane is licensed to the user under the terms of the Apache 2.0 license as that was the license Oqtane consumes the library under. This means their consumption is transitive ie. they have the right to use ImageSharp under the Apache 2.0 license as long as it is used in conjunction with Oqtane. If the user downloads a version of ImageSharp that replaces the version bundled with Oqtane then their consumption becomes direct and they are subject to the terms of the license. "

So this means ImageSharp can be safely upgraded to the latest version without any licensing concerns - as Oqtane is able to include it under the Apache 2.0 license (which is compatible with the MIT license as they are both permissive).
