### PR TITLE
Fix SMTPRelay condition for fromEmail validation

### DIFF
--- a/Oqtane.Server/Infrastructure/Jobs/NotificationJob.cs
+++ b/Oqtane.Server/Infrastructure/Jobs/NotificationJob.cs
@@ -186,7 +186,7 @@ namespace Oqtane.Infrastructure
                                     var mailboxAddressValidationError = "";
 
                                     // sender
-                                    if ((settingRepository.GetSettingValue(settings, "SMTPRelay", "False") == "True") && string.IsNullOrEmpty(fromEmail))
+                                    if ((settingRepository.GetSettingValue(settings, "SMTPRelay", "False") != "True") || (settingRepository.GetSettingValue(settings, "SMTPRelay", "False") == "True") && string.IsNullOrEmpty(fromEmail))
                                     {
                                         fromEmail = settingRepository.GetSettingValue(settings, "SMTPSender", "");
                                         fromName = string.IsNullOrEmpty(fromName) ? site.Name : fromName;


### PR DESCRIPTION
Use default from email for non-relay as well as relay configured where from email was not supplied.