### PR TITLE
fix issues with NotificationJob related to MailKit behavior

### DIFF
--- a/Oqtane.Server/Repository/NotificationRepository.cs
+++ b/Oqtane.Server/Repository/NotificationRepository.cs
@@ -144,14 +144,14 @@ namespace Oqtane.Repository
             // delete notifications in batches of 100 records
             var count = 0;
             var purgedate = DateTime.UtcNow.AddDays(-age);
-            var notifications = db.Notification.Where(item => item.SiteId == siteId && item.FromUserId == null && item.IsDelivered && item.DeliveredOn < purgedate)
+            var notifications = db.Notification.Where(item => item.SiteId == siteId && item.FromUserId == null && (item.IsDeleted || item.IsDelivered && item.DeliveredOn < purgedate))
                 .OrderBy(item => item.DeliveredOn).Take(100).ToList();
             while (notifications.Count > 0)
             {
                 count += notifications.Count;
                 db.Notification.RemoveRange(notifications);
                 db.SaveChanges();
-                notifications = db.Notification.Where(item => item.SiteId == siteId && item.FromUserId == null && item.IsDelivered && item.DeliveredOn < purgedate)
+                notifications = db.Notification.Where(item => item.SiteId == siteId && item.FromUserId == null && (item.IsDeleted || item.IsDelivered && item.DeliveredOn < purgedate))
                 .OrderBy(item => item.DeliveredOn).Take(100).ToList();
             }
             return count;


### PR DESCRIPTION
MailboxAddress.TryParse() seems to use different logic than the MailboxAddress() constructor and as a result, email addresses which pass the TryParse() validation will sometimes throw a parsing exception when creating a new MailboxAddress() object. This behavior is different than System.Net.Mail and did not have exception handling, resulting in the job terminating prematurely.,