### PR TITLE
fix HTML comment to indicate actual RenderMode for component (including Interactivity)

### DIFF
--- a/Oqtane.Client/UI/RenderModeBoundary.razor
+++ b/Oqtane.Client/UI/RenderModeBoundary.razor
@@ -10,7 +10,7 @@
         {
             @if (ModuleType != null)
             {
-                @((MarkupString)$"<!-- rendermode: {ModuleState.RenderMode} - prerender: {ModuleState.Prerender ?? PageState.Site.Prerender} -->")
+                @((MarkupString)$"<!-- rendermode: {((PageState.RenderMode == RenderModes.Static && ModuleState.RenderMode == RenderModes.Static) ? RenderModes.Static : RenderModes.Interactive + ":" + PageState.Runtime)} - prerender: {ModuleState.Prerender ?? PageState.Site.Prerender} -->")
                 <ModuleMessage @ref="moduleMessageTop" Message="@_messageContent" Type="@_messageType" />
                 @DynamicComponent
                 @if (_progressIndicator)


### PR DESCRIPTION
previously it was reporting the ModuleState.RenderMode which is not always the actual render mode used at runtime (ie. it depends on the Site Setting)