### PR TITLE
Fixes 4012: Quill bootstrap theme support

### DIFF
--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.BlazorTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.BlazorTheme/Theme.css
@@ -117,6 +117,35 @@
     margin: .5rem;
 }
 
+/* Oqtane Quill Rich Text Editor Toolbar */
+.ql-editor, .ql-toolbar, .ql-picker-options, .ql-picker-label {
+    background-color: var(--bs-body-bg) !important;
+    color: var(--bs-body-color) !important;
+}
+
+    ql-toolbar button:hover .ql-stroke, .ql-toolbar button:hover .ql-stroke, .ql-toolbar button:focus .ql-stroke, .ql-toolbar button:focus .ql-stroke, .ql-toolbar button.ql-active .ql-stroke, .ql-toolbar button.ql-active .ql-stroke, .ql-toolbar .ql-picker-label:hover .ql-stroke, .ql-toolbar .ql-picker-label:hover .ql-stroke, .ql-toolbar .ql-picker-label.ql-active .ql-stroke, .ql-toolbar .ql-picker-label.ql-active .ql-stroke, .ql-toolbar .ql-picker-item:hover .ql-stroke, .ql-toolbar .ql-picker-item:hover .ql-stroke, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke, .ql-toolbar button:hover .ql-stroke-miter, .ql-toolbar button:hover .ql-stroke-miter, .ql-toolbar button:focus .ql-stroke-miter, .ql-toolbar button:focus .ql-stroke-miter, .ql-toolbar button.ql-active .ql-stroke-miter, .ql-toolbar button.ql-active .ql-stroke-miter, .ql-toolbar .ql-picker-label:hover .ql-stroke-miter, .ql-toolbar .ql-picker-label:hover .ql-stroke-miter, .ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter, .ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter, .ql-toolbar .ql-picker-item:hover .ql-stroke-miter, .ql-toolbar .ql-picker-item:hover .ql-stroke-miter, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter {
+        stroke: var(--bs-link-hover-color) !important;
+    }
+
+    ql-toolbar button .ql-stroke, .ql-toolbar button .ql-stroke, .ql-toolbar button:focus .ql-stroke, .ql-toolbar button:focus .ql-stroke, .ql-toolbar button.ql-active .ql-stroke, .ql-toolbar button.ql-active .ql-stroke, .ql-toolbar .ql-picker-label .ql-stroke, .ql-toolbar .ql-picker-label .ql-stroke, .ql-toolbar .ql-picker-label.ql-active .ql-stroke, .ql-toolbar .ql-picker-label.ql-active .ql-stroke, .ql-toolbar .ql-picker-item .ql-stroke, .ql-toolbar .ql-picker-item .ql-stroke, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke, .ql-toolbar button .ql-stroke-miter, .ql-toolbar button .ql-stroke-miter, .ql-toolbar button:focus .ql-stroke-miter, .ql-toolbar button:focus .ql-stroke-miter, .ql-toolbar button.ql-active .ql-stroke-miter, .ql-toolbar button.ql-active .ql-stroke-miter, .ql-toolbar .ql-picker-label .ql-stroke-miter, .ql-toolbar .ql-picker-label .ql-stroke-miter, .ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter, .ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter, .ql-toolbar .ql-picker-item .ql-stroke-miter, .ql-toolbar .ql-picker-item .ql-stroke-miter, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter {
+        stroke: var(--bs-body-color) !important;
+    }
+
+    /* Oqtane Quill Rich Text Editor WYSIWYG Content */
+    .ql-editor a {
+        color: var(--bs-link-color) !important;
+    }
+
+        .ql-editor a:hover {
+            color: var(--bs-link-hover-color) !important;
+        }
+
+        
+        .ql-editor a.btn, .ql-editor a.btn:hover {
+            text-decoration: unset !important;
+            color: var(--bs-btn-color) !important;
+        }
+
 @media (max-width: 767.98px) {
     .main .top-row {
         display: none;

--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
@@ -96,6 +96,35 @@ div.app-moduleactions a.dropdown-toggle, div.app-moduleactions div.dropdown-menu
     z-index: 1000;
 }
 
+/* Oqtane Quill Rich Text Editor Toolbar */
+.ql-editor, .ql-toolbar, .ql-picker-options, .ql-picker-label {
+    background-color: var(--bs-body-bg) !important;
+    color: var(--bs-body-color) !important;
+}
+
+    ql-toolbar button:hover .ql-stroke, .ql-toolbar button:hover .ql-stroke, .ql-toolbar button:focus .ql-stroke, .ql-toolbar button:focus .ql-stroke, .ql-toolbar button.ql-active .ql-stroke, .ql-toolbar button.ql-active .ql-stroke, .ql-toolbar .ql-picker-label:hover .ql-stroke, .ql-toolbar .ql-picker-label:hover .ql-stroke, .ql-toolbar .ql-picker-label.ql-active .ql-stroke, .ql-toolbar .ql-picker-label.ql-active .ql-stroke, .ql-toolbar .ql-picker-item:hover .ql-stroke, .ql-toolbar .ql-picker-item:hover .ql-stroke, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke, .ql-toolbar button:hover .ql-stroke-miter, .ql-toolbar button:hover .ql-stroke-miter, .ql-toolbar button:focus .ql-stroke-miter, .ql-toolbar button:focus .ql-stroke-miter, .ql-toolbar button.ql-active .ql-stroke-miter, .ql-toolbar button.ql-active .ql-stroke-miter, .ql-toolbar .ql-picker-label:hover .ql-stroke-miter, .ql-toolbar .ql-picker-label:hover .ql-stroke-miter, .ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter, .ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter, .ql-toolbar .ql-picker-item:hover .ql-stroke-miter, .ql-toolbar .ql-picker-item:hover .ql-stroke-miter, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter {
+        stroke: var(--bs-link-hover-color) !important;
+    }
+
+    ql-toolbar button .ql-stroke, .ql-toolbar button .ql-stroke, .ql-toolbar button:focus .ql-stroke, .ql-toolbar button:focus .ql-stroke, .ql-toolbar button.ql-active .ql-stroke, .ql-toolbar button.ql-active .ql-stroke, .ql-toolbar .ql-picker-label .ql-stroke, .ql-toolbar .ql-picker-label .ql-stroke, .ql-toolbar .ql-picker-label.ql-active .ql-stroke, .ql-toolbar .ql-picker-label.ql-active .ql-stroke, .ql-toolbar .ql-picker-item .ql-stroke, .ql-toolbar .ql-picker-item .ql-stroke, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke, .ql-toolbar button .ql-stroke-miter, .ql-toolbar button .ql-stroke-miter, .ql-toolbar button:focus .ql-stroke-miter, .ql-toolbar button:focus .ql-stroke-miter, .ql-toolbar button.ql-active .ql-stroke-miter, .ql-toolbar button.ql-active .ql-stroke-miter, .ql-toolbar .ql-picker-label .ql-stroke-miter, .ql-toolbar .ql-picker-label .ql-stroke-miter, .ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter, .ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter, .ql-toolbar .ql-picker-item .ql-stroke-miter, .ql-toolbar .ql-picker-item .ql-stroke-miter, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter {
+        stroke: var(--bs-body-color) !important;
+    }
+
+    /* Oqtane Quill Rich Text Editor WYSIWYG Content */
+    .ql-editor a {
+        color: var(--bs-link-color) !important;
+    }
+
+        .ql-editor a:hover {
+            color: var(--bs-link-hover-color) !important;
+        }
+
+        
+        .ql-editor a.btn, .ql-editor a.btn:hover {
+            text-decoration: unset !important;
+            color: var(--bs-btn-color) !important;
+        }
+
 @media (max-width: 767.98px) {
 
     .app-menu {

--- a/Oqtane.Server/wwwroot/Themes/Templates/External/Client/wwwroot/Themes/[Owner].Theme.[Theme]/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Templates/External/Client/wwwroot/Themes/[Owner].Theme.[Theme]/Theme.css
@@ -77,6 +77,35 @@ body {
     top: -2px;
 }
 
+/* Oqtane Quill Rich Text Editor Toolbar */
+.ql-editor, .ql-toolbar, .ql-picker-options, .ql-picker-label {
+    background-color: var(--bs-body-bg) !important;
+    color: var(--bs-body-color) !important;
+}
+
+    ql-toolbar button:hover .ql-stroke, .ql-toolbar button:hover .ql-stroke, .ql-toolbar button:focus .ql-stroke, .ql-toolbar button:focus .ql-stroke, .ql-toolbar button.ql-active .ql-stroke, .ql-toolbar button.ql-active .ql-stroke, .ql-toolbar .ql-picker-label:hover .ql-stroke, .ql-toolbar .ql-picker-label:hover .ql-stroke, .ql-toolbar .ql-picker-label.ql-active .ql-stroke, .ql-toolbar .ql-picker-label.ql-active .ql-stroke, .ql-toolbar .ql-picker-item:hover .ql-stroke, .ql-toolbar .ql-picker-item:hover .ql-stroke, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke, .ql-toolbar button:hover .ql-stroke-miter, .ql-toolbar button:hover .ql-stroke-miter, .ql-toolbar button:focus .ql-stroke-miter, .ql-toolbar button:focus .ql-stroke-miter, .ql-toolbar button.ql-active .ql-stroke-miter, .ql-toolbar button.ql-active .ql-stroke-miter, .ql-toolbar .ql-picker-label:hover .ql-stroke-miter, .ql-toolbar .ql-picker-label:hover .ql-stroke-miter, .ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter, .ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter, .ql-toolbar .ql-picker-item:hover .ql-stroke-miter, .ql-toolbar .ql-picker-item:hover .ql-stroke-miter, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter {
+        stroke: var(--bs-link-hover-color) !important;
+    }
+
+    ql-toolbar button .ql-stroke, .ql-toolbar button .ql-stroke, .ql-toolbar button:focus .ql-stroke, .ql-toolbar button:focus .ql-stroke, .ql-toolbar button.ql-active .ql-stroke, .ql-toolbar button.ql-active .ql-stroke, .ql-toolbar .ql-picker-label .ql-stroke, .ql-toolbar .ql-picker-label .ql-stroke, .ql-toolbar .ql-picker-label.ql-active .ql-stroke, .ql-toolbar .ql-picker-label.ql-active .ql-stroke, .ql-toolbar .ql-picker-item .ql-stroke, .ql-toolbar .ql-picker-item .ql-stroke, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke, .ql-toolbar button .ql-stroke-miter, .ql-toolbar button .ql-stroke-miter, .ql-toolbar button:focus .ql-stroke-miter, .ql-toolbar button:focus .ql-stroke-miter, .ql-toolbar button.ql-active .ql-stroke-miter, .ql-toolbar button.ql-active .ql-stroke-miter, .ql-toolbar .ql-picker-label .ql-stroke-miter, .ql-toolbar .ql-picker-label .ql-stroke-miter, .ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter, .ql-toolbar .ql-picker-label.ql-active .ql-stroke-miter, .ql-toolbar .ql-picker-item .ql-stroke-miter, .ql-toolbar .ql-picker-item .ql-stroke-miter, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter, .ql-toolbar .ql-picker-item.ql-selected .ql-stroke-miter {
+        stroke: var(--bs-body-color) !important;
+    }
+
+    /* Oqtane Quill Rich Text Editor WYSIWYG Content */
+    .ql-editor a {
+        color: var(--bs-link-color) !important;
+    }
+
+        .ql-editor a:hover {
+            color: var(--bs-link-hover-color) !important;
+        }
+
+        
+        .ql-editor a.btn, .ql-editor a.btn:hover {
+            text-decoration: unset !important;
+            color: var(--bs-btn-color) !important;
+        }
+
 .navbar-toggler {
     background-color: rgba(255, 255, 255, 0.1);
     margin: .5rem;


### PR DESCRIPTION
# Pull Request

Fixes #4012

## Description
 
Adds Quill Bootstrap theme support to all bootstrap themes.

## Screenshots

![image](https://github.com/oqtane/oqtane.framework/assets/13577556/661be207-db10-48c5-ab41-c7f1422be2ce)

## Additional Information

This PR demonstrates using Bootstrap theme variables to help style the Quill rich text editor component into a Bootstrap enabled theme like the default themes used to showcase the Oqtane Framework.  Switch these variables to your flavor, and away you go 🚀    

_Note:  The `!important` is necessary to override the module loading after the theme._

