### PR TITLE
Add ShowEditMode parameter to ControlPanel to allow hiding the Edit Mode toggle button

### DIFF
--- a/Oqtane.Client/Themes/Controls/Theme/ControlPanel.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/ControlPanel.razor
@@ -9,7 +9,7 @@
     <LanguageSwitcher ButtonClass="@ButtonClass" DropdownAlignment="@LanguageDropdownAlignment" />
 }
 
-@if (_showEditMode || (PageState.Page.IsPersonalizable && PageState.User != null && UserSecurity.IsAuthorized(PageState.User, RoleNames.Registered)))
+@if (ShowEditMode && (_showEditMode || (PageState.Page.IsPersonalizable && PageState.User != null && UserSecurity.IsAuthorized(PageState.User, RoleNames.Registered))))
 {
     <form method="post" class="app-form-inline" @formname="EditModeForm" @onsubmit="@(async () => await ToggleEditMode(PageState.EditMode))" data-enhance>
         <input type="hidden" name="@Constants.RequestVerificationToken" value="@SiteState.AntiForgeryToken" />
@@ -59,9 +59,15 @@
     [Parameter]
     public string LanguageDropdownAlignment { get; set; } = string.Empty; // Empty or Left or Right
 
+    /// <summary>
+    /// Ability to hide the Edit Mode toggle button
+    /// </summary>
+    [Parameter]
+    public bool ShowEditMode { get; set; } = true;
+
     private PageState _pageState;
     private bool _canViewAdminDashboard = false;
-    private bool _showEditMode = false;
+    private bool _showEditMode = false; // internal state (not the same as ShowEditMode parameter)
 
     protected override void OnParametersSet()
     {

--- a/Oqtane.Client/Themes/Controls/Theme/ControlPanelInteractive.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/ControlPanelInteractive.razor
@@ -15,7 +15,6 @@
 @inject ILogService LoggingService
 @inject IStringLocalizer<ControlPanelInteractive> Localizer
 @inject IStringLocalizer<SharedResources> SharedLocalizer
-@inject IServiceProvider ServiceProvider
 
 <button type="button" class="btn @ButtonClass ms-1" data-bs-toggle="offcanvas" data-bs-target="#offcanvasControlPanel" aria-controls="offcanvasControlPanel" @onclick="ClearMessage">
     <span class="oi oi-cog"></span>


### PR DESCRIPTION
# Fix #4883 [ENH] Oqtane ControlPanel component forces edit button unto page

This enhancement addresses issue #4883 by introducing a ShowEditMode parameter to the ControlPanel component. This allows theme developers to hide the Edit Mode toggle button when desired.

### Changes Made
•	Added a new `ShowEditMode` parameter to `ControlPanel.razor` with a default value of `true` to maintain existing behavior.
•	Updated the `ControlPanel` logic to conditionally display the Edit Mode toggle button based on the `ShowEditMode` value.

### Testing Performed
Extensive testing was conducted to ensure this change works as intended across various scenarios.

#### Default Themes
- **Themes Tested**: `Default` themes of **Oqtane** and **Blazor**.
- **Users**: Anonymous and Admin.
- **Render Combinations**:
  - Static, Server
  - Static, Client
  - Static, Auto
  - Interactive, Server
  - Interactive, Client
  - Interactive, Auto
- **Results**:
  - **Anonymous Users:** Edit Mode toggle button is not visible (as expected).
  - **Admin Users:** Edit Mode toggle button is visible (current behavior preserved).

#### Modified Themes with `ShowEditMode="false"`
- **Created** new theme variations named `DefaultHideEditToggle.razor` for both **Oqtane** and **Blazor** themes.
- **Modification**:
  ```razor
    <ControlPanel LanguageDropdownAlignment="right" ShowEditMode="false" />
  ```
- **Users**: Anonymous and Admin.
- **Render Combinations**: Same as above.
- **Results**:
  - All Users: Edit Mode toggle button is not visible.
  - Confirmation: Enhancement allows hiding the Edit Mode toggle as intended.

### Conclusion
The addition of the `ShowEditMode` parameter provides theme developers with the flexibility to hide the Edit Mode toggle button when necessary. The default behavior remains unchanged for existing themes, ensuring backward compatibility.

**Note**: All tests confirm that the enhancement functions correctly without affecting current Oqtane behavior in default themes.