### PR TITLE
Fixes #4012: Adds Quill Editor Bootstrap CSS Styles To The Oqtane Default Theme

### DIFF
--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
@@ -106,6 +106,10 @@ div.app-moduleactions a.dropdown-toggle, div.app-moduleactions div.dropdown-menu
     color: var(--bs-heading-color) !important;
 }
 
+    .ql-header .ql-picker-options .ql-picker-item:first-child {
+        color: var(--bs-body-color) !important;
+    }
+
 .ql-editor a {
     color: var(--bs-link-color) !important;
 }

--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
@@ -97,37 +97,46 @@ div.app-moduleactions a.dropdown-toggle, div.app-moduleactions div.dropdown-menu
 }
 
 /* Oqtane Quill Rich Text Editor */
-.ql-editor, .ql-header .ql-picker-options {
+/* Global styles */
+.ql-header .ql-picker-options,
+.ql-toolbar,
+.ql-editor,
+.ql-tooltip {
     background-color: var(--bs-body-bg) !important;
     color: var(--bs-body-color) !important;
 }
 
-.ql-header .ql-picker-options {
-    color: var(--bs-heading-color) !important;
-}
-
-    .ql-header .ql-picker-options .ql-picker-item:first-child {
-        color: var(--bs-body-color) !important;
+    /* Header picker item styles */
+    .ql-header .ql-picker-options .ql-picker-item:not(:first-child) {
+        color: var(--bs-heading-color) !important;
     }
 
-.ql-editor a {
-    color: var(--bs-link-color) !important;
-}
+        /* Link styles */
+        .ql-header .ql-picker-options .ql-picker-item:not(:first-child).ql-editor a,
+        .ql-editor a {
+            color: var(--bs-link-color) !important;
+        }
 
-    .ql-editor a:hover {
-        color: var(--bs-link-hover-color) !important;
-    }
+            /* Hover styles */
+            .ql-header .ql-picker-options .ql-picker-item:hover,
+            .ql-editor a:hover {
+                color: var(--bs-link-hover-color) !important;
+            }
 
-    .ql-editor a.btn, .ql-editor a.btn:hover {
-        text-decoration: unset !important;
-        color: var(--bs-btn-color) !important;
-    }
+            /* Button link styles */
+            .ql-editor a.btn,
+            .ql-editor a.btn:hover {
+                text-decoration: unset !important;
+                color: var(--bs-btn-color) !important;
+            }
 
+/* Tooltip styles */
 .ql-tooltip {
     background-color: var(--bs-modal-bg) !important;
     color: var(--bs-body-color) !important;
 }
 
+    /* Tooltip link styles */
     .ql-tooltip a {
         color: var(--bs-link-color) !important;
     }

--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
@@ -96,6 +96,38 @@ div.app-moduleactions a.dropdown-toggle, div.app-moduleactions div.dropdown-menu
     z-index: 1000;
 }
 
+/* Oqtane Quill Rich Text Editor */
+.ql-editor, .ql-header .ql-picker-options {
+    background-color: var(--bs-body-bg) !important;
+    color: var(--bs-body-color) !important;
+}
+
+.ql-header .ql-picker-options {
+    color: var(--bs-heading-color) !important;
+}
+
+.ql-editor a {
+    color: var(--bs-link-color) !important;
+}
+
+    .ql-editor a:hover {
+        color: var(--bs-link-hover-color) !important;
+    }
+
+    .ql-editor a.btn, .ql-editor a.btn:hover {
+        text-decoration: unset !important;
+        color: var(--bs-btn-color) !important;
+    }
+
+.ql-tooltip {
+    background-color: var(--bs-modal-bg) !important;
+    color: var(--bs-body-color) !important;
+}
+
+    .ql-tooltip a {
+        color: var(--bs-link-color) !important;
+    }
+
 @media (max-width: 767.98px) {
 
     .app-menu {

--- a/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
+++ b/Oqtane.Server/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/Theme.css
@@ -97,46 +97,39 @@ div.app-moduleactions a.dropdown-toggle, div.app-moduleactions div.dropdown-menu
 }
 
 /* Oqtane Quill Rich Text Editor */
-/* Global styles */
-.ql-header .ql-picker-options,
-.ql-toolbar,
-.ql-editor,
-.ql-tooltip {
+.ql-toolbar {
+    background-color: var(--bs-emphasis-color)
+}
+
+.ql-header .ql-picker-options, .ql-editor {
     background-color: var(--bs-body-bg) !important;
     color: var(--bs-body-color) !important;
 }
-
-    /* Header picker item styles */
     .ql-header .ql-picker-options .ql-picker-item:not(:first-child) {
         color: var(--bs-heading-color) !important;
     }
 
-        /* Link styles */
         .ql-header .ql-picker-options .ql-picker-item:not(:first-child).ql-editor a,
         .ql-editor a {
             color: var(--bs-link-color) !important;
         }
 
-            /* Hover styles */
             .ql-header .ql-picker-options .ql-picker-item:hover,
             .ql-editor a:hover {
                 color: var(--bs-link-hover-color) !important;
             }
 
-            /* Button link styles */
             .ql-editor a.btn,
             .ql-editor a.btn:hover {
                 text-decoration: unset !important;
                 color: var(--bs-btn-color) !important;
             }
 
-/* Tooltip styles */
 .ql-tooltip {
     background-color: var(--bs-modal-bg) !important;
     color: var(--bs-body-color) !important;
 }
 
-    /* Tooltip link styles */
     .ql-tooltip a {
         color: var(--bs-link-color) !important;
     }


### PR DESCRIPTION
# Pull Request

Fixes #4012

## Description

This is to add bootstrap theme support to the Oqtane theme.  This is a minimized version allowing Quill themes to rule the toolbar area while styling the content editing areas.

## Screenshots

Current (Latest)
![image](https://github.com/oqtane/oqtane.framework/assets/13577556/852a1878-2f50-446e-8248-2f9a4e70992a)
![image](https://github.com/oqtane/oqtane.framework/assets/13577556/1ea83507-866d-4bed-b529-2223948afb38)
![image](https://github.com/oqtane/oqtane.framework/assets/13577556/ebb2160a-3042-4188-85e1-d81825cc23c8)
![image](https://github.com/oqtane/oqtane.framework/assets/13577556/21560e04-a940-4a78-8f34-89df496aa036)

Without dark toolbar as I preferred with it:
![image](https://github.com/oqtane/oqtane.framework/assets/13577556/b06f2d63-3b9b-44cb-975e-121015af0161)

![image](https://github.com/oqtane/oqtane.framework/assets/13577556/26a066e1-cc5f-4e26-ae45-f06d8387f7bb)

## Additional Information
More styling can be added to help mimic the Oqtane theme.  More solutions can be made down the road.  This makes the buttons and information in content areas and toolbar match the Oqtane Theme for better user experience.  It is a lot less CSS than previous.  

The `.tooltip` can be removed along with some other styles if necessary.

If desired I can make the `.toolbar` background darker as well so you can se the icons better.  Maybe `--bs-modal-bg` ? like the `tooltip`.  But this is very similar to what is already there if not the same...

Adding `.toolbar` class selector background will make it dark like the theme is as shown below:
```
.ql-editor, .ql-header .ql-picker-options, .ql-toolbar {
    background-color: var(--bs-body-bg) !important;
    color: var(--bs-body-color) !important;
}
```

![image](https://github.com/oqtane/oqtane.framework/assets/13577556/534da3e7-da0d-43b0-beae-224e6583fd1d)


I am going to close #4013 which also has relating conversation details from previous feedback this PR should be more acceptable near term with less overhead.

In summary from the last PR this is on the back burner on the road map for after Oqtane Framework version 5.1 is stabilized and released.