### PR TITLE
Implement Dynamic TargetFramework in Debug Scripts #4897

### DIFF
--- a/Oqtane.Server/wwwroot/Modules/Templates/External/Package/[Owner].Module.[Module].Package.csproj
+++ b/Oqtane.Server/wwwroot/Modules/Templates/External/Package/[Owner].Module.[Module].Package.csproj
@@ -22,8 +22,8 @@
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Condition="'$(OS)' == 'Windows_NT' And '$(Configuration)' == 'Debug'" Command="debug.cmd $(TargetFramework)" />
     <Exec Condition="'$(OS)' != 'Windows_NT' And '$(Configuration)' == 'Debug'" Command="bash $(ProjectDir)debug.sh $(TargetFramework)" />
-    <Exec Condition="'$(OS)' == 'Windows_NT' And '$(Configuration)' == 'Release'" Command="release.cmd" />
-    <Exec Condition="'$(OS)' != 'Windows_NT' And '$(Configuration)' == 'Release'" Command="bash $(ProjectDir)release.sh" />
+    <Exec Condition="'$(OS)' == 'Windows_NT' And '$(Configuration)' == 'Release'" Command="release.cmd $(TargetFramework)" />
+    <Exec Condition="'$(OS)' != 'Windows_NT' And '$(Configuration)' == 'Release'" Command="bash $(ProjectDir)release.sh $(TargetFramework)" />
   </Target>
 
 </Project>

--- a/Oqtane.Server/wwwroot/Modules/Templates/External/Package/[Owner].Module.[Module].Package.csproj
+++ b/Oqtane.Server/wwwroot/Modules/Templates/External/Package/[Owner].Module.[Module].Package.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Condition="'$(OS)' == 'Windows_NT' And '$(Configuration)' == 'Debug'" Command="debug.cmd" />
-    <Exec Condition="'$(OS)' != 'Windows_NT' And '$(Configuration)' == 'Debug'" Command="bash $(ProjectDir)debug.sh" />
+    <Exec Condition="'$(OS)' == 'Windows_NT' And '$(Configuration)' == 'Debug'" Command="debug.cmd $(TargetFramework)" />
+    <Exec Condition="'$(OS)' != 'Windows_NT' And '$(Configuration)' == 'Debug'" Command="bash $(ProjectDir)debug.sh $(TargetFramework)" />
     <Exec Condition="'$(OS)' == 'Windows_NT' And '$(Configuration)' == 'Release'" Command="release.cmd" />
     <Exec Condition="'$(OS)' != 'Windows_NT' And '$(Configuration)' == 'Release'" Command="bash $(ProjectDir)release.sh" />
   </Target>

--- a/Oqtane.Server/wwwroot/Modules/Templates/External/Package/[Owner].Module.[Module].nuspec
+++ b/Oqtane.Server/wwwroot/Modules/Templates/External/Package/[Owner].Module.[Module].nuspec
@@ -20,12 +20,12 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\Client\bin\Release\net9.0\[Owner].Module.[Module].Client.Oqtane.dll" target="lib\net9.0" /> 
-    <file src="..\Client\bin\Release\net9.0\[Owner].Module.[Module].Client.Oqtane.pdb" target="lib\net9.0" /> 
-    <file src="..\Server\bin\Release\net9.0\[Owner].Module.[Module].Server.Oqtane.dll" target="lib\net9.0" /> 
-    <file src="..\Server\bin\Release\net9.0\[Owner].Module.[Module].Server.Oqtane.pdb" target="lib\net9.0" /> 
-    <file src="..\Shared\bin\Release\net9.0\[Owner].Module.[Module].Shared.Oqtane.dll" target="lib\net9.0" /> 
-    <file src="..\Shared\bin\Release\net9.0\[Owner].Module.[Module].Shared.Oqtane.pdb" target="lib\net9.0" /> 
+    <file src="..\Client\bin\Release\$targetframework$\[Owner].Module.[Module].Client.Oqtane.dll" target="lib\$targetframework$" /> 
+    <file src="..\Client\bin\Release\$targetframework$\[Owner].Module.[Module].Client.Oqtane.pdb" target="lib\$targetframework$" /> 
+    <file src="..\Server\bin\Release\$targetframework$\[Owner].Module.[Module].Server.Oqtane.dll" target="lib\$targetframework$" /> 
+    <file src="..\Server\bin\Release\$targetframework$\[Owner].Module.[Module].Server.Oqtane.pdb" target="lib\$targetframework$" /> 
+    <file src="..\Shared\bin\Release\$targetframework$\[Owner].Module.[Module].Shared.Oqtane.dll" target="lib\$targetframework$" /> 
+    <file src="..\Shared\bin\Release\$targetframework$\[Owner].Module.[Module].Shared.Oqtane.pdb" target="lib\$targetframework$" /> 
     <file src="..\Server\wwwroot\**\*.*" target="wwwroot" /> 
     <file src="icon.png" target="" />
   </files>

--- a/Oqtane.Server/wwwroot/Modules/Templates/External/Package/debug.cmd
+++ b/Oqtane.Server/wwwroot/Modules/Templates/External/Package/debug.cmd
@@ -1,7 +1,10 @@
-XCOPY "..\Client\bin\Debug\net9.0\[Owner].Module.[Module].Client.Oqtane.dll" "..\..\[RootFolder]\Oqtane.Server\bin\Debug\net9.0\" /Y
-XCOPY "..\Client\bin\Debug\net9.0\[Owner].Module.[Module].Client.Oqtane.pdb" "..\..\[RootFolder]\Oqtane.Server\bin\Debug\net9.0\" /Y
-XCOPY "..\Server\bin\Debug\net9.0\[Owner].Module.[Module].Server.Oqtane.dll" "..\..\[RootFolder]\Oqtane.Server\bin\Debug\net9.0\" /Y
-XCOPY "..\Server\bin\Debug\net9.0\[Owner].Module.[Module].Server.Oqtane.pdb" "..\..\[RootFolder]\Oqtane.Server\bin\Debug\net9.0\" /Y
-XCOPY "..\Shared\bin\Debug\net9.0\[Owner].Module.[Module].Shared.Oqtane.dll" "..\..\[RootFolder]\Oqtane.Server\bin\Debug\net9.0\" /Y
-XCOPY "..\Shared\bin\Debug\net9.0\[Owner].Module.[Module].Shared.Oqtane.pdb" "..\..\[RootFolder]\Oqtane.Server\bin\Debug\net9.0\" /Y
+@echo off
+set TargetFramework=%1
+
+XCOPY "..\Client\bin\Debug\%TargetFramework%\[Owner].Module.[Module].Client.Oqtane.dll" "..\..\[RootFolder]\Oqtane.Server\bin\Debug\%TargetFramework%\" /Y
+XCOPY "..\Client\bin\Debug\%TargetFramework%\[Owner].Module.[Module].Client.Oqtane.pdb" "..\..\[RootFolder]\Oqtane.Server\bin\Debug\%TargetFramework%\" /Y
+XCOPY "..\Server\bin\Debug\%TargetFramework%\[Owner].Module.[Module].Server.Oqtane.dll" "..\..\[RootFolder]\Oqtane.Server\bin\Debug\%TargetFramework%\" /Y
+XCOPY "..\Server\bin\Debug\%TargetFramework%\[Owner].Module.[Module].Server.Oqtane.pdb" "..\..\[RootFolder]\Oqtane.Server\bin\Debug\%TargetFramework%\" /Y
+XCOPY "..\Shared\bin\Debug\%TargetFramework%\[Owner].Module.[Module].Shared.Oqtane.dll" "..\..\[RootFolder]\Oqtane.Server\bin\Debug\%TargetFramework%\" /Y
+XCOPY "..\Shared\bin\Debug\%TargetFramework%\[Owner].Module.[Module].Shared.Oqtane.pdb" "..\..\[RootFolder]\Oqtane.Server\bin\Debug\%TargetFramework%\" /Y
 XCOPY "..\Server\wwwroot\*" "..\..\[RootFolder]\Oqtane.Server\wwwroot\" /Y /S /I

--- a/Oqtane.Server/wwwroot/Modules/Templates/External/Package/debug.sh
+++ b/Oqtane.Server/wwwroot/Modules/Templates/External/Package/debug.sh
@@ -1,7 +1,11 @@
-cp -f "../Client/bin/Debug/net9.0/[Owner].Module.[Module].Client.Oqtane.dll" "../../oqtane.framework/Oqtane.Server/bin/Debug/net9.0/"
-cp -f "../Client/bin/Debug/net9.0/[Owner].Module.[Module].Client.Oqtane.pdb" "../../oqtane.framework/Oqtane.Server/bin/Debug/net9.0/"
-cp -f "../Server/bin/Debug/net9.0/[Owner].Module.[Module].Server.Oqtane.dll" "../../oqtane.framework/Oqtane.Server/bin/Debug/net9.0/"
-cp -f "../Server/bin/Debug/net9.0/[Owner].Module.[Module].Server.Oqtane.pdb" "../../oqtane.framework/Oqtane.Server/bin/Debug/net9.0/"
-cp -f "../Shared/bin/Debug/net9.0/[Owner].Module.[Module].Shared.Oqtane.dll" "../../oqtane.framework/Oqtane.Server/bin/Debug/net9.0/"
-cp -f "../Shared/bin/Debug/net9.0/[Owner].Module.[Module].Shared.Oqtane.pdb" "../../oqtane.framework/Oqtane.Server/bin/Debug/net9.0/"
+#!/bin/bash
+
+TargetFramework=$1
+
+cp -f "../Client/bin/Debug/$TargetFramework/[Owner].Module.[Module].Client.Oqtane.dll" "../../oqtane.framework/Oqtane.Server/bin/Debug/$TargetFramework/"
+cp -f "../Client/bin/Debug/$TargetFramework/[Owner].Module.[Module].Client.Oqtane.pdb" "../../oqtane.framework/Oqtane.Server/bin/Debug/$TargetFramework/"
+cp -f "../Server/bin/Debug/$TargetFramework/[Owner].Module.[Module].Server.Oqtane.dll" "../../oqtane.framework/Oqtane.Server/bin/Debug/$TargetFramework/"
+cp -f "../Server/bin/Debug/$TargetFramework/[Owner].Module.[Module].Server.Oqtane.pdb" "../../oqtane.framework/Oqtane.Server/bin/Debug/$TargetFramework/"
+cp -f "../Shared/bin/Debug/$TargetFramework/[Owner].Module.[Module].Shared.Oqtane.dll" "../../oqtane.framework/Oqtane.Server/bin/Debug/$TargetFramework/"
+cp -f "../Shared/bin/Debug/$TargetFramework/[Owner].Module.[Module].Shared.Oqtane.pdb" "../../oqtane.framework/Oqtane.Server/bin/Debug/$TargetFramework/"
 cp -rf "../Server/wwwroot/"* "../../oqtane.framework/Oqtane.Server/wwwroot/"

--- a/Oqtane.Server/wwwroot/Modules/Templates/External/Package/release.cmd
+++ b/Oqtane.Server/wwwroot/Modules/Templates/External/Package/release.cmd
@@ -2,6 +2,6 @@
 set TargetFramework=%1
 
 del "*.nupkg"
-"..\..\[RootFolder]\oqtane.package\nuget.exe" pack [Owner].Module.[Module].nuspec -Properties targetframework=$(TargetFramework)
+"..\..\[RootFolder]\oqtane.package\nuget.exe" pack [Owner].Module.[Module].nuspec -Properties targetframework=%TargetFramework%
 XCOPY "*.nupkg" "..\..\[RootFolder]\Oqtane.Server\Packages\" /Y
 

--- a/Oqtane.Server/wwwroot/Modules/Templates/External/Package/release.cmd
+++ b/Oqtane.Server/wwwroot/Modules/Templates/External/Package/release.cmd
@@ -1,4 +1,7 @@
+@echo off
+set TargetFramework=%1
+
 del "*.nupkg"
-"..\..\[RootFolder]\oqtane.package\nuget.exe" pack [Owner].Module.[Module].nuspec 
+"..\..\[RootFolder]\oqtane.package\nuget.exe" pack [Owner].Module.[Module].nuspec -Properties targetframework=$(TargetFramework)
 XCOPY "*.nupkg" "..\..\[RootFolder]\Oqtane.Server\Packages\" /Y
 

--- a/Oqtane.Server/wwwroot/Modules/Templates/External/Package/release.sh
+++ b/Oqtane.Server/wwwroot/Modules/Templates/External/Package/release.sh
@@ -1,2 +1,4 @@
-"..\..\oqtane.framework\oqtane.package\nuget.exe" pack [Owner].Module.[Module].nuspec 
+TargetFramework=$1
+
+"..\..\oqtane.framework\oqtane.package\nuget.exe" pack [Owner].Module.[Module].nuspec -Properties targetframework=$TargetFramework
 cp -f "*.nupkg" "..\..\oqtane.framework\Oqtane.Server\Packages\"

--- a/Oqtane.Server/wwwroot/Themes/Templates/External/Package/[Owner].Theme.[Theme].Package.csproj
+++ b/Oqtane.Server/wwwroot/Themes/Templates/External/Package/[Owner].Theme.[Theme].Package.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Condition="'$(OS)' == 'Windows_NT' And '$(Configuration)' == 'Debug'" Command="debug.cmd" />
-    <Exec Condition="'$(OS)' != 'Windows_NT' And '$(Configuration)' == 'Debug'" Command="bash $(ProjectDir)debug.sh" />
+    <Exec Condition="'$(OS)' == 'Windows_NT' And '$(Configuration)' == 'Debug'" Command="debug.cmd $(TargetFramework)" />
+    <Exec Condition="'$(OS)' != 'Windows_NT' And '$(Configuration)' == 'Debug'" Command="bash $(ProjectDir)debug.sh $(TargetFramework)" />
     <Exec Condition="'$(OS)' == 'Windows_NT' And '$(Configuration)' == 'Release'" Command="release.cmd" />
     <Exec Condition="'$(OS)' != 'Windows_NT' And '$(Configuration)' == 'Release'" Command="bash $(ProjectDir)release.sh" />
   </Target>

--- a/Oqtane.Server/wwwroot/Themes/Templates/External/Package/[Owner].Theme.[Theme].Package.csproj
+++ b/Oqtane.Server/wwwroot/Themes/Templates/External/Package/[Owner].Theme.[Theme].Package.csproj
@@ -20,8 +20,8 @@
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Condition="'$(OS)' == 'Windows_NT' And '$(Configuration)' == 'Debug'" Command="debug.cmd $(TargetFramework)" />
     <Exec Condition="'$(OS)' != 'Windows_NT' And '$(Configuration)' == 'Debug'" Command="bash $(ProjectDir)debug.sh $(TargetFramework)" />
-    <Exec Condition="'$(OS)' == 'Windows_NT' And '$(Configuration)' == 'Release'" Command="release.cmd" />
-    <Exec Condition="'$(OS)' != 'Windows_NT' And '$(Configuration)' == 'Release'" Command="bash $(ProjectDir)release.sh" />
+    <Exec Condition="'$(OS)' == 'Windows_NT' And '$(Configuration)' == 'Release'" Command="release.cmd $(TargetFramework)" />
+    <Exec Condition="'$(OS)' != 'Windows_NT' And '$(Configuration)' == 'Release'" Command="bash $(ProjectDir)release.sh $(TargetFramework)" />
   </Target>
 
 </Project>

--- a/Oqtane.Server/wwwroot/Themes/Templates/External/Package/[Owner].Theme.[Theme].nuspec
+++ b/Oqtane.Server/wwwroot/Themes/Templates/External/Package/[Owner].Theme.[Theme].nuspec
@@ -20,8 +20,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\Client\bin\Release\net9.0\[Owner].Theme.[Theme].Client.Oqtane.dll" target="lib\net9.0" /> 
-    <file src="..\Client\bin\Release\net9.0\[Owner].Theme.[Theme].Client.Oqtane.pdb" target="lib\net9.0" /> 
+    <file src="..\Client\bin\Release\$targetframework$\[Owner].Theme.[Theme].Client.Oqtane.dll" target="lib\$targetframework$" /> 
+    <file src="..\Client\bin\Release\$targetframework$\[Owner].Theme.[Theme].Client.Oqtane.pdb" target="lib\$targetframework$" /> 
     <file src="..\Client\wwwroot\**\*.*" target="wwwroot" /> 
     <file src="icon.png" target="" />
   </files>

--- a/Oqtane.Server/wwwroot/Themes/Templates/External/Package/debug.cmd
+++ b/Oqtane.Server/wwwroot/Themes/Templates/External/Package/debug.cmd
@@ -1,3 +1,6 @@
-XCOPY "..\Client\bin\Debug\net9.0\[Owner].Theme.[Theme].Client.Oqtane.dll" "..\..\[RootFolder]\Oqtane.Server\bin\Debug\net9.0\" /Y
-XCOPY "..\Client\bin\Debug\net9.0\[Owner].Theme.[Theme].Client.Oqtane.pdb" "..\..\[RootFolder]\Oqtane.Server\bin\Debug\net9.0\" /Y
+@echo off
+set TargetFramework=%1
+
+XCOPY "..\Client\bin\Debug\%TargetFramework%\[Owner].Theme.[Theme].Client.Oqtane.dll" "..\..\[RootFolder]\Oqtane.Server\bin\Debug\%TargetFramework%\" /Y
+XCOPY "..\Client\bin\Debug\%TargetFramework%\[Owner].Theme.[Theme].Client.Oqtane.pdb" "..\..\[RootFolder]\Oqtane.Server\bin\Debug\%TargetFramework%\" /Y
 XCOPY "..\Client\wwwroot\*" "..\..\[RootFolder]\Oqtane.Server\wwwroot\" /Y /S /I

--- a/Oqtane.Server/wwwroot/Themes/Templates/External/Package/debug.sh
+++ b/Oqtane.Server/wwwroot/Themes/Templates/External/Package/debug.sh
@@ -1,3 +1,7 @@
-cp -f "../Client/bin/Debug/net9.0/[Owner].Theme.[Theme].Client.Oqtane.dll" "../../oqtane.framework/Oqtane.Server/bin/Debug/net9.0/"
-cp -f "../Client/bin/Debug/net9.0/[Owner].Theme.[Theme].Client.Oqtane.pdb" "../../oqtane.framework/Oqtane.Server/bin/Debug/net9.0/"
+#!/bin/bash
+
+TargetFramework=$1
+
+cp -f "../Client/bin/Debug/$TargetFramework/[Owner].Theme.[Theme].Client.Oqtane.dll" "../../oqtane.framework/Oqtane.Server/bin/Debug/$TargetFramework/"
+cp -f "../Client/bin/Debug/$TargetFramework/[Owner].Theme.[Theme].Client.Oqtane.pdb" "../../oqtane.framework/Oqtane.Server/bin/Debug/$TargetFramework/"
 cp -rf "../Server/wwwroot/"* "../../oqtane.framework/Oqtane.Server/wwwroot/"

--- a/Oqtane.Server/wwwroot/Themes/Templates/External/Package/release.cmd
+++ b/Oqtane.Server/wwwroot/Themes/Templates/External/Package/release.cmd
@@ -1,3 +1,6 @@
+@echo off
+set TargetFramework=%1
+
 del "*.nupkg"
-"..\..\[RootFolder]\oqtane.package\nuget.exe" pack [Owner].Theme.[Theme].nuspec 
+"..\..\[RootFolder]\oqtane.package\nuget.exe" pack [Owner].Theme.[Theme].nuspec -Properties targetframework=$(TargetFramework)
 XCOPY "*.nupkg" "..\..\[RootFolder]\Oqtane.Server\wwwroot\Packages\" /Y

--- a/Oqtane.Server/wwwroot/Themes/Templates/External/Package/release.cmd
+++ b/Oqtane.Server/wwwroot/Themes/Templates/External/Package/release.cmd
@@ -2,5 +2,5 @@
 set TargetFramework=%1
 
 del "*.nupkg"
-"..\..\[RootFolder]\oqtane.package\nuget.exe" pack [Owner].Theme.[Theme].nuspec -Properties targetframework=$(TargetFramework)
+"..\..\[RootFolder]\oqtane.package\nuget.exe" pack [Owner].Theme.[Theme].nuspec -Properties targetframework=%TargetFramework%
 XCOPY "*.nupkg" "..\..\[RootFolder]\Oqtane.Server\wwwroot\Packages\" /Y

--- a/Oqtane.Server/wwwroot/Themes/Templates/External/Package/release.sh
+++ b/Oqtane.Server/wwwroot/Themes/Templates/External/Package/release.sh
@@ -1,2 +1,4 @@
-"..\..\oqtane.framework\oqtane.package\nuget.exe" pack [Owner].Theme.[Theme].nuspec 
+TargetFramework=$1
+
+"..\..\oqtane.framework\oqtane.package\nuget.exe" pack [Owner].Theme.[Theme].nuspec -Properties targetframework=$TargetFramework
 cp -f "*.nupkg" "..\..\oqtane.framework\Oqtane.Server\Packages\"


### PR DESCRIPTION
## Description
This PR updates our debug scripts (both .cmd and .sh) to dynamically use the current TargetFramework passed from the build process. This change improves flexibility and future-proofs our build process for different .NET versions.

## Changes Made
- Modified build events to pass $(TargetFramework) to debug scripts
- Updated debug.cmd to accept and use the TargetFramework parameter
- Updated debug.sh to accept and use the TargetFramework parameter
- Replaced hardcoded framework versions (e.g., net9.0) with the dynamic TargetFramework variable in file paths

## How to Test
1. Build the project with different TargetFramework settings
2. Verify that the correct files are copied to the appropriate directories based on the current TargetFramework

## Impact
This change affects the build process but should not impact runtime behavior. It will make it easier to manage different .NET versions in the future.