### PR TITLE
parsedCulture capture null

### DIFF
--- a/Oqtane.Server/Components/App.razor
+++ b/Oqtane.Server/Components/App.razor
@@ -215,7 +215,11 @@
                     // set language for page
                     if (!string.IsNullOrEmpty(culture))
                     {
-                        _language = Shared.CookieRequestCultureProvider.ParseCookieValue(culture).Culture.Name;
+                        var parsedCulture = Shared.CookieRequestCultureProvider.ParseCookieValue(culture);
+                        if (parsedCulture?.Culture != null)
+                        {
+                            _language = parsedCulture.Culture.Name;
+                        }
                     }
 
                     // create initial PageState


### PR DESCRIPTION
Returns null on a fresh installation of windows os and Oqtane.

`Shared.CookieRequestCultureProvider.ParseCookieValue(culture).Culture.Name;`