### PR TITLE
Fix #4710 - Adds language switcher component cookie set options for secure, httpOnly, sameSite + interop.cs/interop.js methods samesite and secure options

### DIFF
--- a/Oqtane.Client/Modules/Admin/Languages/Add.razor
+++ b/Oqtane.Client/Modules/Admin/Languages/Add.razor
@@ -130,7 +130,7 @@ else
         {
             var interop = new Interop(JSRuntime);
             var localizationCookieValue = CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture));
-            await interop.SetCookie(CookieRequestCultureProvider.DefaultCookieName, localizationCookieValue, 360, true, true, "Lax");
+            await interop.SetCookie(CookieRequestCultureProvider.DefaultCookieName, localizationCookieValue, 360, true, "Lax");
         }
     }
 

--- a/Oqtane.Client/Modules/Admin/Languages/Add.razor
+++ b/Oqtane.Client/Modules/Admin/Languages/Add.razor
@@ -130,7 +130,7 @@ else
         {
             var interop = new Interop(JSRuntime);
             var localizationCookieValue = CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture));
-            await interop.SetCookie(CookieRequestCultureProvider.DefaultCookieName, localizationCookieValue, 360);
+            await interop.SetCookie(CookieRequestCultureProvider.DefaultCookieName, localizationCookieValue, 360, true, true, "Lax");
         }
     }
 

--- a/Oqtane.Client/Modules/Admin/Languages/Edit.razor
+++ b/Oqtane.Client/Modules/Admin/Languages/Edit.razor
@@ -103,7 +103,7 @@ else
         {
             var interop = new Interop(JSRuntime);
             var localizationCookieValue = CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture));
-            await interop.SetCookie(CookieRequestCultureProvider.DefaultCookieName, localizationCookieValue, 360, true, true, "Lax");
+            await interop.SetCookie(CookieRequestCultureProvider.DefaultCookieName, localizationCookieValue, 360, true, "Lax");
         }
     }
 

--- a/Oqtane.Client/Modules/Admin/Languages/Edit.razor
+++ b/Oqtane.Client/Modules/Admin/Languages/Edit.razor
@@ -103,7 +103,7 @@ else
         {
             var interop = new Interop(JSRuntime);
             var localizationCookieValue = CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture));
-            await interop.SetCookie(CookieRequestCultureProvider.DefaultCookieName, localizationCookieValue, 360);
+            await interop.SetCookie(CookieRequestCultureProvider.DefaultCookieName, localizationCookieValue, 360, true, true, "Lax");
         }
     }
 

--- a/Oqtane.Client/Themes/Controls/Theme/LanguageSwitcher.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/LanguageSwitcher.razor
@@ -54,7 +54,16 @@
             if (_supportedCultures.Any(item => item.Name == culture))
             {
                 var localizationCookieValue = CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture));
-                HttpContext.Response.Cookies.Append(CookieRequestCultureProvider.DefaultCookieName, localizationCookieValue, new CookieOptions { Path = "/", Expires = DateTimeOffset.UtcNow.AddYears(365) });
+
+                HttpContext.Response.Cookies.Append(CookieRequestCultureProvider.DefaultCookieName, localizationCookieValue, new CookieOptions
+                    {
+                        Path = "/",
+                        Expires = DateTimeOffset.UtcNow.AddYears(365),
+                        SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax, // Set SameSite attribute
+                        Secure = true, // Ensure the cookie is only sent over HTTPS
+                        HttpOnly = true // Optional: Helps mitigate XSS attacks
+                    });
+
             }
             NavigationManager.NavigateTo(NavigationManager.Uri.Replace($"?culture={culture}", ""), true);
         }
@@ -66,7 +75,7 @@
         {
             var localizationCookieValue = CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture));
             var interop = new Interop(JSRuntime);
-            await interop.SetCookie(CookieRequestCultureProvider.DefaultCookieName, localizationCookieValue, 360);
+            await interop.SetCookie(CookieRequestCultureProvider.DefaultCookieName, localizationCookieValue, 360, true, true, "Lax");
             NavigationManager.NavigateTo(NavigationManager.Uri, true);
         }
     }

--- a/Oqtane.Client/Themes/Controls/Theme/LanguageSwitcher.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/LanguageSwitcher.razor
@@ -75,7 +75,7 @@
         {
             var localizationCookieValue = CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture));
             var interop = new Interop(JSRuntime);
-            await interop.SetCookie(CookieRequestCultureProvider.DefaultCookieName, localizationCookieValue, 360, true, true, "Lax");
+            await interop.SetCookie(CookieRequestCultureProvider.DefaultCookieName, localizationCookieValue, 360, true, "Lax");
             NavigationManager.NavigateTo(NavigationManager.Uri, true);
         }
     }

--- a/Oqtane.Client/Themes/Controls/Theme/LanguageSwitcher.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/LanguageSwitcher.razor
@@ -56,7 +56,7 @@
                 var localizationCookieValue = CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture));
                 HttpContext.Response.Cookies.Append(CookieRequestCultureProvider.DefaultCookieName, localizationCookieValue, new CookieOptions { Path = "/", Expires = DateTimeOffset.UtcNow.AddYears(365) });
             }
-            NavigationManager.NavigateTo(NavigationManager.Uri.Replace($"?culture={culture}", ""), forceLoad: true);
+            NavigationManager.NavigateTo(NavigationManager.Uri.Replace($"?culture={culture}", ""), true);
         }
     }
 
@@ -67,7 +67,7 @@
             var localizationCookieValue = CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture));
             var interop = new Interop(JSRuntime);
             await interop.SetCookie(CookieRequestCultureProvider.DefaultCookieName, localizationCookieValue, 360);
-            NavigationManager.NavigateTo(NavigationManager.Uri, forceLoad: true);
+            NavigationManager.NavigateTo(NavigationManager.Uri, true);
         }
     }
 }

--- a/Oqtane.Client/UI/Interop.cs
+++ b/Oqtane.Client/UI/Interop.cs
@@ -16,13 +16,13 @@ namespace Oqtane.UI
             _jsRuntime = jsRuntime;
         }
 
-        public Task SetCookie(string name, string value, int days)
+        public Task SetCookie(string name, string value, int days, bool secure, bool httpOnly, string sameSite)
         {
             try
             {
                 _jsRuntime.InvokeVoidAsync(
                     "Oqtane.Interop.setCookie",
-                    name, value, days);
+                    name, value, days, secure, httpOnly, sameSite);
                 return Task.CompletedTask;
             }
             catch

--- a/Oqtane.Client/UI/Interop.cs
+++ b/Oqtane.Client/UI/Interop.cs
@@ -22,7 +22,7 @@ namespace Oqtane.UI
             {
                 _jsRuntime.InvokeVoidAsync(
                     "Oqtane.Interop.setCookie",
-                    name, value, days, secure, httpOnly, sameSite);
+                    name, value, days, secure, sameSite);
                 return Task.CompletedTask;
             }
             catch

--- a/Oqtane.Client/UI/Interop.cs
+++ b/Oqtane.Client/UI/Interop.cs
@@ -16,7 +16,7 @@ namespace Oqtane.UI
             _jsRuntime = jsRuntime;
         }
 
-        public Task SetCookie(string name, string value, int days, bool secure, bool httpOnly, string sameSite)
+        public Task SetCookie(string name, string value, int days, bool secure, string sameSite)
         {
             try
             {

--- a/Oqtane.Maui/wwwroot/js/interop.js
+++ b/Oqtane.Maui/wwwroot/js/interop.js
@@ -1,11 +1,18 @@
 var Oqtane = Oqtane || {};
 
 Oqtane.Interop = {
-    setCookie: function (name, value, days) {
+    setCookie: function (name, value, days, secure, httpOnly, sameSite) {
         var d = new Date();
         d.setTime(d.getTime() + (days * 24 * 60 * 60 * 1000));
         var expires = "expires=" + d.toUTCString();
-        document.cookie = name + "=" + value + ";" + expires + ";path=/";
+        var cookieString = name + "=" + value + ";" + expires + ";path=/";
+        if (sameSite === "Lax" || sameSite === "Strict" || sameSite === "None") {
+            cookieString += `; SameSite=${sameSite}`;
+        }
+        if (secure) {
+            cookieString += "; Secure";
+        }
+        document.cookie = cookieString;
     },
     getCookie: function (name) {
         name = name + "=";

--- a/Oqtane.Maui/wwwroot/js/interop.js
+++ b/Oqtane.Maui/wwwroot/js/interop.js
@@ -1,7 +1,7 @@
 var Oqtane = Oqtane || {};
 
 Oqtane.Interop = {
-    setCookie: function (name, value, days, secure, httpOnly, sameSite) {
+    setCookie: function (name, value, days, secure, sameSite) {
         var d = new Date();
         d.setTime(d.getTime() + (days * 24 * 60 * 60 * 1000));
         var expires = "expires=" + d.toUTCString();

--- a/Oqtane.Server/wwwroot/js/interop.js
+++ b/Oqtane.Server/wwwroot/js/interop.js
@@ -1,7 +1,7 @@
 var Oqtane = Oqtane || {};
 
 Oqtane.Interop = {
-    setCookie: function (name, value, days, secure, httpOnly, sameSite) {
+    setCookie: function (name, value, days, secure, sameSite) {
         var d = new Date();
         d.setTime(d.getTime() + (days * 24 * 60 * 60 * 1000));
         var expires = "expires=" + d.toUTCString();

--- a/Oqtane.Server/wwwroot/js/interop.js
+++ b/Oqtane.Server/wwwroot/js/interop.js
@@ -1,11 +1,25 @@
 var Oqtane = Oqtane || {};
 
 Oqtane.Interop = {
-    setCookie: function (name, value, days) {
+    setCookie: function (name, value, days, secure, httpOnly, sameSite) {
         var d = new Date();
         d.setTime(d.getTime() + (days * 24 * 60 * 60 * 1000));
         var expires = "expires=" + d.toUTCString();
-        document.cookie = name + "=" + value + ";" + expires + ";path=/";
+        var cookieString = name + "=" + value + ";" + expires + ";path=/";
+
+        // Add SameSite attribute
+        if (sameSite === "Lax" || sameSite === "Strict" || sameSite === "None") {
+            cookieString += `; SameSite=${sameSite}`;
+        }
+
+        // Add Secure attribute
+        if (secure) {
+            cookieString += "; Secure";
+        }
+
+        // Note: HttpOnly cannot be set here; it needs to be handled server-side.
+
+        document.cookie = cookieString;
     },
     getCookie: function (name) {
         name = name + "=";

--- a/Oqtane.Server/wwwroot/js/interop.js
+++ b/Oqtane.Server/wwwroot/js/interop.js
@@ -6,19 +6,12 @@ Oqtane.Interop = {
         d.setTime(d.getTime() + (days * 24 * 60 * 60 * 1000));
         var expires = "expires=" + d.toUTCString();
         var cookieString = name + "=" + value + ";" + expires + ";path=/";
-
-        // Add SameSite attribute
         if (sameSite === "Lax" || sameSite === "Strict" || sameSite === "None") {
             cookieString += `; SameSite=${sameSite}`;
         }
-
-        // Add Secure attribute
         if (secure) {
             cookieString += "; Secure";
         }
-
-        // Note: HttpOnly cannot be set here; it needs to be handled server-side.
-
         document.cookie = cookieString;
     },
     getCookie: function (name) {


### PR DESCRIPTION
 Fixes #4710 
 *DRAFT*

### Issues Resolved

This PR allows setting different cookies SameSite and Secure cookie attributes via javascript interop setCookie method.

Language switcher cookie set options for "secure, httpOnly, sameSite" is also done in the code behind logic.

Also the NavigateTo function was simplified to use "true" instead of explicitly setting force reload to true.

HttpOnly can only be set server-side and so it is not set client-side via js interop as a note.  This has caused issues with interactive render mode due to SignalR and JavaScript.

This is a work in progress at this point.

### Additional Context
This resolves the issue but should be tested for further side effects for any third party modules that may need to be informed to make this update adding the new values to this function when used to set cookies.

Maybe a breaking change due to having to pass new settings in the method to the JavaScript interop, but it would be on the side of security.

We may need to create a second interop.js method `setCookieSecure { }` and deprecate the other `setCookie { ]` to allow time and build developer awareness to create cookies using this alternative method.  Or we can just simply set these without sending the attribute settings within the current 'setCookie { } method'

Please review as this will allow these cookies to not flash warnings in browser when set.

This is an example of how I believe it could be implemented allowing developers to create cookies with different SameSite and Secure Cookie settings.

Working to also resolve other issues in this area so I would like to keep this a draft and also await feedback.

Discussion #4703 

I created Issue #4714 to discuss this as these are in the same logic being updated in this PR and can be addressed as well here.  Or we can keep them two different PR's.

It would not be hard to create the conditional logic for the render mode interactive to set the `HttpOnly=False` to resolve this issue as well.

The issue here is while in interactive modes (SignalR) Oqtane uses JavaScript to create cookies and the `HttpOnly` setting in this mode set to `true` will not access the cookie.  This is true for the `Culture` cookie for the `LanguageSwitcher.razor` component and needs reviewed for the `Visitor` cookie as well.  We will need to create logic to handle which render mode is being set in the site settings to determine which cookie setting to use if we are unable to work this issue out in code.  JavaScript interop won’t be able to access these cookies directly if `HttpOnly=true`.

Visitor Cookie should be reviewed to see if it is functioning in both modes as intended.  This is created server side and not sure it needs to be written to like the culture cookie with same issue described while in interactive mode.