### PR TITLE
Bump Radzen, Swashbuckle, MailKit, NodaTime

### DIFF
--- a/Oqtane.Client/Oqtane.Client.csproj
+++ b/Oqtane.Client/Oqtane.Client.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Localization" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
-    <PackageReference Include="Radzen.Blazor" Version="9.0.0" />
+    <PackageReference Include="Radzen.Blazor" Version="9.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Oqtane.Package/Oqtane.Client.nuspec
+++ b/Oqtane.Package/Oqtane.Client.nuspec
@@ -23,7 +23,7 @@
         <dependency id="Microsoft.AspNetCore.Components.WebAssembly.Authentication" version="10.0.3" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Localization" version="10.0.3" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Http" version="10.0.3" exclude="Build,Analyzers" />
-        <dependency id="Radzen.Blazor" version="9.0.0" exclude="Build,Analyzers" />
+        <dependency id="Radzen.Blazor" version="9.0.8" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>

--- a/Oqtane.Package/Oqtane.Server.nuspec
+++ b/Oqtane.Package/Oqtane.Server.nuspec
@@ -26,8 +26,8 @@
         <dependency id="Microsoft.EntityFrameworkCore.Relational" version="10.0.3" exclude="Build,Analyzers" />
         <dependency id="SixLabors.ImageSharp" version="3.1.12" exclude="Build,Analyzers" />
         <dependency id="HtmlAgilityPack" version="1.12.4" exclude="Build,Analyzers" />
-        <dependency id="Swashbuckle.AspNetCore" version="10.1.2" exclude="Build,Analyzers" />
-        <dependency id="MailKit" version="4.14.1" exclude="Build,Analyzers" />
+        <dependency id="Swashbuckle.AspNetCore" version="10.1.4" exclude="Build,Analyzers" />
+        <dependency id="MailKit" version="4.15.1" exclude="Build,Analyzers" />
         <dependency id="MySql.Data" version="9.6.0" exclude="Build,Analyzers" />
         <dependency id="MySql.EntityFrameworkCore" version="10.0.1" exclude="Build,Analyzers" />
         <dependency id="EFCore.NamingConventions" version="10.0.1" exclude="Build,Analyzers" />

--- a/Oqtane.Package/Oqtane.Shared.nuspec
+++ b/Oqtane.Package/Oqtane.Shared.nuspec
@@ -20,7 +20,7 @@
       <group targetFramework="net10.0">
         <dependency id="Microsoft.EntityFrameworkCore" version="10.0.3" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.3" exclude="Build,Analyzers" />
-        <dependency id="NodaTime" version="3.3.0" exclude="Build,Analyzers" />
+        <dependency id="NodaTime" version="3.3.1" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>

--- a/Oqtane.Server/Oqtane.Server.csproj
+++ b/Oqtane.Server/Oqtane.Server.csproj
@@ -34,8 +34,8 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.2" />
-    <PackageReference Include="MailKit" Version="4.14.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
+    <PackageReference Include="MailKit" Version="4.15.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Oqtane.Shared/Oqtane.Shared.csproj
+++ b/Oqtane.Shared/Oqtane.Shared.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="NodaTime" Version="3.3.0" />
+    <PackageReference Include="NodaTime" Version="3.3.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgrade several dependencies across projects:
- Radzen.Blazor 9.0.0 -> 9.0.8 (Oqtane.Client.csproj and Oqtane.Client.nuspec)
- Swashbuckle.AspNetCore 10.1.2 -> 10.1.4 (Oqtane.Server.csproj and Oqtane.Server.nuspec)
- MailKit 4.14.1 -> 4.15.1 (Oqtane.Server.csproj and Oqtane.Server.nuspec)
- NodaTime 3.3.0 -> 3.3.1 (Oqtane.Shared.csproj and Oqtane.Shared.nuspec) These are patch/minor dependency updates to incorporate fixes and improvements.