### PR TITLE
Files server optimization

### DIFF
--- a/Oqtane.Server/Pages/Files.cshtml.cs
+++ b/Oqtane.Server/Pages/Files.cshtml.cs
@@ -137,14 +137,14 @@ namespace Oqtane.Pages
             string downloadName = file.Name;
             string filepath = _files.GetFilePath(file);
 
+            var etagInput = $"{file.ModifiedOn.Ticks}:{file.Size}";
+
             if (Request.QueryString.HasValue)
             {
-                etag = Utilities.GenerateSimpleHash(Request.QueryString.Value);
+                etagInput += $":{Request.QueryString.Value}";
             }
-            else
-            {
-                etag = Convert.ToString(file.ModifiedOn.Ticks ^ file.Size, 16);
-            }
+
+            etag = Utilities.GenerateHashMD5(etagInput);
 
             var header = "";
             if (HttpContext.Request.Headers.TryGetValue(HeaderNames.IfNoneMatch, out var ifNoneMatch))

--- a/Oqtane.Server/Pages/Files.cshtml.cs
+++ b/Oqtane.Server/Pages/Files.cshtml.cs
@@ -133,18 +133,9 @@ namespace Oqtane.Pages
                 }
             }
 
-            string etag;
+            string etag = Convert.ToString(file.ModifiedOn.Ticks ^ file.Size, 16);
             string downloadName = file.Name;
             string filepath = _files.GetFilePath(file);
-
-            if (Request.QueryString.HasValue)
-            {
-                etag = Utilities.GenerateSimpleHash16($"{file.ModifiedOn.Ticks}:{file.Size}:{Request.QueryString.Value}");
-            }
-            else
-            {
-                etag = Convert.ToString(file.ModifiedOn.Ticks ^ file.Size, 16);
-            }
 
             var header = "";
             if (HttpContext.Request.Headers.TryGetValue(HeaderNames.IfNoneMatch, out var ifNoneMatch))

--- a/Oqtane.Server/Pages/Files.cshtml.cs
+++ b/Oqtane.Server/Pages/Files.cshtml.cs
@@ -137,14 +137,14 @@ namespace Oqtane.Pages
             string downloadName = file.Name;
             string filepath = _files.GetFilePath(file);
 
-            var etagInput = $"{file.ModifiedOn.Ticks}:{file.Size}";
-
             if (Request.QueryString.HasValue)
             {
-                etagInput += $":{Request.QueryString.Value}";
+                etag = Utilities.GenerateSimpleHash16($"{file.ModifiedOn.Ticks}:{file.Size}:{Request.QueryString.Value}");
             }
-
-            etag = Utilities.GenerateSimpleHash16(etagInput);
+            else
+            {
+                etag = Convert.ToString(file.ModifiedOn.Ticks ^ file.Size, 16);
+            }
 
             var header = "";
             if (HttpContext.Request.Headers.TryGetValue(HeaderNames.IfNoneMatch, out var ifNoneMatch))

--- a/Oqtane.Server/Pages/Files.cshtml.cs
+++ b/Oqtane.Server/Pages/Files.cshtml.cs
@@ -144,7 +144,7 @@ namespace Oqtane.Pages
                 etagInput += $":{Request.QueryString.Value}";
             }
 
-            etag = Utilities.GenerateHashMD5(etagInput);
+            etag = Utilities.GenerateSimpleHash16(etagInput);
 
             var header = "";
             if (HttpContext.Request.Headers.TryGetValue(HeaderNames.IfNoneMatch, out var ifNoneMatch))

--- a/Oqtane.Server/Pages/Files.cshtml.cs
+++ b/Oqtane.Server/Pages/Files.cshtml.cs
@@ -112,7 +112,7 @@ namespace Oqtane.Pages
 
                         url += Request.QueryString.Value.Substring(1);
                     }
-                    
+
                     return RedirectPermanent(url);
                 }
 
@@ -136,6 +136,34 @@ namespace Oqtane.Pages
             string etag;
             string downloadName = file.Name;
             string filepath = _files.GetFilePath(file);
+
+            if (Request.QueryString.HasValue)
+            {
+                etag = Utilities.GenerateSimpleHash(Request.QueryString.Value);
+            }
+            else
+            {
+                etag = Convert.ToString(file.ModifiedOn.Ticks ^ file.Size, 16);
+            }
+
+            var header = "";
+            if (HttpContext.Request.Headers.TryGetValue(HeaderNames.IfNoneMatch, out var ifNoneMatch))
+            {
+                header = ifNoneMatch.ToString();
+            }
+
+            if (header.Equals(etag))
+            {
+                HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
+                return Content(String.Empty);
+            }
+
+            if (!System.IO.File.Exists(filepath))
+            {
+                _logger.Log(LogLevel.Error, this, LogFunction.Read, "File Does Not Exist {FilePath}", filepath);
+                HttpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                return BrokenFile();
+            }
 
             // evaluate any querystring parameters
             bool isRequestingImageManipulation = false;
@@ -163,34 +191,6 @@ namespace Oqtane.Pages
             if (Request.Query.TryGetValue("format", out var format) && _imageService.GetAvailableFormats().Contains(format.ToString()))
             {
                 isRequestingImageManipulation = true;
-            }
-
-            if (isRequestingImageManipulation)
-            {
-                etag = Utilities.GenerateSimpleHash(Request.QueryString.Value);
-            }
-            else
-            {
-                etag = Convert.ToString(file.ModifiedOn.Ticks ^ file.Size, 16);
-            }
-
-            var header = "";
-            if (HttpContext.Request.Headers.TryGetValue(HeaderNames.IfNoneMatch, out var ifNoneMatch))
-            {
-                header = ifNoneMatch.ToString();
-            }
-
-            if (header.Equals(etag))
-            {
-                HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
-                return Content(String.Empty);
-            }
-
-            if (!System.IO.File.Exists(filepath))
-            {
-                _logger.Log(LogLevel.Error, this, LogFunction.Read, "File Does Not Exist {FilePath}", filepath);
-                HttpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
-                return BrokenFile();
             }
 
             if (isRequestingImageManipulation)

--- a/Oqtane.Shared/Shared/Utilities.cs
+++ b/Oqtane.Shared/Shared/Utilities.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using File = Oqtane.Models.File;
@@ -617,6 +618,13 @@ namespace Oqtane.Shared
                 }
                 return hash.ToString("X8");
             }
+        }
+
+        public static string GenerateHashMD5(string input)
+        {
+            var bytes = Encoding.UTF8.GetBytes(input);
+            var hashBytes = MD5.HashData(bytes);
+            return Convert.ToHexString(hashBytes);
         }
 
         [Obsolete("ContentUrl(Alias alias, int fileId) is deprecated. Use FileUrl(Alias alias, int fileId) instead.", false)]

--- a/Oqtane.Shared/Shared/Utilities.cs
+++ b/Oqtane.Shared/Shared/Utilities.cs
@@ -5,7 +5,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using File = Oqtane.Models.File;

--- a/Oqtane.Shared/Shared/Utilities.cs
+++ b/Oqtane.Shared/Shared/Utilities.cs
@@ -620,11 +620,17 @@ namespace Oqtane.Shared
             }
         }
 
-        public static string GenerateHashMD5(string input)
+        public static string GenerateSimpleHash16(string text)
         {
-            var bytes = Encoding.UTF8.GetBytes(input);
-            var hashBytes = MD5.HashData(bytes);
-            return Convert.ToHexString(hashBytes);
+            unchecked // prevent overflow exception
+            {
+                long hash = 23;
+                foreach (char c in text)
+                {
+                    hash = hash * 31 + c;
+                }
+                return hash.ToString("X16");
+            }
         }
 
         [Obsolete("ContentUrl(Alias alias, int fileId) is deprecated. Use FileUrl(Alias alias, int fileId) instead.", false)]

--- a/Oqtane.Shared/Shared/Utilities.cs
+++ b/Oqtane.Shared/Shared/Utilities.cs
@@ -620,19 +620,6 @@ namespace Oqtane.Shared
             }
         }
 
-        public static string GenerateSimpleHash16(string text)
-        {
-            unchecked // prevent overflow exception
-            {
-                long hash = 23;
-                foreach (char c in text)
-                {
-                    hash = hash * 31 + c;
-                }
-                return hash.ToString("X16");
-            }
-        }
-
         [Obsolete("ContentUrl(Alias alias, int fileId) is deprecated. Use FileUrl(Alias alias, int fileId) instead.", false)]
         public static string ContentUrl(Alias alias, int fileId)
         {


### PR DESCRIPTION
Implements some optimizations for the /files server:

- Early return when 404 or 304, before evaluating query string
- Improves ETag compute by always including the ModifiedOn property and using MD5 to reduce probability of collisions (important when using CDNs)