### PR TITLE
Fix Cookie Date Conversion to Respect Culture and Format

### DIFF
--- a/Oqtane.Server/Components/App.razor
+++ b/Oqtane.Server/Components/App.razor
@@ -338,7 +338,7 @@
             {
                 var values = visitorCookieValue.Split('|');
                 int.TryParse(values[0], out _visitorId);
-                DateTime.TryParse(values[1], out expiry);
+                DateTime.TryParseExact(values[1], "M/d/yyyy hh:mm:ss tt", CultureInfo.InvariantCulture, DateTimeStyles.None, out expiry);
             }
             else // legacy cookie format
             {
@@ -425,7 +425,7 @@
 
                 Context.Response.Cookies.Append(
                     visitorCookieName,
-                    $"{_visitorId}|{expiry}",
+                    $"{_visitorId}|{expiry.ToString("M/d/yyyy hh:mm:ss tt", CultureInfo.InvariantCulture)}",
                     new CookieOptions()
                     {
                         Expires = DateTimeOffset.UtcNow.AddYears(10),


### PR DESCRIPTION
This pull request addresses an issue where non-ASCII characters were being introduced into HTTP client headers due to improper cookie date conversion. The date conversion was not taking into account culture and format, leading to non-ASCII characters being added on macOS between the time and the AM/PM part of the date.

The fix ensures that the cookie date is converted to text using a culture and format that preserves ASCII characters, thereby preventing non-ASCII characters from being added to the HTTP headers.

**Steps to Reproduce:**
1. Execute the project on a macOS and try to login.
2. An exception “Request headers must contain only ASCII characters.” will be thrown due to the character between the time and the AM/PM part of the date. Example cookie with problem: APP_VISITOR_1=1|6/4/2024 10:39:43 AM.

**Details about the Fix:**
The conversion now explicitly uses a culture and format that respects ASCII characters, ensuring compatibility across different operating systems.

**Testing:**
- Verified the fix on macOS to ensure no non-ASCII characters are present.
- Tested on Windows to ensure consistent behavior.
