### PR TITLE
Fixes #4762: Adds logic ScrollTo interop.js method detecting if method is executed inside a modal

### DIFF
--- a/Oqtane.Maui/wwwroot/js/interop.js
+++ b/Oqtane.Maui/wwwroot/js/interop.js
@@ -417,11 +417,20 @@ Oqtane.Interop = {
         }
     },
     scrollTo: function (top, left, behavior) {
-        window.scrollTo({
-            top: top,
-            left: left,
-            behavior: behavior
-        });
+        const modal = document.querySelector('.modal');
+        if (modal) {
+            modal.scrollTo({
+                top: top,
+                left: left,
+                behavior: behavior
+            });
+        } else {
+            window.scrollTo({
+                top: top,
+                left: left,
+                behavior: behavior
+            });
+        }
     },
     scrollToId: function (id) {
         var element = document.getElementById(id);

--- a/Oqtane.Server/wwwroot/js/interop.js
+++ b/Oqtane.Server/wwwroot/js/interop.js
@@ -417,11 +417,20 @@ Oqtane.Interop = {
         }
     },
     scrollTo: function (top, left, behavior) {
-        window.scrollTo({
-            top: top,
-            left: left,
-            behavior: behavior
-        });
+        const modal = document.querySelector('.modal');
+        if (modal) {
+            modal.scrollTo({
+                top: top,
+                left: left,
+                behavior: behavior
+            });
+        } else {
+            window.scrollTo({
+                top: top,
+                left: left,
+                behavior: behavior
+            });
+        }
     },
     scrollToId: function (id) {
         var element = document.getElementById(id);


### PR DESCRIPTION
Fixes #4762
Adds logic ScrollTo interop.js method detecting if method is executed inside a `class=".modal"` for places like the admin modal popups.

This allows the ScrollToTop function to work properly inside areas like the admin\pages\add.razor popup modal