### PR TITLE
fix #5074: generate cancellation token for file upload

### DIFF
--- a/Oqtane.Client/Modules/Controls/FileManager.razor
+++ b/Oqtane.Client/Modules/Controls/FileManager.razor
@@ -362,6 +362,8 @@
             }
             if (restricted == "")
             {
+                CancellationTokenSource tokenSource = new CancellationTokenSource();
+
                 try
                 {
                     // upload the files
@@ -394,7 +396,7 @@
                     }
 
                     // upload files
-                    var success = await interop.UploadFiles(posturl, folder, _guid, SiteState.AntiForgeryToken, jwt, chunksize);
+                    var success = await interop.UploadFiles(posturl, folder, _guid, SiteState.AntiForgeryToken, jwt, chunksize, tokenSource.Token);
 
                     // reset progress indicators
                     if (ShowProgress)
@@ -449,6 +451,10 @@
                     _message = Localizer["Error.File.Upload"];
                     _messagetype = MessageType.Error;
                     _uploading = false;
+                    await tokenSource.CancelAsync();
+                }
+                finally {
+                    tokenSource.Dispose();
                 }
 
             }

--- a/Oqtane.Client/UI/Interop.cs
+++ b/Oqtane.Client/UI/Interop.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using System.Text.Json;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace Oqtane.UI
 {
@@ -214,12 +215,12 @@ namespace Oqtane.UI
             return Task.CompletedTask;
         }
 
-        public ValueTask<bool> UploadFiles(string posturl, string folder, string id, string antiforgerytoken, string jwt, int chunksize)
+        public ValueTask<bool> UploadFiles(string posturl, string folder, string id, string antiforgerytoken, string jwt, int chunksize, CancellationToken cancellationToken = default)
         {
             try
             {
                 return _jsRuntime.InvokeAsync<bool>(
-                    "Oqtane.Interop.uploadFiles",
+                    "Oqtane.Interop.uploadFiles", cancellationToken,
                     posturl, folder, id, antiforgerytoken, jwt, chunksize);
             }
             catch


### PR DESCRIPTION
Fixes #5074 by generating a cancellation token to override the default JSRuntime timeout