### PR TITLE
Fix #4318: remove the page info when perform a new search.

### DIFF
--- a/Oqtane.Client/Modules/Admin/SearchResults/Index.razor
+++ b/Oqtane.Client/Modules/Admin/SearchResults/Index.razor
@@ -106,6 +106,10 @@
             ClearModuleMessage();
 
             _currentPage = 0;
+            if(PageState.QueryString.ContainsKey("page"))
+            {
+                PageState.QueryString.Remove("page");
+            }
             await PerformSearch();
         }
     }


### PR DESCRIPTION
Fix #4318: remove the page info when perform a new search.