### PR TITLE
Add AltText/title support to ActionDialog and ActionLink

### DIFF
--- a/Oqtane.Client/Modules/Controls/ActionDialog.razor
+++ b/Oqtane.Client/Modules/Controls/ActionDialog.razor
@@ -35,11 +35,11 @@
     {
         if (Disabled)
         {
-            <button type="button" class="@Class" disabled>@((MarkupString)_openIconSpan) @_openText</button>
+            <button type="button" class="@Class" title="@AltText" disabled>@((MarkupString)_openIconSpan) @_openText</button>
         }
         else
         {
-            <button type="button" class="@Class" @onclick="DisplayModal">@((MarkupString)_openIconSpan) @_openText</button>
+            <button type="button" class="@Class" title="@AltText" @onclick="DisplayModal">@((MarkupString)_openIconSpan) @_openText</button>
         }
     }
 }
@@ -83,13 +83,13 @@ else
     {
         if (Disabled)
         {
-            <button type="button" class="@Class" disabled>@((MarkupString)_openIconSpan) @_openText</button>
+            <button type="button" title="@AltText" class="@Class" disabled>@((MarkupString)_openIconSpan) @_openText</button>
         }
         else
         {
             <form method="post" class="app-form-inline" @formname="@($"ActionDialogActionForm:{ModuleState.PageModuleId}:{Id}")" @onsubmit="DisplayModal" data-enhance>
                 <input type="hidden" name="@Constants.RequestVerificationToken" value="@SiteState.AntiForgeryToken" />
-                <button type="submit" class="@Class">@((MarkupString)_openIconSpan) @_openText</button>
+                <button type="submit" title="@AltText" class="@Class">@((MarkupString)_openIconSpan) @_openText</button>
             </form>
         }
     }
@@ -112,6 +112,9 @@ else
 
     [Parameter]
     public string Text { get; set; } // optional - defaults to Action if not specified
+    
+    [Parameter]
+    public string AltText { get; set; } // optional
 
     [Parameter]
     public string Action { get; set; } // optional

--- a/Oqtane.Client/Modules/Controls/ActionLink.razor
+++ b/Oqtane.Client/Modules/Controls/ActionLink.razor
@@ -8,17 +8,17 @@
 {
     if (Disabled)
     {
-        <NavLink class="@($"{_classname} disabled")" href="@_url" style="@_style">@((MarkupString)_iconSpan) @_text</NavLink>
+        <NavLink class="@($"{_classname} disabled")" title="@AltText" href="@_url" style="@_style">@((MarkupString)_iconSpan) @_text</NavLink>
 	}
 	else
 	{
 		if (OnClick == null)
 		{
-			<NavLink class="@_classname" href="@_url" style="@_style">@((MarkupString)_iconSpan) @_text</NavLink>
+            <NavLink class="@_classname" title="@AltText" href="@_url" style="@_style">@((MarkupString)_iconSpan) @_text</NavLink>
 		}
 		else
 		{
-			<button type="button" class="@_classname" style="@_style" onclick="@OnClick">@((MarkupString)_iconSpan) @_text</button>
+            <button type="button" class="@_classname" title="@AltText" style="@_style" onclick="@OnClick">@((MarkupString)_iconSpan) @_text</button>
 		}
 	}
 }
@@ -41,6 +41,9 @@
 
     [Parameter]
     public string Text { get; set; } // optional - defaults to Action if not specified
+
+    [Parameter]
+    public string AltText { get; set; } // optional 
 
     [Parameter]
     public int ModuleId { get; set; } = -1; // optional - allows the link to target a specific moduleid


### PR DESCRIPTION
Introduce optional AltText parameter to ActionDialog and ActionLink components. AltText is now used as the title attribute on rendered buttons and links, providing tooltips for improved accessibility and user experience. All relevant elements, including those in disabled states, now support this enhancement.