### PR TITLE
performance and scalability improvement - get the most recent HtmlText record directly from database and cache only a single object rather than the entire collection

### DIFF
--- a/Oqtane.Client/Modules/HtmlText/Edit.razor
+++ b/Oqtane.Client/Modules/HtmlText/Edit.razor
@@ -122,13 +122,9 @@
 	{
 		try
 		{
-			htmltext = await HtmlTextService.GetHtmlTextAsync(htmltext.HtmlTextId, htmltext.ModuleId);
-			if (htmltext != null)
-			{
-				_view = htmltext.Content;
-				_view = Utilities.FormatContent(_view, PageState.Alias, "render");
-				StateHasChanged();
-			}		
+			_view = htmltext.Content;
+			_view = Utilities.FormatContent(_view, PageState.Alias, "render");
+			StateHasChanged();
 		}
 		catch (Exception ex)
 		{
@@ -141,19 +137,15 @@
 	{
 		try
 		{
-			htmltext = await HtmlTextService.GetHtmlTextAsync(htmltext.HtmlTextId, ModuleState.ModuleId);
-			if (htmltext != null)
-			{
-				var content = htmltext.Content;
-				htmltext = new HtmlText();
-				htmltext.ModuleId = ModuleState.ModuleId;
-				htmltext.Content = content;
-				await HtmlTextService.AddHtmlTextAsync(htmltext);
-				await logger.LogInformation("Content Restored {HtmlText}", htmltext);
-				AddModuleMessage(Localizer["Message.Content.Restored"], MessageType.Success);
-				await LoadContent();
-				StateHasChanged();
-			}				
+			var content = htmltext.Content;
+			htmltext = new HtmlText();
+			htmltext.ModuleId = ModuleState.ModuleId;
+			htmltext.Content = content;
+			await HtmlTextService.AddHtmlTextAsync(htmltext);
+			await logger.LogInformation("Content Restored {HtmlText}", htmltext);
+			AddModuleMessage(Localizer["Message.Content.Restored"], MessageType.Success);
+			await LoadContent();
+			StateHasChanged();
 		}
 		catch (Exception ex)
 		{
@@ -166,15 +158,11 @@
 	{
 		try
 		{
-			htmltext = await HtmlTextService.GetHtmlTextAsync(htmltext.HtmlTextId, ModuleState.ModuleId);
-			if (htmltext != null)
-			{
-				await HtmlTextService.DeleteHtmlTextAsync(htmltext.HtmlTextId, htmltext.ModuleId);
-				await logger.LogInformation("Content Deleted {HtmlText}", htmltext);
-				AddModuleMessage(Localizer["Message.Content.Deleted"], MessageType.Success);
-				await LoadContent();
-				StateHasChanged();
-			}		
+			await HtmlTextService.DeleteHtmlTextAsync(htmltext.HtmlTextId, htmltext.ModuleId);
+			await logger.LogInformation("Content Deleted {HtmlText}", htmltext);
+			AddModuleMessage(Localizer["Message.Content.Deleted"], MessageType.Success);
+			await LoadContent();
+			StateHasChanged();
 		}
 		catch (Exception ex)
 		{

--- a/Oqtane.Client/Modules/HtmlText/Services/HtmlTextService.cs
+++ b/Oqtane.Client/Modules/HtmlText/Services/HtmlTextService.cs
@@ -14,8 +14,6 @@ namespace Oqtane.Modules.HtmlText.Services
 
         Task<Models.HtmlText> GetHtmlTextAsync(int moduleId);
 
-        Task<Models.HtmlText> GetHtmlTextAsync(int htmlTextId, int moduleId);
-
         Task<Models.HtmlText> AddHtmlTextAsync(Models.HtmlText htmltext);
 
         Task DeleteHtmlTextAsync(int htmlTextId, int moduleId);
@@ -36,11 +34,6 @@ namespace Oqtane.Modules.HtmlText.Services
         public async Task<Models.HtmlText> GetHtmlTextAsync(int moduleId)
         {
             return await GetJsonAsync<Models.HtmlText>(CreateAuthorizationPolicyUrl($"{ApiUrl}/{moduleId}", EntityNames.Module, moduleId));
-        }
-
-        public async Task<Models.HtmlText> GetHtmlTextAsync(int htmlTextId, int moduleId)
-        {
-            return await GetJsonAsync<Models.HtmlText>(CreateAuthorizationPolicyUrl($"{ApiUrl}/{htmlTextId}/{moduleId}", EntityNames.Module, moduleId));
         }
 
         public async Task<Models.HtmlText> AddHtmlTextAsync(Models.HtmlText htmlText)

--- a/Oqtane.Client/Modules/HtmlText/Settings.razor
+++ b/Oqtane.Client/Modules/HtmlText/Settings.razor
@@ -39,7 +39,7 @@
         try
         {
             _dynamictokens = SettingService.GetSetting(ModuleState.Settings, "DynamicTokens", "false");
-            _versions = SettingService.GetSetting(ModuleState.Settings, "Versions", "3");
+            _versions = SettingService.GetSetting(ModuleState.Settings, "Versions", "5");
         }
         catch (Exception ex)
         {

--- a/Oqtane.Server/Modules/HtmlText/Controllers/HtmlTextController.cs
+++ b/Oqtane.Server/Modules/HtmlText/Controllers/HtmlTextController.cs
@@ -58,23 +58,6 @@ namespace Oqtane.Modules.HtmlText.Controllers
             }
         }
 
-        // GET api/<controller>/5/6
-        [HttpGet("{id}/{moduleId}")]
-        [Authorize(Policy = PolicyNames.ViewModule)]
-        public async Task<Models.HtmlText> Get(int id, int moduleId)
-        {
-            if (IsAuthorizedEntityId(EntityNames.Module, moduleId))
-            {
-                return await _htmlTextService.GetHtmlTextAsync(id, moduleId);
-            }
-            else
-            {
-                _logger.Log(LogLevel.Error, this, LogFunction.Security, "Unauthorized Html/Text Get Attempt {HtmlTextId}", id);
-                HttpContext.Response.StatusCode = (int)HttpStatusCode.Forbidden;
-                return null;
-            }
-        }
-
         // POST api/<controller>
         [HttpPost]
         [Authorize(Policy = PolicyNames.EditModule)]

--- a/Oqtane.Server/Modules/HtmlText/Repository/HtmlTextRepository.cs
+++ b/Oqtane.Server/Modules/HtmlText/Repository/HtmlTextRepository.cs
@@ -11,7 +11,7 @@ namespace Oqtane.Modules.HtmlText.Repository
     public interface IHtmlTextRepository
     {
         IEnumerable<Models.HtmlText> GetHtmlTexts(int moduleId);
-        Models.HtmlText GetHtmlText(int htmlTextId);
+        Models.HtmlText GetHtmlText(int moduleId);
         Models.HtmlText AddHtmlText(Models.HtmlText htmlText);
         void DeleteHtmlText(int htmlTextId);
     }
@@ -34,17 +34,18 @@ namespace Oqtane.Modules.HtmlText.Repository
             return db.HtmlText.Where(item => item.ModuleId == moduleId).ToList();
         }
 
-        public Models.HtmlText GetHtmlText(int htmlTextId)
+        public Models.HtmlText GetHtmlText(int moduleId)
         {
             using var db = _factory.CreateDbContext();
-            return db.HtmlText.Find(htmlTextId);
+            return db.HtmlText.Where(item => item.ModuleId == moduleId)?
+                .OrderByDescending(item => item.CreatedOn).FirstOrDefault();
         }
 
         public Models.HtmlText AddHtmlText(Models.HtmlText htmlText)
         {
             using var db = _factory.CreateDbContext();
 
-            var versions = int.Parse(_settingRepository.GetSettingValue(EntityNames.Module, htmlText.ModuleId, "Versions", "3"));
+            var versions = int.Parse(_settingRepository.GetSettingValue(EntityNames.Module, htmlText.ModuleId, "Versions", "5"));
             if (versions > 0)
             {
                 var htmlTexts = db.HtmlText.Where(item => item.ModuleId == htmlText.ModuleId).OrderByDescending(item => item.CreatedOn).ToList();


### PR DESCRIPTION
on content intensive sites this will result in a significant memory reduction 