### PR TITLE
fix #5414 - add DelimitName database provider method to better support MigrationBuilder.Sql() operations

### DIFF
--- a/Oqtane.Database.MySQL/MySQLDatabase.cs
+++ b/Oqtane.Database.MySQL/MySQLDatabase.cs
@@ -75,13 +75,9 @@ namespace Oqtane.Database.MySQL
             return dr;
         }
 
-        public override string RewriteName(string name, bool isQuery)
+        public override string DelimitName(string name)
         {
-            if (name.ToLower() == "rows" && isQuery)
-            {
-                name = $"`{name}`"; // escape reserved word in SQL query
-            }
-            return name;
+            return $"`{name}`";
         }
 
         public override DbContextOptionsBuilder UseDatabase(DbContextOptionsBuilder optionsBuilder, string connectionString)

--- a/Oqtane.Database.PostgreSQL/PostgreSQLDatabase.cs
+++ b/Oqtane.Database.PostgreSQL/PostgreSQLDatabase.cs
@@ -87,9 +87,9 @@ namespace Oqtane.Database.PostgreSQL
             return _rewriter.RewriteName(name);
         }
 
-        public override string RewriteName(string name, bool isQuery)
+        public override string DelimitName(string name)
         {
-            return _rewriter.RewriteName(name);
+            return $"\"{name}\"";
         }
 
         public override string RewriteValue(string value, string type)

--- a/Oqtane.Database.SqlServer/SqlServerDatabase.cs
+++ b/Oqtane.Database.SqlServer/SqlServerDatabase.cs
@@ -46,6 +46,11 @@ namespace Oqtane.Database.SqlServer
             }
         }
 
+        public override string DelimitName(string name)
+        {
+            return $"[{name}]";
+        }
+
         public override int ExecuteNonQuery(string connectionString, string query)
         {
             var conn = new SqlConnection(FormatConnectionString(connectionString));

--- a/Oqtane.Database.Sqlite/SqliteDatabase.cs
+++ b/Oqtane.Database.Sqlite/SqliteDatabase.cs
@@ -84,6 +84,11 @@ namespace Oqtane.Database.Sqlite
             return dr;
         }
 
+        public override string DelimitName(string name)
+        {
+            return $"\"{name}\"";
+        }
+
         public override DbContextOptionsBuilder UseDatabase(DbContextOptionsBuilder optionsBuilder, string connectionString)
         {
             return optionsBuilder.UseSqlite(connectionString)

--- a/Oqtane.Server/Databases/DatabaseBase.cs
+++ b/Oqtane.Server/Databases/DatabaseBase.cs
@@ -61,12 +61,12 @@ namespace Oqtane.Databases
 
         public abstract IDataReader ExecuteReader(string connectionString, string query);
 
-        public virtual string RewriteName(string name)
+        public virtual string DelimitName(string name)
         {
             return name;
         }
 
-        public virtual string RewriteName(string name, bool isQuery)
+        public virtual string RewriteName(string name)
         {
             return name;
         }

--- a/Oqtane.Server/Databases/Interfaces/IDatabase.cs
+++ b/Oqtane.Server/Databases/Interfaces/IDatabase.cs
@@ -26,9 +26,9 @@ namespace Oqtane.Databases.Interfaces
 
         public IDataReader ExecuteReader(string connectionString, string query);
 
-        public string RewriteName(string name);
+        public string DelimitName(string name); // only used in conjunction with method using MigrationBuilder.Sql()
 
-        public string RewriteName(string name, bool isQuery);
+        public string RewriteName(string name);
 
         public string RewriteValue(string value, string type);
 

--- a/Oqtane.Server/Infrastructure/DatabaseManager.cs
+++ b/Oqtane.Server/Infrastructure/DatabaseManager.cs
@@ -738,7 +738,7 @@ namespace Oqtane.Infrastructure
                 databases += "{ \"Name\": \"LocalDB\", \"ControlType\": \"Oqtane.Installer.Controls.LocalDBConfig, Oqtane.Client\", \"DBTYpe\": \"Oqtane.Database.SqlServer.SqlServerDatabase, Oqtane.Database.SqlServer\" },";
                 databases += "{ \"Name\": \"SQL Server\", \"ControlType\": \"Oqtane.Installer.Controls.SqlServerConfig, Oqtane.Client\", \"DBTYpe\": \"Oqtane.Database.SqlServer.SqlServerDatabase, Oqtane.Database.SqlServer\" },";
                 databases += "{ \"Name\": \"SQLite\", \"ControlType\": \"Oqtane.Installer.Controls.SqliteConfig, Oqtane.Client\", \"DBTYpe\": \"Oqtane.Database.Sqlite.SqliteDatabase, Oqtane.Database.Sqlite\" },";
-                databases += "{ \"Name\": \"MySQL\", \"ControlType\": \"Oqtane.Installer.Controls.MySQLConfig, Oqtane.Client\", \"DBTYpe\": \"Oqtane.Database.MySQL.SqlServerDatabase, Oqtane.Database.MySQL\" },";
+                databases += "{ \"Name\": \"MySQL\", \"ControlType\": \"Oqtane.Installer.Controls.MySQLConfig, Oqtane.Client\", \"DBTYpe\": \"Oqtane.Database.MySQL.MySQLDatabase, Oqtane.Database.MySQL\" },";
                 databases += "{ \"Name\": \"PostgreSQL\", \"ControlType\": \"Oqtane.Installer.Controls.PostgreSQLConfig, Oqtane.Client\", \"DBTYpe\": \"Oqtane.Database.PostgreSQL.PostgreSQLDatabase, Oqtane.Database.PostgreSQL\" }";
                 databases += "]";
                 _configManager.AddOrUpdateSetting(SettingKeys.AvailableDatabasesSection, databases, true);

--- a/Oqtane.Server/Migrations/EntityBuilders/BaseEntityBuilder.cs
+++ b/Oqtane.Server/Migrations/EntityBuilders/BaseEntityBuilder.cs
@@ -33,26 +33,26 @@ namespace Oqtane.Migrations.EntityBuilders
 
         protected string Schema { get; init; }
 
-        private string RewriteSqlEntityTableName(string name)
+        private string AddSchema(string name)
         {
-            if (Schema == null)
+            if (string.IsNullOrEmpty(Schema))
             {
-                return RewriteName(name);
+                return name;
             }
             else
             {
-                return $"{Schema}.{RewriteName(name)}";
+                return $"{Schema}.{name}";
             }
+        }
+
+        private string DelimitName(string name)
+        {
+            return ActiveDatabase.DelimitName(name);
         }
 
         private string RewriteName(string name)
         {
             return ActiveDatabase.RewriteName(name);
-        }
-
-        private string RewriteName(string name, bool isQuery)
-        {
-            return ActiveDatabase.RewriteName(name, isQuery);
         }
 
         private string RewriteValue(string value, string type)
@@ -468,9 +468,10 @@ namespace Oqtane.Migrations.EntityBuilders
 
         public void DeleteFromTable(string condition = "")
         {
-            var deleteSql = $"DELETE FROM {RewriteSqlEntityTableName(EntityTableName)} ";
+            var deleteSql = $"DELETE FROM {AddSchema(DelimitName(RewriteName(EntityTableName)))} ";
             if(!string.IsNullOrEmpty(condition))
             {
+                // note that condition values must be created using RewriteName(), DelimitName(), RewriteValue() if targeting multiple database platforms 
                 deleteSql +=  $"WHERE {condition}";
             }
             _migrationBuilder.Sql(deleteSql);
@@ -488,9 +489,10 @@ namespace Oqtane.Migrations.EntityBuilders
 
         public void UpdateColumn(string columnName, string value, string type, string condition)
         {
-            var updateSql = $"UPDATE {RewriteSqlEntityTableName(EntityTableName)} SET {RewriteName(columnName, true)} = {RewriteValue(value, type)} ";
+            var updateSql = $"UPDATE {AddSchema(DelimitName(RewriteName(EntityTableName)))} SET {DelimitName(RewriteName(columnName))} = {RewriteValue(value, type)} ";
             if (!string.IsNullOrEmpty(condition))
             {
+                // note that condition values must be created using RewriteName(), DelimitName(), RewriteValue() if targeting multiple database platforms 
                 updateSql += $"WHERE {condition}";
             }
             _migrationBuilder.Sql(updateSql);

--- a/Oqtane.Server/Migrations/Framework/MultiDatabaseMigration.cs
+++ b/Oqtane.Server/Migrations/Framework/MultiDatabaseMigration.cs
@@ -12,14 +12,19 @@ namespace Oqtane.Migrations
 
         protected IDatabase ActiveDatabase { get; }
 
-        protected string RewriteName(string name)
+        protected string DelimitName(string name)
         {
-            return ActiveDatabase.RewriteName(name, false);
+            return ActiveDatabase.DelimitName(name);
         }
 
-        protected string RewriteName(string name, bool isQuery)
+        protected string RewriteName(string name)
         {
-            return ActiveDatabase.RewriteName(name, isQuery);
+            return ActiveDatabase.RewriteName(name);
+        }
+
+        protected string RewriteValue(string value, string type)
+        {
+            return ActiveDatabase.RewriteValue(value, type);
         }
     }
 }

--- a/Oqtane.Server/Migrations/Tenant/01000101_AddAdditionColumnToNotifications.cs
+++ b/Oqtane.Server/Migrations/Tenant/01000101_AddAdditionColumnToNotifications.cs
@@ -21,7 +21,7 @@ namespace Oqtane.Migrations.Tenant
             notificationEntityBuilder.AddDateTimeColumn("SendOn", true);
 
             //Update new Column
-            notificationEntityBuilder.UpdateColumn("SendOn", $"{ActiveDatabase.RewriteName("CreatedOn")}", $"{ActiveDatabase.RewriteName("SendOn")} IS NULL");
+            notificationEntityBuilder.UpdateColumn("SendOn", $"{RewriteName("CreatedOn")}", $"{DelimitName(RewriteName("SendOn"))} IS NULL");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/Oqtane.Server/Migrations/Tenant/02000101_UpdateIconColumnInPage.cs
+++ b/Oqtane.Server/Migrations/Tenant/02000101_UpdateIconColumnInPage.cs
@@ -18,8 +18,8 @@ namespace Oqtane.Migrations.Tenant
         {
             ///Update Icon Field in Page
             var pageEntityBuilder = new PageEntityBuilder(migrationBuilder, ActiveDatabase);
-            var updateSql = ActiveDatabase.ConcatenateSql("'oi oi-'", $"{ActiveDatabase.RewriteName("Icon")}");
-            pageEntityBuilder.UpdateColumn("Icon", updateSql, $"{ActiveDatabase.RewriteName("Icon")} <> ''" );
+            var updateSql = ActiveDatabase.ConcatenateSql("'oi oi-'", $"{DelimitName(RewriteName("Icon"))}");
+            pageEntityBuilder.UpdateColumn("Icon", updateSql, $"{DelimitName(RewriteName("Icon"))} <> ''" );
         }
     }
 }

--- a/Oqtane.Server/Migrations/Tenant/02000202_UpdateDefaultContainerTypeInSitePage.cs
+++ b/Oqtane.Server/Migrations/Tenant/02000202_UpdateDefaultContainerTypeInSitePage.cs
@@ -20,18 +20,18 @@ namespace Oqtane.Migrations.Tenant
             {
                 //Update DefaultContainerType In Site
                 var siteEntityBuilder = new SiteEntityBuilder(migrationBuilder, ActiveDatabase);
-                siteEntityBuilder.UpdateColumn("DefaultContainerType", "'Oqtane.Themes.OqtaneTheme.DefaultTitle, Oqtane.Client'", "DefaultContainerType = 'Oqtane.Themes.OqtaneTheme.Container, Oqtane.Client'");
-                siteEntityBuilder.UpdateColumn("DefaultContainerType", "'Oqtane.Themes.OqtaneTheme.DefaultNoTitle, Oqtane.Client'", "DefaultContainerType = 'Oqtane.Themes.OqtaneTheme.NoTitle, Oqtane.Client'");
+                siteEntityBuilder.UpdateColumn("DefaultContainerType", "'Oqtane.Themes.OqtaneTheme.DefaultTitle, Oqtane.Client'", $"{DelimitName(RewriteName("DefaultContainerType"))} = 'Oqtane.Themes.OqtaneTheme.Container, Oqtane.Client'");
+                siteEntityBuilder.UpdateColumn("DefaultContainerType", "'Oqtane.Themes.OqtaneTheme.DefaultNoTitle, Oqtane.Client'", $"{DelimitName(RewriteName("DefaultContainerType"))} = 'Oqtane.Themes.OqtaneTheme.NoTitle, Oqtane.Client'");
 
                 //Update DefaultContainerType in Page
                 var pageEntityBuilder = new PageEntityBuilder(migrationBuilder, ActiveDatabase);
-                pageEntityBuilder.UpdateColumn("DefaultContainerType", "'Oqtane.Themes.OqtaneTheme.DefaultTitle, Oqtane.Client'", "DefaultContainerType = 'Oqtane.Themes.OqtaneTheme.Container, Oqtane.Client'");
-                pageEntityBuilder.UpdateColumn("DefaultContainerType", "'Oqtane.Themes.OqtaneTheme.DefaultNoTitle, Oqtane.Client'", "DefaultContainerType = 'Oqtane.Themes.OqtaneTheme.NoTitle, Oqtane.Client'");
+                pageEntityBuilder.UpdateColumn("DefaultContainerType", "'Oqtane.Themes.OqtaneTheme.DefaultTitle, Oqtane.Client'", $"{DelimitName(RewriteName("DefaultContainerType"))} = 'Oqtane.Themes.OqtaneTheme.Container, Oqtane.Client'");
+                pageEntityBuilder.UpdateColumn("DefaultContainerType", "'Oqtane.Themes.OqtaneTheme.DefaultNoTitle, Oqtane.Client'", $"{DelimitName(RewriteName("DefaultContainerType"))} = 'Oqtane.Themes.OqtaneTheme.NoTitle, Oqtane.Client'");
 
                 //Update ContainerType in PageModule
                 var pageModuleEntityBuilder = new PageModuleEntityBuilder(migrationBuilder, ActiveDatabase);
-                pageModuleEntityBuilder.UpdateColumn("ContainerType", "'Oqtane.Themes.OqtaneTheme.DefaultTitle, Oqtane.Client'", "ContainerType = 'Oqtane.Themes.OqtaneTheme.Container, Oqtane.Client'");
-                pageModuleEntityBuilder.UpdateColumn("ContainerType", "'Oqtane.Themes.OqtaneTheme.DefaultNoTitle, Oqtane.Client'", "ContainerType = 'Oqtane.Themes.OqtaneTheme.NoTitle, Oqtane.Client'");
+                pageModuleEntityBuilder.UpdateColumn("ContainerType", "'Oqtane.Themes.OqtaneTheme.DefaultTitle, Oqtane.Client'", $"{DelimitName(RewriteName("ContainerType"))} = 'Oqtane.Themes.OqtaneTheme.Container, Oqtane.Client'");
+                pageModuleEntityBuilder.UpdateColumn("ContainerType", "'Oqtane.Themes.OqtaneTheme.DefaultNoTitle, Oqtane.Client'", $"{DelimitName(RewriteName("ContainerType"))} = 'Oqtane.Themes.OqtaneTheme.NoTitle, Oqtane.Client'");
             }
 
         }

--- a/Oqtane.Server/Migrations/Tenant/02000203_DropDefaultLayoutInSite.cs
+++ b/Oqtane.Server/Migrations/Tenant/02000203_DropDefaultLayoutInSite.cs
@@ -29,22 +29,22 @@ namespace Oqtane.Migrations.Tenant
                 siteEntityBuilder.DropColumn("DefaultLayoutType");
 
                 //Update DefaultContainerType In Site
-                siteEntityBuilder.UpdateColumn("DefaultContainerType", "'Oqtane.Themes.OqtaneTheme.Container, Oqtane.Client'", "DefaultContainerType = 'Oqtane.Themes.OqtaneTheme.DefaultTitle, Oqtane.Client'");
-                siteEntityBuilder.UpdateColumn("DefaultContainerType", "'Oqtane.Themes.OqtaneTheme.Container, Oqtane.Client'", "DefaultContainerType = 'Oqtane.Themes.OqtaneTheme.DefaultNoTitle, Oqtane.Client'");
+                siteEntityBuilder.UpdateColumn("DefaultContainerType", "'Oqtane.Themes.OqtaneTheme.Container, Oqtane.Client'", $"{DelimitName(RewriteName("DefaultContainerType"))} = 'Oqtane.Themes.OqtaneTheme.DefaultTitle, Oqtane.Client'");
+                siteEntityBuilder.UpdateColumn("DefaultContainerType", "'Oqtane.Themes.OqtaneTheme.Container, Oqtane.Client'", $"{DelimitName(RewriteName("DefaultContainerType"))} = 'Oqtane.Themes.OqtaneTheme.DefaultNoTitle, Oqtane.Client'");
 
                 //Drop Column from Page Table
                 var pageEntityBuilder = new PageEntityBuilder(migrationBuilder, ActiveDatabase);
                 pageEntityBuilder.DropColumn("LayoutType");
 
                 //Update DefaultContainerType in Page
-                pageEntityBuilder.UpdateColumn("DefaultContainerType", "'Oqtane.Themes.OqtaneTheme.Container, Oqtane.Client'", "DefaultContainerType = 'Oqtane.Themes.OqtaneTheme.DefaultTitle, Oqtane.Client'");
-                pageEntityBuilder.UpdateColumn("DefaultContainerType", "'Oqtane.Themes.OqtaneTheme.Container, Oqtane.Client'", "DefaultContainerType = 'Oqtane.Themes.OqtaneTheme.DefaultNoTitle, Oqtane.Client'");
+                pageEntityBuilder.UpdateColumn("DefaultContainerType", "'Oqtane.Themes.OqtaneTheme.Container, Oqtane.Client'", $"{DelimitName(RewriteName("DefaultContainerType"))} = 'Oqtane.Themes.OqtaneTheme.DefaultTitle, Oqtane.Client'");
+                pageEntityBuilder.UpdateColumn("DefaultContainerType", "'Oqtane.Themes.OqtaneTheme.Container, Oqtane.Client'", $"{DelimitName(RewriteName("DefaultContainerType"))} = 'Oqtane.Themes.OqtaneTheme.DefaultNoTitle, Oqtane.Client'");
 
 
                 //Update ContainerType in PageModule
                 var pageModuleEntityBuilder = new PageModuleEntityBuilder(migrationBuilder, ActiveDatabase);
-                pageModuleEntityBuilder.UpdateColumn("ContainerType", "'Oqtane.Themes.OqtaneTheme.Container, Oqtane.Client'", "ContainerType = 'Oqtane.Themes.OqtaneTheme.DefaultTitle, Oqtane.Client'");
-                pageModuleEntityBuilder.UpdateColumn("ContainerType", "'Oqtane.Themes.OqtaneTheme.Container, Oqtane.Client'", "ContainerType = 'Oqtane.Themes.OqtaneTheme.DefaultNoTitle, Oqtane.Client'");
+                pageModuleEntityBuilder.UpdateColumn("ContainerType", "'Oqtane.Themes.OqtaneTheme.Container, Oqtane.Client'", $"{DelimitName(RewriteName("ContainerType"))} = 'Oqtane.Themes.OqtaneTheme.DefaultTitle, Oqtane.Client'");
+                pageModuleEntityBuilder.UpdateColumn("ContainerType", "'Oqtane.Themes.OqtaneTheme.Container, Oqtane.Client'", $"{DelimitName(RewriteName("ContainerType"))} = 'Oqtane.Themes.OqtaneTheme.DefaultNoTitle, Oqtane.Client'");
 
             }
         }

--- a/Oqtane.Server/Migrations/Tenant/02030001_AddFolderCapacity.cs
+++ b/Oqtane.Server/Migrations/Tenant/02030001_AddFolderCapacity.cs
@@ -20,7 +20,7 @@ namespace Oqtane.Migrations.Tenant
             var folderEntityBuilder = new FolderEntityBuilder(migrationBuilder, ActiveDatabase);
             folderEntityBuilder.AddIntegerColumn("Capacity", true);
             folderEntityBuilder.UpdateColumn("Capacity", "0");
-            folderEntityBuilder.UpdateColumn("Capacity", Constants.UserFolderCapacity.ToString(), $"{ActiveDatabase.RewriteName("Name")} = 'My Folder'");
+            folderEntityBuilder.UpdateColumn("Capacity", Constants.UserFolderCapacity.ToString(), $"{DelimitName(RewriteName("Name"))} = 'My Folder'");
             folderEntityBuilder.AddStringColumn("ImageSizes", 512, true, true);
 
             var fileEntityBuilder = new FileEntityBuilder(migrationBuilder, ActiveDatabase);

--- a/Oqtane.Server/Migrations/Tenant/03000201_UpdateSettingIsPublic.cs
+++ b/Oqtane.Server/Migrations/Tenant/03000201_UpdateSettingIsPublic.cs
@@ -18,13 +18,13 @@ namespace Oqtane.Migrations.Tenant
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             var settingEntityBuilder = new SettingEntityBuilder(migrationBuilder, ActiveDatabase);
-            settingEntityBuilder.UpdateColumn("IsPublic", "1", "bool", $"{RewriteName("SettingName")} NOT LIKE 'SMTP%'");
+            settingEntityBuilder.UpdateColumn("IsPublic", "1", "bool", $"{DelimitName(RewriteName("SettingName"))} NOT LIKE 'SMTP%'");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             var settingEntityBuilder = new SettingEntityBuilder(migrationBuilder, ActiveDatabase);
-            settingEntityBuilder.UpdateColumn("IsPublic", "0", "bool", $"{RewriteName("SettingName")} NOT LIKE 'SMTP%'");
+            settingEntityBuilder.UpdateColumn("IsPublic", "0", "bool", $"{DelimitName(RewriteName("SettingName"))} NOT LIKE 'SMTP%'");
         }
     }
 }

--- a/Oqtane.Server/Migrations/Tenant/03000202_UpdateSettingIsPrivate.cs
+++ b/Oqtane.Server/Migrations/Tenant/03000202_UpdateSettingIsPrivate.cs
@@ -20,7 +20,7 @@ namespace Oqtane.Migrations.Tenant
             var settingEntityBuilder = new SettingEntityBuilder(migrationBuilder, ActiveDatabase);
             settingEntityBuilder.AddBooleanColumn("IsPrivate", true);
             settingEntityBuilder.UpdateColumn("IsPrivate", "0", "bool", "");
-            settingEntityBuilder.UpdateColumn("IsPrivate", "1", "bool", $"{RewriteName("EntityName")} = 'Site' AND { RewriteName("SettingName")} LIKE 'SMTP%'");
+            settingEntityBuilder.UpdateColumn("IsPrivate", "1", "bool", $"{DelimitName(RewriteName("EntityName"))} = 'Site' AND { DelimitName(RewriteName("SettingName"))} LIKE 'SMTP%'");
             settingEntityBuilder.DropColumn("IsPublic");
         }
 

--- a/Oqtane.Server/Migrations/Tenant/06010402_ResetTimeZone.cs
+++ b/Oqtane.Server/Migrations/Tenant/06010402_ResetTimeZone.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Oqtane.Databases.Interfaces;
+using Oqtane.Migrations.EntityBuilders;
+using Oqtane.Repository;
+
+namespace Oqtane.Migrations.Tenant
+{
+    [DbContext(typeof(TenantDBContext))]
+    [Migration("Tenant.06.01.04.02")]
+    public class ResetTimeZone : MultiDatabaseMigration
+    {
+        public ResetTimeZone(IDatabase database) : base(database)
+        {
+        }
+
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // resetting value as framework now uses IANA ID consistently for time zones
+            var siteEntityBuilder = new SiteEntityBuilder(migrationBuilder, ActiveDatabase);
+            siteEntityBuilder.UpdateColumn("TimeZoneId", "''");
+
+            var userEntityBuilder = new UserEntityBuilder(migrationBuilder, ActiveDatabase);
+            userEntityBuilder.UpdateColumn("TimeZoneId", "''");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // not implemented
+        }
+    }
+}


### PR DESCRIPTION
this PR was tested on new install scenarios for SQL Server, SQLite, PostgreSQL, and MySQL