### PR TITLE
Fix admin/pages not showing 404 for unauthorized users

### DIFF
--- a/Oqtane.Server/Infrastructure/SiteTemplates/AdminSiteTemplate.cs
+++ b/Oqtane.Server/Infrastructure/SiteTemplates/AdminSiteTemplate.cs
@@ -266,7 +266,6 @@ namespace Oqtane.SiteTemplates
                 PermissionList = new List<Permission>
                 {
                     new Permission(PermissionNames.View, RoleNames.Admin, true),
-                    new Permission(PermissionNames.View, RoleNames.Registered, true),
                     new Permission(PermissionNames.Edit, RoleNames.Admin, true)
                 },
                 PageTemplateModules = new List<PageTemplateModule>


### PR DESCRIPTION
When logged in with an account only in the Registered Users role, the page under the URL "admin/pages" does not show a 404 page. Instead it stays blank. This behavior is different to all the other admin pages, and this PR fixes that.