### PR TITLE
Scroll to top after saving settings - Fixes #4758

### DIFF
--- a/Oqtane.Client/Modules/Admin/Users/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Users/Index.razor
@@ -691,6 +691,10 @@ else
             await logger.LogError(ex, "Error Saving Site Settings {Error}", ex.Message);
             AddModuleMessage(Localizer["Error.SaveSiteSettings"], MessageType.Error);
         }
+        finally
+        {
+            await ScrollToPageTop();
+        }
     }
 
     private void ProviderChanged(ChangeEventArgs e)


### PR DESCRIPTION
 Fixes #4758

adds scroll to top as a `finally` part of the `try/catch` block