### PR TITLE
Update NuGet package versions for dependencies

### DIFF
--- a/Oqtane.Server/Oqtane.Server.csproj
+++ b/Oqtane.Server/Oqtane.Server.csproj
@@ -31,10 +31,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.0-rc.2.25502.107" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.0-rc.2.25502.107" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0-rc.2.25502.107" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.12.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.5" />
-    <PackageReference Include="MailKit" Version="4.14.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
+    <PackageReference Include="MailKit" Version="4.14.1" />
   </ItemGroup>
   
   <ItemGroup>
@@ -42,8 +42,8 @@
     <PackageReference Include="MySql.Data" Version="9.4.0" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     <!-- PostgreSQL Database Provider Dependencies -->
-    <PackageReference Include="EFCore.NamingConventions" Version="9.0.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="EFCore.NamingConventions" Version="10.0.0-rc.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0-rc.2" />
     <!-- SQLite Database Provider Dependencies -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0-rc.2.25502.107" />
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.0-rc.2.25502.107" />


### PR DESCRIPTION
Update NuGet package versions for dependencies
Upgraded the following NuGet packages to newer versions:
- `SixLabors.ImageSharp` from `3.1.11` to `3.1.12`
- `HtmlAgilityPack` from `1.12.3` to `1.12.4`
- `Swashbuckle.AspNetCore` from `9.0.5` to `9.0.6`
- `MailKit` from `4.14.0` to `4.14.1`
- `EFCore.NamingConventions` from `9.0.0` to `10.0.0-rc.2`
- `Npgsql.EntityFrameworkCore.PostgreSQL` from `9.0.4` to `10.0.0-rc.2`