### PR TITLE
fix: set Rich active tab for Quill text editor

### DIFF
--- a/Oqtane.Client/Modules/Controls/QuillJSTextEditor.razor
+++ b/Oqtane.Client/Modules/Controls/QuillJSTextEditor.razor
@@ -263,12 +263,12 @@
 
     protected override void OnParametersSet()
     {
+        LoadSettings();
+
         if (!_allowRichText)
         {
             _activetab = "Raw";
         }
-
-        LoadSettings();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)


### PR DESCRIPTION
The active tab in the Quill text editor was being set before loading settings. Therefore, the active tab was Raw even if raw html is not allowed.