### PR TITLE
Fix IconOnly not working

### DIFF
--- a/Oqtane.Client/Modules/Controls/ActionDialog.razor
+++ b/Oqtane.Client/Modules/Controls/ActionDialog.razor
@@ -173,6 +173,12 @@ else
             _editmode = bool.Parse(EditMode);
         }
 
+        Text = Localize(nameof(Text), Text);
+        Header = Localize(nameof(Header), Header);
+        Message = Localize(nameof(Message), Message);
+
+        _openText = Text;
+
         if (!string.IsNullOrEmpty(IconName))
         {
             if (IconOnly)
@@ -190,12 +196,7 @@ else
             _openIconSpan = $"<span class=\"{IconName}\"></span>{(IconOnly ? "" : "&nbsp")}";
             _iconSpan = $"<span class=\"{IconName}\"></span>&nbsp";
         }
-
-        Text = Localize(nameof(Text), Text);
-        Header = Localize(nameof(Header), Header);
-        Message = Localize(nameof(Message), Message);
-
-        _openText = Text;
+        
         _permissions = (PermissionList == null) ? ModuleState.PermissionList : PermissionList;
         _authorized = IsAuthorized();
 


### PR DESCRIPTION
It was just a matter of the order in which the _openText variable is set.

This PR fixes https://github.com/oqtane/oqtane.framework/issues/4586.