### PR TITLE
revert #4250 which disabled prerendering by default for static rendered sites

### DIFF
--- a/Oqtane.Client/Modules/Admin/Site/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Site/Index.razor
@@ -336,7 +336,7 @@
                     <div class="row mb-1 align-items-center">
                         <Label Class="col-sm-3" For="rendermode" HelpText="The default render mode for the site" ResourceKey="Rendermode">Render Mode: </Label>
                         <div class="col-sm-9">
-                            <select id="rendermode" class="form-select" value="@_rendermode" @onchange="(e => RenderModeChanged(e))" required>
+                            <select id="rendermode" class="form-select" @bind="@_rendermode" required>
                                 <option value="@RenderModes.Interactive">@(SharedLocalizer["RenderMode" + @RenderModes.Interactive])</option>
                                 <option value="@RenderModes.Static">@(SharedLocalizer["RenderMode" + @RenderModes.Static])</option>
                                 <option value="@RenderModes.Headless">@(SharedLocalizer["RenderMode" + @RenderModes.Headless])</option>
@@ -595,23 +595,6 @@
         {
             await logger.LogError(ex, "Error Loading Containers For Theme {ThemeType} {Error}", _themetype, ex.Message);
             AddModuleMessage(Localizer["Error.Theme.LoadPane"], MessageType.Error);
-        }
-    }
-
-    private void RenderModeChanged(ChangeEventArgs e)
-    {
-        _rendermode = (string)e.Value;
-        switch (_rendermode)
-        {
-            case RenderModes.Interactive:
-                _prerender = "True";
-                break;
-            case RenderModes.Static:
-                _prerender = "False";
-                break;
-            case RenderModes.Headless:
-                _prerender = "False";
-                break;
         }
     }
 

--- a/Oqtane.Server/Infrastructure/DatabaseManager.cs
+++ b/Oqtane.Server/Infrastructure/DatabaseManager.cs
@@ -560,7 +560,7 @@ namespace Oqtane.Infrastructure
                                 SiteTemplateType = install.SiteTemplate,
                                 RenderMode = rendermode,
                                 Runtime = runtime,
-                                Prerender = (rendermode == RenderModes.Interactive),
+                                Prerender = true,
                                 Hybrid = false
                             };
                             site = sites.AddSite(site);


### PR DESCRIPTION
Disabling prerendering prevented OnInitialized from being called twice - but it also impacted the user experience because the browser would not start rendering a component until after all API calls were completed.