### PR TITLE
fix #5352: remove requests to cookie consent service when not enabled

### DIFF
--- a/Oqtane.Client/Themes/Controls/Theme/CookieConsent.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/CookieConsent.razor
@@ -103,6 +103,9 @@
     {
         var cookieConsentSetting = SettingService.GetSetting(PageState.Site.Settings, "CookieConsent", string.Empty);
         _enabled = !string.IsNullOrEmpty(cookieConsentSetting);
+
+        if (!_enabled) return;
+
         _optout = cookieConsentSetting == "optout";
         _actioned = await CookieConsentService.IsActionedAsync();
 


### PR DESCRIPTION
Fixes #5352 with an early return in the CookieConsent control initialization method if cookie consent is not enabled.