### PR TITLE
Fix for #4259 Localizer Null in Module Settings

### DIFF
--- a/Oqtane.Client/Modules/Admin/Modules/Settings.razor
+++ b/Oqtane.Client/Modules/Admin/Modules/Settings.razor
@@ -126,9 +126,8 @@
     <AuditInfo CreatedBy="@createdby" CreatedOn="@createdon" ModifiedBy="@modifiedby" ModifiedOn="@modifiedon"></AuditInfo>
 </form>
 
-    @code {
+@code {
     public override SecurityAccessLevel SecurityAccessLevel => SecurityAccessLevel.Edit;
-    public override string Title => Localizer["ModuleSettings.Title"];
 
     private ElementReference form;
     private bool validated = false;
@@ -158,6 +157,7 @@
 
     protected override void OnInitialized()
     {
+        SetModuleTitle(Localizer["ModuleSettings.Title"]);
         _module = ModuleState.ModuleDefinition.Name;
         _title = ModuleState.Title;
         _moduleSettingsTitle = Localizer["ModuleSettings.Heading"];
@@ -173,7 +173,8 @@
         modifiedon = ModuleState.ModifiedOn;
         _effectivedate = Utilities.UtcAsLocalDate(ModuleState.EffectiveDate);
         _expirydate = Utilities.UtcAsLocalDate(ModuleState.ExpiryDate);
-
+        
+        
         if (ModuleState.ModuleDefinition != null)
         {
             _permissionNames = ModuleState.ModuleDefinition?.PermissionNames;


### PR DESCRIPTION
removed the override string Title as it will be set Localized in the OnInitialized using SetModuleTitle base method.