### PR TITLE
Image optimization to webp without manipulation

### DIFF
--- a/Oqtane.Server/Services/ImageService.cs
+++ b/Oqtane.Server/Services/ImageService.cs
@@ -90,6 +90,32 @@ namespace Oqtane.Services
             return imagepath;
         }
 
+        public string OptimizeImageToWebp(string filepath, int quality, string imagepath)
+        {
+            try
+            {
+                if (quality < 0) quality = 0;
+                else if (quality > 100) quality = 100;
+
+                using (var stream = new FileStream(filepath, FileMode.Open, FileAccess.Read))
+                {
+                    stream.Position = 0;
+                    using (var image = Image.Load(stream))
+                    {
+                        var encoder = GetWebpEncoder(transparent: true, quality);
+                        image.SaveAsWebp(imagepath, encoder);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Log(LogLevel.Error, this, LogFunction.Security, ex, "Error Optimizing Image To Webp For File {FilePath} {Quality} {Error}", filepath, quality, ex.Message);
+                imagepath = "";
+            }
+
+            return imagepath;
+        }
+
         private static IImageEncoder GetEncoder(string format, bool transparent)
         {
             return format switch
@@ -111,12 +137,12 @@ namespace Oqtane.Services
             };
         }
 
-        private static WebpEncoder GetWebpEncoder(bool transparent)
+        private static WebpEncoder GetWebpEncoder(bool transparent, int quality = IImageService.DefaultQuality)
         {
             return new WebpEncoder()
             {
                 FileFormat = WebpFileFormatType.Lossy,
-                Quality = 60,
+                Quality = quality,
                 TransparentColorMode = transparent ? WebpTransparentColorMode.Preserve : WebpTransparentColorMode.Clear,
             };
         }

--- a/Oqtane.Shared/Interfaces/IImageService.cs
+++ b/Oqtane.Shared/Interfaces/IImageService.cs
@@ -2,8 +2,11 @@ namespace Oqtane.Services
 {
     public interface IImageService
     {
+        public const int DefaultQuality = 60;
+
         public string[] GetAvailableFormats();
 
         public string CreateImage(string filepath, int width, int height, string mode, string position, string background, string rotate, string format, string imagepath);
+        public string OptimizeImageToWebp(string filepath, int quality, string imagepath);
     }
 }


### PR DESCRIPTION
This pull request introduces new functionality for image optimization, allowing images to be served as optimized WebP files with configurable quality (closes #5979).

**Image Optimization Functionality:**

- Added a new `GetOptimizedImage` endpoint to `FileController` that serves the optimized WebP images.
- Updated the `IImageService` interface to include a new `OptimizeImageToWebp` method and defined a `DefaultQuality` constant for image optimization.
- Implemented the `OptimizeImageToWebp` method in `ImageService`, using the specified quality. The WebP encoder now uses the provided quality value instead of a hardcoded default.

**File Handling and Query Parameter Improvements:**

- Enhanced the file handling logic in `Files.cshtml.cs` to support an `optimize` query parameter, which triggers the image optimization with optional `quality` and `recreate` parameters. Image manipulation (resize, crop, ...) takes precedence over optimization if both queries are included.

(Only the PR summary was generated by Copilot, not the code)