### PR TITLE
Format Exception in int.Parse(route.ModuleId)

### DIFF
--- a/Oqtane.Client/Modules/Admin/Pages/Edit.razor
+++ b/Oqtane.Client/Modules/Admin/Pages/Edit.razor
@@ -1,5 +1,6 @@
 @namespace Oqtane.Modules.Admin.Pages
 @using Oqtane.Interfaces
+@using System.Globalization
 @inherits ModuleBase
 @inject NavigationManager NavigationManager
 @inject IPageService PageService
@@ -362,7 +363,7 @@
                     _parent = PageState.Pages.FirstOrDefault(item => item.PageId == _page.ParentId);
                 }
                 _children = new List<Page>();
-                foreach (Page p in PageState.Pages.Where(item => (_parentid == "-1" && item.ParentId == null) || (item.ParentId == int.Parse(_parentid))))
+                foreach (Page p in PageState.Pages.Where(item => (_parentid == "-1" && item.ParentId == null) || (item.ParentId == int.Parse(_parentid, CultureInfo.InvariantCulture))))
                 {
                     if (p.PageId != _pageId && UserSecurity.IsAuthorized(PageState.User, PermissionNames.View, p.PermissionList))
                     {

--- a/Oqtane.Client/UI/SiteRouter.razor
+++ b/Oqtane.Client/UI/SiteRouter.razor
@@ -1,6 +1,7 @@
 @using System.Diagnostics.CodeAnalysis
 @using System.Net
 @using Microsoft.AspNetCore.Http
+@using System.Globalization
 @namespace Oqtane.UI
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject SiteState SiteState
@@ -103,7 +104,7 @@
         _error = "";
 
         Route route = new Route(_absoluteUri, SiteState.Alias.Path);
-        int moduleid = int.Parse(route.ModuleId);
+        int moduleid = int.Parse(route.ModuleId, CultureInfo.InvariantCulture);
         var action = route.Action; 
 
         var querystring = Utilities.ParseQueryString(route.Query);
@@ -263,7 +264,7 @@
                     }
                     else
                     {
-                        editmode = (page.PageId == ((user.Settings.ContainsKey("CP-editmode")) ? int.Parse(user.Settings["CP-editmode"]) : -1));
+                        editmode = (page.PageId == ((user.Settings.ContainsKey("CP-editmode")) ? int.Parse(user.Settings["CP-editmode"], CultureInfo.InvariantCulture) : -1));
                         if (!editmode)
                         {
                             var userSettings = new Dictionary<string, string> { { "CP-editmode", "-1" } };

--- a/Oqtane.Server/Components/App.razor
+++ b/Oqtane.Server/Components/App.razor
@@ -16,6 +16,7 @@
 @using Oqtane.Shared
 @using Oqtane.Themes
 @using Oqtane.Extensions
+@using System.Globalization
 @inject NavigationManager NavigationManager
 @inject IAntiforgery Antiforgery
 @inject IConfigManager ConfigManager
@@ -176,7 +177,7 @@
                     }
 
                     // include stylesheets to prevent FOUC
-                    var resources = GetPageResources(alias, site, page, int.Parse(route.ModuleId), route.Action);
+                    var resources = GetPageResources(alias, site, page, int.Parse(route.ModuleId, CultureInfo.InvariantCulture), route.Action);
                     ManageStyleSheets(resources);
 
                     // scripts


### PR DESCRIPTION
int.Parse("-1") throws  FormatException for cultures other than English (en-US)