### PR TITLE
Fix `TypeError: Cannot read properties of undefined (reading 'remove')` in `interop.js`

### DIFF
--- a/Oqtane.Server/wwwroot/js/interop.js
+++ b/Oqtane.Server/wwwroot/js/interop.js
@@ -124,7 +124,7 @@ Oqtane.Interop = {
         }
     },
     includeScript: function (id, src, integrity, crossorigin, type, content, location, dataAttributes) {
-        var script;
+        var script = null;
         if (src !== "") {
             script = document.querySelector("script[src=\"" + CSS.escape(src) + "\"]");
         }
@@ -140,7 +140,7 @@ Oqtane.Interop = {
                 }
             }
         }
-        if (script !== null) {
+        if (script instanceof HTMLScriptElement) {
             script.remove();
             script = null;
         }


### PR DESCRIPTION
fixes #5791


### 🧩 Summary

This PR fixes an intermittent JavaScript runtime error in **`Oqtane.Server/wwwroot/js/interop.js`**, where the variable `script` could remain `undefined` before attempting `.remove()`.

In some custom module scenarios (especially when including or reloading inline scripts dynamically), `includeScript()` could execute along a code path that skipped initialization of the `script` variable, leading to:

```
TypeError: Cannot read properties of undefined (reading 'remove')
```


### ✅ Changes Made

1. **Initialize `script` to null** to ensure safe declaration:

   ```js
   var script = null;
   ```
2. **Add defensive check** before calling `.remove()`:

   ```js
   if (script instanceof HTMLScriptElement) {
       script.remove();
   }
   ```

