### PR TITLE
Null or empty check for FormatContent

### DIFF
--- a/Oqtane.Shared/Shared/Utilities.cs
+++ b/Oqtane.Shared/Shared/Utilities.cs
@@ -139,6 +139,9 @@ namespace Oqtane.Shared
 
         public static string FormatContent(string content, Alias alias, string operation)
         {
+            if (string.IsNullOrEmpty(content) || alias == null)
+                return content;
+
             var aliasUrl = (alias != null && !string.IsNullOrEmpty(alias.Path)) ? "/" + alias.Path : "";
             switch (operation)
             {


### PR DESCRIPTION
Added null or empty check for the content and alias parameters at the beginning of the method.