### PR TITLE
DRAFT: Insert Scripts regardless of render modes and at the top of the script block

### DIFF
--- a/Oqtane.Server/Components/App.razor
+++ b/Oqtane.Server/Components/App.razor
@@ -178,12 +178,8 @@
                     // include stylesheets to prevent FOUC
                     var resources = GetPageResources(alias, site, page, int.Parse(route.ModuleId), route.Action);
                     ManageStyleSheets(resources);
+                    ManageScripts(resources, alias);
 
-                    // scripts
-                    if (_renderMode == RenderModes.Static)
-                    {
-                        ManageScripts(resources, alias);
-                    }
                     if (_renderMode == RenderModes.Interactive && _runtime == Runtimes.Server)
                     {
                         _reconnectScript = CreateReconnectScript();
@@ -520,7 +516,8 @@
         {
             if (!_bodyResources.Contains(script))
             {
-                _bodyResources += script + Environment.NewLine;
+                //insert scripts above the built-ins to avoid timing issues.
+                _bodyResources = script + Environment.NewLine + _bodyResources;
             }
         }
     }


### PR DESCRIPTION
To support 3rd part custom control libraries the JS scripts need to be included in the page for all  render modes.  To ensure that the JS is available when the app starts, ensure they are added to the top of the scripts block before the built-in scripts.  Source of this was a custom MudBlazor Theme that stopped working when upgrading to 5.1.0