### PR TITLE
Localization Cookie Static Conditional HttpOnly=True

### DIFF
--- a/Oqtane.Client/Themes/Controls/Theme/LanguageSwitcher.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/LanguageSwitcher.razor
@@ -61,7 +61,7 @@
                     Expires = DateTimeOffset.UtcNow.AddYears(365),
                     SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax, // Set SameSite attribute
                     Secure = true, // Ensure the cookie is only sent over HTTPS
-                    HttpOnly = false // cookie is updated using JS Interop in Interactive render mode
+                    HttpOnly = PageState.RenderMode == RenderModes.Static // sets the cookie HttpOnly=true only if the rendermode is not updated using JS Interop in Interactive render mode
                 });
 
             }

--- a/Oqtane.Client/Themes/Controls/Theme/LanguageSwitcher.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/LanguageSwitcher.razor
@@ -61,7 +61,9 @@
                     Expires = DateTimeOffset.UtcNow.AddYears(365),
                     SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax, // Set SameSite attribute
                     Secure = true, // Ensure the cookie is only sent over HTTPS
-                    HttpOnly = PageState.RenderMode == RenderModes.Static // sets the cookie HttpOnly=true only if the rendermode is not updated using JS Interop in Interactive render mode
+                    HttpOnly = PageState.RenderMode == RenderModes.Static // Sets the cookie with HttpOnly=true only if the render mode is Static. 
+                                                                          // In Interactive mode, cookies are updated using JavaScript Interop, 
+                                                                          // which requires HttpOnly to be false.
                 });
 
             }

--- a/Oqtane.Server/Components/App.razor
+++ b/Oqtane.Server/Components/App.razor
@@ -609,7 +609,9 @@
             Expires = DateTimeOffset.UtcNow.AddYears(1),
             SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax, // Set SameSite attribute
             Secure = true, // Ensure the cookie is only sent over HTTPS
-            HttpOnly = _renderMode == RenderModes.Static // Set HttpOnly based on render mode
+            HttpOnly = _renderMode == RenderModes.Static  // Sets the cookie with HttpOnly=true only if the render mode is Static. 
+                                                          // In Interactive mode, cookies are updated using JavaScript Interop, 
+                                                          // which requires HttpOnly to be false.
         };
 
         Context.Response.Cookies.Append(

--- a/Oqtane.Server/Components/App.razor
+++ b/Oqtane.Server/Components/App.razor
@@ -604,38 +604,19 @@
 
     private void SetLocalizationCookie(string culture)
     {
-        if (_renderMode == RenderModes.Static)
+        var cookieOptions = new Microsoft.AspNetCore.Http.CookieOptions
         {
-            var cookieOptions = new Microsoft.AspNetCore.Http.CookieOptions
-                {
-                    Expires = DateTimeOffset.UtcNow.AddYears(1),
-                    SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax, // Set SameSite attribute
-                    Secure = true, // Ensure the cookie is only sent over HTTPS
-                    HttpOnly = true // Optional: Helps mitigate XSS attacks
-                };
+            Expires = DateTimeOffset.UtcNow.AddYears(1),
+            SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax, // Set SameSite attribute
+            Secure = true, // Ensure the cookie is only sent over HTTPS
+            HttpOnly = _renderMode == RenderModes.Static // Set HttpOnly based on render mode
+        };
 
-            Context.Response.Cookies.Append(
-                CookieRequestCultureProvider.DefaultCookieName,
-                CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture)),
-                cookieOptions
-            );
-        }
-        else
-        {
-            var cookieOptions = new Microsoft.AspNetCore.Http.CookieOptions
-                {
-                    Expires = DateTimeOffset.UtcNow.AddYears(1),
-                    SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax, // Set SameSite attribute
-                    Secure = true, // Ensure the cookie is only sent over HTTPS
-                    HttpOnly = false // cookie is updated using JS Interop
-                };
-
-            Context.Response.Cookies.Append(
-                CookieRequestCultureProvider.DefaultCookieName,
-                CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture)),
-                cookieOptions
-            );
-        }
+        Context.Response.Cookies.Append(
+            CookieRequestCultureProvider.DefaultCookieName,
+            CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture)),
+            cookieOptions
+        );
     }
 
     private async Task<List<Resource>> GetPageResources(Alias alias, Site site, Page page, List<Module> modules, int moduleid, string action)

--- a/Oqtane.Server/Components/App.razor
+++ b/Oqtane.Server/Components/App.razor
@@ -604,19 +604,38 @@
 
     private void SetLocalizationCookie(string culture)
     {
-        var cookieOptions = new Microsoft.AspNetCore.Http.CookieOptions
+        if (_renderMode == RenderModes.Static)
         {
-            Expires = DateTimeOffset.UtcNow.AddYears(1),
-            SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax, // Set SameSite attribute
-            Secure = true, // Ensure the cookie is only sent over HTTPS
-            HttpOnly = false // cookie is updated using JS Interop in Interactive render mode
-        };
+            var cookieOptions = new Microsoft.AspNetCore.Http.CookieOptions
+                {
+                    Expires = DateTimeOffset.UtcNow.AddYears(1),
+                    SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax, // Set SameSite attribute
+                    Secure = true, // Ensure the cookie is only sent over HTTPS
+                    HttpOnly = true // Optional: Helps mitigate XSS attacks
+                };
 
-        Context.Response.Cookies.Append(
-            CookieRequestCultureProvider.DefaultCookieName,
-            CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture)),
-            cookieOptions
-        );
+            Context.Response.Cookies.Append(
+                CookieRequestCultureProvider.DefaultCookieName,
+                CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture)),
+                cookieOptions
+            );
+        }
+        else
+        {
+            var cookieOptions = new Microsoft.AspNetCore.Http.CookieOptions
+                {
+                    Expires = DateTimeOffset.UtcNow.AddYears(1),
+                    SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax, // Set SameSite attribute
+                    Secure = true, // Ensure the cookie is only sent over HTTPS
+                    HttpOnly = false // cookie is updated using JS Interop
+                };
+
+            Context.Response.Cookies.Append(
+                CookieRequestCultureProvider.DefaultCookieName,
+                CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture)),
+                cookieOptions
+            );
+        }
     }
 
     private async Task<List<Resource>> GetPageResources(Alias alias, Site site, Page page, List<Module> modules, int moduleid, string action)


### PR DESCRIPTION
Fix #4714 
#4703 
#4728

This adds a conditional checks in `LangaugeSwitcher.razor` component and `App.razor` component to check if current rendermode is static and set `HttpOnly=True` if it is for the culture cookie when created.  Otherwise sets to false.



