### PR TITLE
Fixes #5005: Add Browser Caching for Static Assets

### DIFF
--- a/Oqtane.Server/Startup.cs
+++ b/Oqtane.Server/Startup.cs
@@ -205,6 +205,7 @@ namespace Oqtane
                 ServeUnknownFileTypes = true,
                 OnPrepareResponse = (ctx) =>
                 {
+                    ctx.Context.Response.Headers.Append("Cache-Control", "public, max-age=604800");
                     var policy = corsPolicyProvider.GetPolicyAsync(ctx.Context, Constants.MauiCorsPolicy)
                         .ConfigureAwait(false).GetAwaiter().GetResult();
                     corsService.ApplyResult(corsService.EvaluatePolicy(ctx.Context, policy), ctx.Context.Response);

--- a/Oqtane.Server/appsettings.json
+++ b/Oqtane.Server/appsettings.json
@@ -2,10 +2,10 @@
   "RenderMode": "Interactive",
   "Runtime": "Server",
   "Database": {
-    "DefaultDBType": ""
+    "DefaultDBType": "Oqtane.Database.SqlServer.SqlServerDatabase, Oqtane.Database.SqlServer"
   },
   "ConnectionStrings": {
-    "DefaultConnection": ""
+    "DefaultConnection": "Data Source=(LocalDb)\\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\\Oqtane-202501210838.mdf;Initial Catalog=Oqtane-202501210838;Integrated Security=SSPI;Encrypt=false;"
   },
   "Installation": {
     "DefaultAlias": "",
@@ -54,5 +54,6 @@
     "LogLevel": {
       "Default": "Information"
     }
-  }
+  },
+  "InstallationId": "60faae5c-96ea-4416-9abf-9203fd9e3d8d"
 }

--- a/Oqtane.Server/appsettings.json
+++ b/Oqtane.Server/appsettings.json
@@ -2,10 +2,10 @@
   "RenderMode": "Interactive",
   "Runtime": "Server",
   "Database": {
-    "DefaultDBType": "Oqtane.Database.SqlServer.SqlServerDatabase, Oqtane.Database.SqlServer"
+    "DefaultDBType": ""
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=(LocalDb)\\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\\Oqtane-202501210838.mdf;Initial Catalog=Oqtane-202501210838;Integrated Security=SSPI;Encrypt=false;"
+    "DefaultConnection": ""
   },
   "Installation": {
     "DefaultAlias": "",
@@ -54,6 +54,5 @@
     "LogLevel": {
       "Default": "Information"
     }
-  },
-  "InstallationId": "60faae5c-96ea-4416-9abf-9203fd9e3d8d"
+  }
 }


### PR DESCRIPTION
This PR addresses issue #5005 by adding the Cache-Control header for static file responses. This enhancement will allow browsers to cache static assets such as images, JavaScript, and CSS, improving performance by reducing the number of network requests on subsequent visits. The change is aimed at improving Lighthouse performance metrics for the application.

Testing:

Changes have been tested locally to confirm the Cache-Control headers are being correctly applied to static files.
Performance testing has shown an improvement in load times when the caching headers are applied.

![Screenshot 2025-01-21 171303](https://github.com/user-attachments/assets/e57006a3-d6b6-4350-a3b6-a8e5becff5fb)
![Screenshot 2025-01-21 171116](https://github.com/user-attachments/assets/c9df04dd-d7b6-4456-a683-7f62715b7d03)

Note:
Since this is my first PR, please let me know if there are any suggestions for improvements if I have missed anything or if I have done it totally wrong!!. I'm open to feedback!
