### PR TITLE
Fix: for Disabling search does not hide search icon #4824

### DIFF
--- a/Oqtane.Client/Modules/Admin/Search/Index.razor
+++ b/Oqtane.Client/Modules/Admin/Search/Index.razor
@@ -85,7 +85,7 @@
         {
             var settings = await SettingService.GetSiteSettingsAsync(PageState.Site.SiteId);
             settings = SettingService.SetSetting(settings, "Search_SearchProvider", _searchProvider);
-            settings = SettingService.SetSetting(settings, "Search_Enabled", _enabled, true);
+            settings = SettingService.SetSetting(settings, "Search_Enabled", _enabled);
             settings = SettingService.SetSetting(settings, "Search_LastIndexedOn", _lastIndexedOn, true);
             settings = SettingService.SetSetting(settings, "Search_IgnorePages", _ignorePages, true);
             settings = SettingService.SetSetting(settings, "Search_IgnoreEntities", _ignoreEntities, true);


### PR DESCRIPTION
"Search_Enabled" in the settings was being saved as Private this meant that unauthorized users could not access this value.