### PR TITLE
fix #4562 - module template issue caused by gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,10 +22,14 @@ Oqtane.Server/Packages
 Oqtane.Server/wwwroot/Content
 Oqtane.Server/wwwroot/Packages/*.log
 
-Oqtane.Server/wwwroot/Modules
+Oqtane.Server/wwwroot/Modules/*
 !Oqtane.Server/wwwroot/Modules/Oqtane.Modules.*
 !Oqtane.Server/wwwroot/Modules/Templates
+Oqtane.Server/wwwroot/Modules/Templates/*
+!Oqtane.Server/wwwroot/Modules/Templates/External
 
-Oqtane.Server/wwwroot/Themes
+Oqtane.Server/wwwroot/Themes/*
 !Oqtane.Server/wwwroot/Themes/Oqtane.Themes.*
 !Oqtane.Server/wwwroot/Themes/Templates
+Oqtane.Server/wwwroot/Themes/Templates/*
+Oqtane.Server/wwwroot/Themes/Templates/External

--- a/Oqtane.Server/wwwroot/Modules/Templates/External/Client/Startup/ClientStartup.cs
+++ b/Oqtane.Server/wwwroot/Modules/Templates/External/Client/Startup/ClientStartup.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
+using Oqtane.Services;
+using [Owner].Module.[Module].Services;
+
+namespace [Owner].Module.[Module].Startup
+{
+    public class ClientStartup : IClientStartup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddScoped<I[Module]Service, [Module]Service>();
+        }
+    }
+}

--- a/Oqtane.Server/wwwroot/Modules/Templates/External/Server/Startup/ServerStartup.cs
+++ b/Oqtane.Server/wwwroot/Modules/Templates/External/Server/Startup/ServerStartup.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Builder; 
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Oqtane.Infrastructure;
+using [Owner].Module.[Module].Repository;
+using [Owner].Module.[Module].Services;
+
+namespace [Owner].Module.[Module].Startup
+{
+    public class ServerStartup : IServerStartup
+    {
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            // not implemented
+        }
+
+        public void ConfigureMvc(IMvcBuilder mvcBuilder)
+        {
+            // not implemented
+        }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddTransient<I[Module]Service, Server[Module]Service>();
+            services.AddDbContextFactory<[Module]Context>(opt => { }, ServiceLifetime.Transient);
+        }
+    }
+}


### PR DESCRIPTION
PR #4541 was not valid as it did not actually include the necessary changes to resolve issue #4537 - this was because the gitignore file was excluding files which should have been included. This PR fixes the gitignore and merges the default module template files which were supposed to be committed in #4541