### PR TITLE
Fix #4492: Updates Culture and Visitor cookies to use "Lax" SameSite and Secure Cookie Options

### DIFF
--- a/Oqtane.Server/Components/App.razor
+++ b/Oqtane.Server/Components/App.razor
@@ -429,7 +429,10 @@
                     new CookieOptions()
                     {
                         Expires = DateTimeOffset.UtcNow.AddYears(10),
-                        IsEssential = true
+                        IsEssential = true,
+                        SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax, // Set SameSite attribute
+                        Secure = true, // Ensure the cookie is only sent over HTTPS
+                        HttpOnly = true // Optional: Helps mitigate XSS attacks
                     }
                 );
             }
@@ -601,9 +604,19 @@
 
     private void SetLocalizationCookie(string culture)
     {
+        var cookieOptions = new Microsoft.AspNetCore.Http.CookieOptions
+        {
+            Expires = DateTimeOffset.UtcNow.AddYears(1),
+            SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax, // Set SameSite attribute
+            Secure = true, // Ensure the cookie is only sent over HTTPS
+            HttpOnly = true // Optional: Helps mitigate XSS attacks
+        };
+
         Context.Response.Cookies.Append(
             CookieRequestCultureProvider.DefaultCookieName,
-            CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture)));
+            CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture)),
+            cookieOptions
+        );
     }
 
     private async Task<List<Resource>> GetPageResources(Alias alias, Site site, Page page, List<Module> modules, int moduleid, string action)

--- a/Oqtane.Server/Startup.cs
+++ b/Oqtane.Server/Startup.cs
@@ -100,7 +100,6 @@ namespace Oqtane
                 options.Cookie.Name = Constants.AntiForgeryTokenCookieName;
                 options.Cookie.SameSite = SameSiteMode.Strict;
                 options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
-                options.Cookie.HttpOnly = true;
             });
 
             services.AddIdentityCore<IdentityUser>(options => { })

--- a/Oqtane.Server/Startup.cs
+++ b/Oqtane.Server/Startup.cs
@@ -100,6 +100,7 @@ namespace Oqtane
                 options.Cookie.Name = Constants.AntiForgeryTokenCookieName;
                 options.Cookie.SameSite = SameSiteMode.Strict;
                 options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+                options.Cookie.HttpOnly = true;
             });
 
             services.AddIdentityCore<IdentityUser>(options => { })


### PR DESCRIPTION
Fixes #4492 

Sets options on cookies for samesite, secure and httponly for Culture and Visitor cookies to lax (default) in order to remove browser warnings.

Visitor cookie adds these options:
```
                        SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax, // Set SameSite attribute
                        Secure = true, // Ensure the cookie is only sent over HTTPS
                        HttpOnly = true // Optional: Helps mitigate XSS attacks
```

Culture cookie adds these options:

```
                        Expires = DateTimeOffset.UtcNow.AddYears(1),
                        SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax, // Set SameSite attribute
                        Secure = true, // Ensure the cookie is only sent over HTTPS
                        HttpOnly = true // Optional: Helps mitigate XSS attacks
```

Some added cookie options such as Expires/Secure/HttpOnly may need reviewed/adjusted or maybe this is not the fix but thought I would open up the discussion with this pull request.

Secure over HTTPS only, not sure if this would mess up a HTTP load balanced backend for example.  Maybe this would need to be able to be set to false in an environment setting?

I set to lax since this was default and would allow more flexibility however these could be set to strict as well.  I am not sure if any issues with third party logins or things of this nature so I left as lax until further discussion.  Merge and make adjustments or suggest edits I can apply them to this PR, or close for a better solution/fix.

I set these to `SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax` since that is what they default and what it was using prior to avoid breaking anyone sites so if you have subdomain sites the cookie can be passed between them. Setting this to `SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Strict` is more secure however I am not sure it would allow having the cookie follow a user between sites with the same top level domain from my understanding.  `options.Cookie.SameSite = SameSiteMode.Strict;` the AntiForgeryToken Cookie uses.

When set to strict on a default installation the site still work for the standalone site.  Testing scenarios with sub-domain sites that need to maintain settings between them is what would need to be reviewed more/tested.

We can set this to strict if desired as well I just didn't want to break anything with this PR so left it default=lax for that option and am waiting for feedback relating.

I also added `HttpOnly = true // Optional: Helps mitigate XSS attacks` to all three cookies in this PR.

And `Secure = true, // Ensure the cookie is only sent over HTTPS` which may or may not be desired with a load balancer so not sure 100% on this, but for general web app purposes makes sense.

As shown in screenshot this will resolve these issues with warnings in console developer tools:

![image](https://github.com/user-attachments/assets/b3cbb39b-c582-41bf-bac2-2b91db4fdca7)
