### PR TITLE
Update v6.2.0 azure deploy and Oqtane.Server project dependencies

### DIFF
--- a/Oqtane.Server/Oqtane.Server.csproj
+++ b/Oqtane.Server/Oqtane.Server.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.8" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
     <PackageReference Include="MailKit" Version="4.13.0" />
   </ItemGroup>
   
@@ -62,7 +62,7 @@
     <!-- SQLite Database Provider Dependencies -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.8" />
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="9.0.8" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.1" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.2" />
     <!-- SQL Server Database Provider Dependencies -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.8" />
   </ItemGroup>

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -220,7 +220,7 @@
 	  "apiVersion": "2024-04-01",
 	  "name": "[concat(parameters('BlazorWebsiteName'), '/ZipDeploy')]",
           "properties": {
-	    "packageUri": "https://github.com/oqtane/oqtane.framework/releases/download/v6.1.5/Oqtane.Framework.6.1.5.Install.zip"
+	    "packageUri": "https://github.com/oqtane/oqtane.framework/releases/download/v6.2.0/Oqtane.Framework.6.2.0.Install.zip"
           },
           "dependsOn": [
             "[resourceId('Microsoft.Web/sites', parameters('BlazorWebsiteName'))]"


### PR DESCRIPTION
Updates link to v6.2.0 in azuredeploy.json and updates the Oqtane.Server project dependencies for Swashbuckle.AspNetCore plus SQLitePCLRaw.bundle_e_sqlite3 to latest releases.