### PR TITLE
_text being set and resetting other options

### DIFF
--- a/Oqtane.Client/Modules/Controls/ActionLink.razor
+++ b/Oqtane.Client/Modules/Controls/ActionLink.razor
@@ -100,7 +100,7 @@
         _text = Action;
         if (!string.IsNullOrEmpty(Text))
         {
-            _text = Text;
+            _text = Localize(nameof(Text), _text);
         }
 
         if (IconOnly && !string.IsNullOrEmpty(IconName))
@@ -150,7 +150,6 @@
         }
 
 		_permissions = (PermissionList == null) ? ModuleState.PermissionList : PermissionList;
-		_text = Localize(nameof(Text), _text);
 
 		_url = EditUrl(_path, _moduleId, Action, _parameters);
 		if (!string.IsNullOrEmpty(ReturnUrl))


### PR DESCRIPTION
if (IconOnly && !string.IsNullOrEmpty(IconName)) was not having an impact as the _text variable was being reset.

This fix allows the ActionLink to display just the Icon