### PR TITLE
remove content files from Oqtane.Server Nuget package

### DIFF
--- a/Oqtane.Package/Oqtane.Server.nuspec
+++ b/Oqtane.Package/Oqtane.Server.nuspec
@@ -41,16 +41,6 @@
         <dependency id="Microsoft.EntityFrameworkCore.SqlServer" version="9.0.9" exclude="Build,Analyzers" />
       </group>
     </dependencies>
-    <contentFiles>
-      <files include="any/any/wwwroot/*.*" buildAction="Content" copyToOutput="true" flatten="false" />
-      <files include="any/any/wwwroot/css/**/*.*" buildAction="Content" copyToOutput="true" flatten="false" />
-      <files include="any/any/wwwroot/images/**/*.*" buildAction="Content" copyToOutput="true" flatten="false" />
-      <files include="any/any/wwwroot/js/**/*.*" buildAction="Content" copyToOutput="true" flatten="false" />
-      <files include="any/any/wwwroot/Modules/Oqtane.Modules.Admin.Login/**/*.*" buildAction="Content" copyToOutput="true" flatten="false" />
-      <files include="any/any/wwwroot/Modules/Oqtane.Modules.HtmlText/**/*.*" buildAction="Content" copyToOutput="true" flatten="false" />
-      <files include="any/any/wwwroot/Themes/Oqtane.Themes.BlazorTheme/**/*.*" buildAction="Content" copyToOutput="true" flatten="false" />
-      <files include="any/any/wwwroot/Themes/Oqtane.Themes.OqtaneTheme/**/*.*" buildAction="Content" copyToOutput="true" flatten="false" />
-    </contentFiles>
     <frameworkReferences>
       <group targetFramework="net9.0">
         <frameworkReference name="Microsoft.AspNetCore.App" />
@@ -60,14 +50,6 @@
   <files>
     <file src="..\Oqtane.Server\bin\Release\net9.0\Oqtane.Server.dll" target="lib\net9.0" /> 
     <file src="..\Oqtane.Server\bin\Release\net9.0\Oqtane.Server.pdb" target="lib\net9.0" /> 
-    <file src="..\Oqtane.Server\wwwroot\*.*" target="contentFiles\any\any\wwwroot\" />
-    <file src="..\Oqtane.Server\wwwroot\css\**\*.*" target="contentFiles\any\any\wwwroot\css\" />
-    <file src="..\Oqtane.Server\wwwroot\images\**\*.*" target="contentFiles\any\any\wwwroot\images\" />
-    <file src="..\Oqtane.Server\wwwroot\js\**\*.*" target="contentFiles\any\any\wwwroot\js\" />
-    <file src="..\Oqtane.Server\wwwroot\Modules\Oqtane.Modules.Admin.Login\**\*.*" target="contentFiles\any\any\wwwroot\Modules\Oqtane.Modules.Admin.Login\" />
-    <file src="..\Oqtane.Server\wwwroot\Modules\Oqtane.Modules.HtmlText\**\*.*" target="contentFiles\any\any\wwwroot\Modules\Oqtane.Modules.HtmlText\" />
-    <file src="..\Oqtane.Server\wwwroot\Themes\Oqtane.Themes.BlazorTheme\**\*.*" target="contentFiles\any\any\wwwroot\Themes\Oqtane.Themes.BlazorTheme\" />
-    <file src="..\Oqtane.Server\wwwroot\Themes\Oqtane.Themes.OqtaneTheme\**\*.*" target="contentFiles\any\any\wwwroot\Themes\Oqtane.Themes.OqtaneTheme\" />
     <file src="icon.png" target="" />
     <file src="readme.md" target="" />
   </files>


### PR DESCRIPTION
#5605 added the assets to the Oqtane.Server package as contentFiles. This allowed the Oqtane Application template to access the assets from the package rather than requiring that they be duplicated within the Application template. And when publishing, it copied the assets to the publish folder successfully. However, when running in Visual Studio the JavaScript and CSS assets were not accessible resulting in 404 errors. Therefore this needed to be rolled back.