### PR TITLE
RadzenTextEditor.placeholder.cs in RadzenTextEditor for docs

### DIFF
--- a/Oqtane.Client/Modules/Controls/TextEditors/Radzen/RadzenTextEditor.placeholder.cs
+++ b/Oqtane.Client/Modules/Controls/TextEditors/Radzen/RadzenTextEditor.placeholder.cs
@@ -1,0 +1,12 @@
+// This is just a placeholder file
+// It is necessary for the documentation to successfully build this project.
+// Reason is that docfx will run the .net compiler and find references
+// to this class in the project.
+// But since the real class is just a .razor file, ATM docfx will fail.
+//
+// Note added 2025-09-23 by @tvatavuk.
+// We hope that as .net and docfx improve, the razor-compiler will work in that scenario
+// as well, and this file can be removed.
+
+namespace Oqtane.Modules.Controls;
+public partial class RadzenTextEditor;


### PR DESCRIPTION
This is just a placeholder file
It is necessary for the documentation to successfully build this project. Reason is that docfx will run the .net compiler and find references to this class in the project.
But since the real class is just a .razor file, ATM docfx will fail.

We hope that as .net and docfx improve, the razor-compiler will work in that scenario as well, and this file can be removed.

It is related to: https://github.com/oqtane/oqtane.docs/issues/112