### PR TITLE
Update ActionDialog Add method to ensure consistent button sizing

### DIFF
--- a/Oqtane.Client/Modules/Controls/ActionDialog.razor
+++ b/Oqtane.Client/Modules/Controls/ActionDialog.razor
@@ -24,7 +24,7 @@
                             {
                                 <button type="button" class="@Class" @onclick="Confirm">@((MarkupString)_iconSpan) @Text</button>
                             }
-                            <button type="button" class="btn btn-secondary" @onclick="DisplayModal">@SharedLocalizer["Cancel"]</button>
+                            <button type="button" class="btn btn-secondary @GetButtonSize()" @onclick="DisplayModal">@SharedLocalizer["Cancel"]</button>
                         </div>
                     </div>
                 </div>
@@ -71,7 +71,7 @@ else
                             }
                             <form method="post" @formname="@($"ActionDialogCancelForm:{ModuleState.PageModuleId}:{Id}")" @onsubmit="DisplayModal" data-enhance>
                                 <input type="hidden" name="@Constants.RequestVerificationToken" value="@SiteState.AntiForgeryToken" />
-                                <button type="submit" class="btn btn-secondary">@SharedLocalizer["Cancel"]</button>
+                                <button type="submit" class="btn btn-secondary @GetButtonSize()">@SharedLocalizer["Cancel"]</button>
                             </form>
                         </div>
                     </div>
@@ -196,7 +196,7 @@ else
             _openIconSpan = $"<span class=\"{IconName}\"></span>{(IconOnly ? "" : "&nbsp")}";
             _iconSpan = $"<span class=\"{IconName}\"></span>&nbsp";
         }
-        
+
         _permissions = (PermissionList == null) ? ModuleState.PermissionList : PermissionList;
         _authorized = IsAuthorized();
 
@@ -206,6 +206,15 @@ else
         {
             _visible = (PageState.QueryString["dialog"] == Id); 
         }
+    }
+    /// <summary>
+    /// Checks the Class that is used for the Action Button, if it is small make the Cancel Button small as well.
+    /// </summary>
+    /// <param name="Class"></param>
+    /// <returns></returns>
+    private string GetButtonSize()
+    {
+        return Class.Contains("btn-sm", StringComparison.OrdinalIgnoreCase) ? "btn-sm" : string.Empty;
     }
 
     private bool IsAuthorized()

--- a/Oqtane.Client/Modules/Controls/ActionDialog.razor
+++ b/Oqtane.Client/Modules/Controls/ActionDialog.razor
@@ -22,9 +22,9 @@
                         <div class="modal-footer">
                             @if (!string.IsNullOrEmpty(Action))
                             {
-                                <button type="button" class="@Class" @onclick="Confirm">@((MarkupString)_iconSpan) @Text</button>
+                                <button type="button" class="@ConfirmClass" @onclick="Confirm">@((MarkupString)_iconSpan) @Text</button>
                             }
-                            <button type="button" class="btn btn-secondary @GetButtonSize()" @onclick="DisplayModal">@SharedLocalizer["Cancel"]</button>
+                            <button type="button" class="@CancelClass" @onclick="DisplayModal">@SharedLocalizer["Cancel"]</button>
                         </div>
                     </div>
                 </div>
@@ -66,12 +66,12 @@ else
                             {
                                 <form method="post" @formname="@($"ActionDialogConfirmForm:{ModuleState.PageModuleId}:{Id}")" @onsubmit="Confirm" data-enhance>
                                     <input type="hidden" name="@Constants.RequestVerificationToken" value="@SiteState.AntiForgeryToken" />
-                                    <button type="submit" class="@Class">@((MarkupString)_iconSpan) @Text</button>
+                                    <button type="submit" class="@ConfirmClass">@((MarkupString)_iconSpan) @Text</button>
                                 </form>
                             }
                             <form method="post" @formname="@($"ActionDialogCancelForm:{ModuleState.PageModuleId}:{Id}")" @onsubmit="DisplayModal" data-enhance>
                                 <input type="hidden" name="@Constants.RequestVerificationToken" value="@SiteState.AntiForgeryToken" />
-                                <button type="submit" class="btn btn-secondary @GetButtonSize()">@SharedLocalizer["Cancel"]</button>
+                                <button type="submit" class="@CancelClass">@SharedLocalizer["Cancel"]</button>
                             </form>
                         </div>
                     </div>
@@ -129,6 +129,12 @@ else
     public string Class { get; set; } // optional
 
     [Parameter]
+    public string ConfirmClass { get; set; } // optional - for Confirm modal button
+
+    [Parameter]
+    public string CancelClass { get; set; } // optional - for Cancel modal button
+
+    [Parameter]
     public bool Disabled { get; set; } // optional
 
     [Parameter]
@@ -166,6 +172,16 @@ else
         if (string.IsNullOrEmpty(Class))
         {
             Class = "btn btn-success";
+        }
+
+        if (string.IsNullOrEmpty(ConfirmClass))
+        {
+            ConfirmClass = Class;
+        }
+
+        if (string.IsNullOrEmpty(CancelClass))
+        {
+            CancelClass = "btn btn-secondary";
         }
 
         if (!string.IsNullOrEmpty(EditMode))


### PR DESCRIPTION
This PR introduces a new private method GetButtonSize() to enhance the consistency of button sizing within our UI. The method specifically checks for the presence of the "btn-sm" class in the Action Button's class list and applies the same sizing to the Cancel Button if found.