### PR TITLE
Maximum upload file size parameter for FileManager

### DIFF
--- a/Oqtane.Client/Modules/Controls/FileManager.razor
+++ b/Oqtane.Client/Modules/Controls/FileManager.razor
@@ -61,6 +61,12 @@
                                 {
                                     <input type="file" id="@_fileinputid" name="file" accept="@_filter" />
                                 }
+                                @if (MaxUploadFileSize > 0)
+                                {
+                                    <div class="row my-1">
+                                        <small class="fw-light">@string.Format(Localizer["File.MaxSize"], MaxUploadFileSize)</small>
+                                    </div>
+                                }
                             </div>
                             <div class="col-auto">
                                 <button type="button" class="btn btn-success" @onclick="UploadFiles">@SharedLocalizer["Upload"]</button>
@@ -162,6 +168,9 @@
 
     [Parameter]
     public int ChunkSize { get; set; } = 1; // optional - size of file chunks to upload in MB
+
+    [Parameter]
+    public int MaxUploadFileSize { get; set; } = -1; // optional - maximum upload file size in MB
 
     [Parameter]
     public EventCallback<int> OnUpload { get; set; } // optional - executes a method in the calling component when a file is uploaded
@@ -381,16 +390,39 @@
         if (uploads.Length > 0)
         {
             string restricted = "";
+            string tooLarge = "";
             foreach (var upload in uploads)
             {
-                var filename = upload.Split(':')[0];
+                var fileparts = upload.Split(':');
+                var filename = fileparts[0];
+
+                if (MaxUploadFileSize > 0)
+                {
+                    var filesizeBytes = long.Parse(fileparts[1]);
+                    var filesizeMB = (double)filesizeBytes / (1024 * 1024);
+                    if (filesizeMB > MaxUploadFileSize)
+                    {
+                        tooLarge += (tooLarge == "" ? "" : ",") + filename;
+                    }
+                }
+
                 var extension = (filename.LastIndexOf(".") != -1) ? filename.Substring(filename.LastIndexOf(".") + 1) : "";
                 if (!PageState.Site.UploadableFiles.Split(',').Contains(extension.ToLower()))
                 {
                     restricted += (restricted == "" ? "" : ",") + extension;
                 }
             }
-            if (restricted == "")
+            if (restricted != "")
+            {
+                _message = string.Format(Localizer["Message.File.Restricted"], restricted);
+                _messagetype = MessageType.Warning;
+            }
+            else if (tooLarge != "")
+            {
+                _message = string.Format(Localizer["Message.File.TooLarge"], tooLarge, MaxUploadFileSize);
+                _messagetype = MessageType.Warning;
+            }
+            else
             {
                 CancellationTokenSource tokenSource = new CancellationTokenSource();
 
@@ -489,11 +521,6 @@
                 finally {
                     tokenSource.Dispose();
                 }
-            }
-            else
-            {
-                _message = string.Format(Localizer["Message.File.Restricted"], restricted);
-                _messagetype = MessageType.Warning;
             }
         }
         else

--- a/Oqtane.Client/Resources/Modules/Controls/FileManager.resx
+++ b/Oqtane.Client/Resources/Modules/Controls/FileManager.resx
@@ -144,4 +144,10 @@
   <data name="Message.File.Restricted" xml:space="preserve">
     <value>Files With Extension Of {0} Are Restricted From Upload. Please Contact Your Administrator For More Information.</value>
   </data>
+  <data name="File.MaxSize" xml:space="preserve">
+    <value>Maximum upload file size: {0} MB</value>
+  </data>
+  <data name="Message.File.TooLarge" xml:space="preserve">
+    <value>File(s) {0} exceed(s) the maximum upload size of {1} MB</value>
+  </data>
 </root>


### PR DESCRIPTION
This pull request enhances the `FileManager` component by introducing support for a configurable maximum upload file size. It adds user feedback for files that exceed this limit, both in the UI and in validation logic, and updates localization resources to support the new messages. (closes #5982)

**File upload size limitation and validation:**

* Added a new `[Parameter]` property `MaxUploadFileSize` to `FileManager.razor`, allowing the maximum upload file size (in MB) to be set by the parent component.
* Updated the file upload validation logic to check each file's size against `MaxUploadFileSize`, and display a warning message if any files are too large.

**User interface improvements:**

* Displayed the maximum allowed file size in the upload UI when `MaxUploadFileSize` is set, helping users understand the upload constraints before selecting files.

**Localization updates:**

* Added new resource strings for the maximum file size label and the "file too large" warning message in `FileManager.resx`.

(Only the PR summary was generated by Copilot, not the code)