### PR TITLE
Fix SMTPRelay condition for sender email validation

### DIFF
--- a/Oqtane.Server/Infrastructure/Jobs/NotificationJob.cs
+++ b/Oqtane.Server/Infrastructure/Jobs/NotificationJob.cs
@@ -186,7 +186,7 @@ namespace Oqtane.Infrastructure
                                     var mailboxAddressValidationError = "";
 
                                     // sender
-                                    if (settingRepository.GetSettingValue(settings, "SMTPRelay", "False") != "True")
+                                    if ((settingRepository.GetSettingValue(settings, "SMTPRelay", "False") == "True") && string.IsNullOrEmpty(fromEmail))
                                     {
                                         fromEmail = settingRepository.GetSettingValue(settings, "SMTPSender", "");
                                         fromName = string.IsNullOrEmpty(fromName) ? site.Name : fromName;


### PR DESCRIPTION
Prior change was leaving sender null and not properly setting "From" address when used in a relay configuration. This caused emails to go to the deleted state and not be delivered.