### PR TITLE
Move I[Module]Service to Shared/Interfaces

### DIFF
--- a/Oqtane.Application/Server/wwwroot/Modules/Templates/Internal/Client/Services/[Module]Service.cs
+++ b/Oqtane.Application/Server/wwwroot/Modules/Templates/Internal/Client/Services/[Module]Service.cs
@@ -7,18 +7,6 @@ using Oqtane.Shared;
 
 namespace [Owner].Module.[Module].Services
 {
-    public interface I[Module]Service 
-    {
-        Task<List<Models.[Module]>> Get[Module]sAsync(int ModuleId);
-
-        Task<Models.[Module]> Get[Module]Async(int [Module]Id, int ModuleId);
-
-        Task<Models.[Module]> Add[Module]Async(Models.[Module] [Module]);
-
-        Task<Models.[Module]> Update[Module]Async(Models.[Module] [Module]);
-
-        Task Delete[Module]Async(int [Module]Id, int ModuleId);
-    }
 
     public class [Module]Service : ServiceBase, I[Module]Service
     {

--- a/Oqtane.Application/Server/wwwroot/Modules/Templates/Internal/Shared/Interfaces/I[Module]Service.cs
+++ b/Oqtane.Application/Server/wwwroot/Modules/Templates/Internal/Shared/Interfaces/I[Module]Service.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace [Owner].Module.[Module].Services
+{
+    public interface I[Module]Service 
+    {
+        Task<List<Models.[Module]>> Get[Module]sAsync(int ModuleId);
+
+        Task<Models.[Module]> Get[Module]Async(int [Module]Id, int ModuleId);
+
+        Task<Models.[Module]> Add[Module]Async(Models.[Module] [Module]);
+
+        Task<Models.[Module]> Update[Module]Async(Models.[Module] [Module]);
+
+        Task Delete[Module]Async(int [Module]Id, int ModuleId);
+    }
+}


### PR DESCRIPTION
Extract the I[Module]Service interface out of Client/Services/[Module]Service.cs and add it as a new shared interface file at Internal/Shared/Interfaces/I[Module]Service.cs. The inline interface definition was removed from [Module]Service.cs so the service class now implements the shared contract, centralizing the interface for reuse across components.