### PR TITLE
fix #5229 - move IServerStartup.Configure execution until later so that it is possible to register custom endpoints

### DIFF
--- a/Oqtane.Server/Infrastructure/Middleware/TenantMiddleware.cs
+++ b/Oqtane.Server/Infrastructure/Middleware/TenantMiddleware.cs
@@ -23,10 +23,6 @@ namespace Oqtane.Infrastructure
             var config = context.RequestServices.GetService(typeof(IConfigManager)) as IConfigManager;
             string path = context.Request.Path.ToString();
 
-            // note that in order to support Alias subfolders we used to ignore Blazor framework requests...
-            // but this does not work in static rendering as the web UI request originates from /_blazor
-            //if (config.IsInstalled() && !path.StartsWith("/_"))
-
             if (config.IsInstalled()) 
             {
                 // get alias (note that this also sets SiteState.Alias)

--- a/Oqtane.Server/Startup.cs
+++ b/Oqtane.Server/Startup.cs
@@ -195,9 +195,6 @@ namespace Oqtane
                 app.UseHsts();
             }
 
-            // execute any IServerStartup logic
-            app.ConfigureOqtaneAssemblies(env);
-
             // allow oqtane localization middleware
             app.UseOqtaneLocalization();
 
@@ -247,6 +244,9 @@ namespace Oqtane
                     .AddInteractiveWebAssemblyRenderMode()
                     .AddAdditionalAssemblies(typeof(SiteRouter).Assembly);
             });
+
+            // execute any IServerStartup logic
+            app.ConfigureOqtaneAssemblies(env);
 
             // simulate the fallback routing approach of traditional Blazor - allowing the custom SiteRouter to handle all routing concerns
             app.UseEndpoints(endpoints =>


### PR DESCRIPTION
Note - this could be a breaking change for some third party modules which rely on the current location where Configure is executed.