### PR TITLE
Fixes #4062: App.razor - moves loading body resources above blazor.web.js

### DIFF
--- a/Oqtane.Server/Components/App.razor
+++ b/Oqtane.Server/Components/App.razor
@@ -68,11 +68,6 @@
                 <Routes PageState="@_pageState" RenderMode="@_renderMode" Runtime="@_runtime" AntiForgeryToken="@_antiForgeryToken" AuthorizationToken="@_authorizationToken" Platform="@_platform" @rendermode="InteractiveRenderMode.GetInteractiveRenderMode(_runtime, _prerender)" />
             }
 
-            <script src="js/app.js"></script>
-            <script src="js/loadjs.min.js"></script>
-            <script src="js/interop.js"></script>
-            <script src="_framework/blazor.web.js"></script>
-
             @if (!string.IsNullOrEmpty(_reconnectScript))
             {
                 @((MarkupString)_reconnectScript)
@@ -82,6 +77,11 @@
                 @((MarkupString)_PWAScript)
             }
             @((MarkupString)_bodyResources)
+
+            <script src="js/app.js"></script>
+            <script src="js/loadjs.min.js"></script>
+            <script src="js/interop.js"></script>
+            <script src="_framework/blazor.web.js"></script>
         }
         else
         {


### PR DESCRIPTION
# Pull Request

Fixes #4062

## Description

Moves resources loading in the body of `App.razor` file above loading the `blazor.web.js`

## Screenshots

![image](https://github.com/oqtane/oqtane.framework/assets/13577556/d2e7f984-c825-45a1-b940-51e37dea936e)
![image](https://github.com/oqtane/oqtane.framework/assets/13577556/793b287b-aa5e-4a68-8310-992c136ee7cb)
