### PR TITLE
[FIX] - #4284 

### DIFF
--- a/Oqtane.Server/Managers/UserManager.cs
+++ b/Oqtane.Server/Managers/UserManager.cs
@@ -85,7 +85,10 @@ namespace Oqtane.Managers
             List<UserRole> userroles = _userRoles.GetUserRoles(userId, siteId).ToList();
             foreach (UserRole userrole in userroles)
             {
-                roles += userrole.Role.Name + ";";
+                if (userrole.Role.Name == RoleNames.Host)
+                {
+                    roles += userrole.Role.Name + ";";
+                }
                 if (userrole.Role.Name == RoleNames.Host && !userroles.Any(item => item.Role.Name == RoleNames.Admin))
                 {
                     roles += RoleNames.Admin + ";";
@@ -94,6 +97,11 @@ namespace Oqtane.Managers
                 {
                     roles += RoleNames.Registered + ";";
                 }
+                if (Utilities.IsUserRoleValid(userrole.EffectiveDate, userrole.ExpiryDate))
+                {
+                    roles += userrole.Role.Name + ";";
+                }
+
             }
             if (roles != "") roles = ";" + roles;
             return roles;

--- a/Oqtane.Shared/Shared/Utilities.cs
+++ b/Oqtane.Shared/Shared/Utilities.cs
@@ -582,6 +582,28 @@ namespace Oqtane.Shared
                 return true;
             }
         }
+        public static bool IsUserRoleValid(DateTime? effectiveDate, DateTime? expiryDate)
+        {
+            DateTime currentUtcTime = DateTime.UtcNow;
+
+            if (effectiveDate.HasValue && expiryDate.HasValue)
+            {
+                return currentUtcTime >= effectiveDate.Value && currentUtcTime <= expiryDate.Value;
+            }
+            else if (effectiveDate.HasValue)
+            {
+                return currentUtcTime >= effectiveDate.Value;
+            }
+            else if (expiryDate.HasValue)
+            {
+                // Include equality check here
+                return currentUtcTime <= expiryDate.Value;
+            }
+            else
+            {
+                return true;
+            }
+        }
         public static bool ValidateEffectiveExpiryDates(DateTime? effectiveDate, DateTime? expiryDate)
         {
             // Treat DateTime.MinValue as null


### PR DESCRIPTION
When a user has a role that has an expiry date that is not Valid (i.e. in the past) it is still authorised for that role