### PR TITLE
Use Microsoft.IO.RecyclableMemoryStreamManager

### DIFF
--- a/Oqtane.Client/Program.cs
+++ b/Oqtane.Client/Program.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using Oqtane.Documentation;
+using Oqtane.Helpers;
 using Oqtane.Models;
 using Oqtane.Modules;
 using Oqtane.Services;
@@ -152,11 +153,11 @@ namespace Oqtane.Client
                 var zip = await http.GetByteArrayAsync($"{urlpath}api/Installation/load?list=" + string.Join(",", list));
 
                 // asemblies and debug symbols are packaged in a zip file
-                using (ZipArchive archive = new ZipArchive(new MemoryStream(zip)))
+                using (ZipArchive archive = new ZipArchive(StreamHelpers.RecyclableMemoryStreamManager.GetStream(nameof(Oqtane.Client.Program.Main), zip)))
                 {
                     foreach (ZipArchiveEntry entry in archive.Entries)
                     {
-                        using (var memoryStream = new MemoryStream())
+                        using (var memoryStream = StreamHelpers.RecyclableMemoryStreamManager.GetStream(nameof(Oqtane.Client.Program.Main)))
                         {
                             entry.Open().CopyTo(memoryStream);
                             byte[] file = memoryStream.ToArray();

--- a/Oqtane.Server/Controllers/InstallationController.cs
+++ b/Oqtane.Server/Controllers/InstallationController.cs
@@ -17,6 +17,7 @@ using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
+using Oqtane.Helpers;
 
 namespace Oqtane.Controllers
 {
@@ -214,7 +215,7 @@ namespace Oqtane.Controllers
                 }
 
                 // create zip file containing assemblies and debug symbols
-                using (var memoryStream = new MemoryStream())
+                using (var memoryStream = StreamHelpers.RecyclableMemoryStreamManager.GetStream(nameof(Oqtane.Controllers.InstallationController.GetAssemblyList)))
                 {
                     using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, true))
                     {
@@ -249,11 +250,7 @@ namespace Oqtane.Controllers
             else
             {
                 // return empty zip
-                using (var memoryStream = new MemoryStream())
-                {
-                    using (var zip = new ZipArchive(memoryStream, ZipArchiveMode.Create)) {}
-                    return memoryStream.ToArray();
-                }
+                return [];
             }
         }
 

--- a/Oqtane.Shared/Helpers/StreamHelpers.cs
+++ b/Oqtane.Shared/Helpers/StreamHelpers.cs
@@ -1,0 +1,18 @@
+using Microsoft.IO;
+
+namespace Oqtane.Helpers
+{
+    public static class StreamHelpers
+    {
+        public static readonly RecyclableMemoryStreamManager RecyclableMemoryStreamManager = new(new RecyclableMemoryStreamManager.Options()
+        {
+            BlockSize = RecyclableMemoryStreamManager.DefaultBlockSize,
+            LargeBufferMultiple = RecyclableMemoryStreamManager.DefaultLargeBufferMultiple,
+            MaximumBufferSize = RecyclableMemoryStreamManager.DefaultMaximumBufferSize,
+            GenerateCallStacks = false,
+            AggressiveBufferReturn = false,
+            MaximumLargePoolFreeBytes = 16 * 1024 * 1024 * 4,
+            MaximumSmallPoolFreeBytes = 100 * 1024
+        });
+    }
+}

--- a/Oqtane.Shared/Oqtane.Shared.csproj
+++ b/Oqtane.Shared/Oqtane.Shared.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-rc.2.24474.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.0-rc.2.24474.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0-rc.2.24473.5" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Text.Json" Version="9.0.0-rc.2.24473.5" />
   </ItemGroup>


### PR DESCRIPTION
Closes #4797 

Initial commit switching from `MemorySteam` to `Microsoft.IO.RecyclableMemoryStream`.
I haven't changed the `LoadFromStream` functions, as I don't know how that works, whether its inner stream should be disposed or not.