### PR TITLE
Avoid extra db call to retrieve site when page not found

### DIFF
--- a/Oqtane.Server/Components/App.razor
+++ b/Oqtane.Server/Components/App.razor
@@ -292,7 +292,7 @@
         string referrer = (Context.Request.Headers[HeaderNames.Referer] != StringValues.Empty) ? Context.Request.Headers[HeaderNames.Referer] : "";
 
         // page not found - look for url mapping
-        var urlMapping = UrlMappingRepository.GetUrlMapping(site.SiteId, route.PagePath, referrer);
+        var urlMapping = UrlMappingRepository.GetUrlMapping(site.SiteId, route.PagePath, referrer, site.CaptureBrokenUrls);
         if (urlMapping != null && !string.IsNullOrEmpty(urlMapping.MappedUrl))
         {
             // redirect to mapped url

--- a/Oqtane.Server/Repository/UrlMappingRepository.cs
+++ b/Oqtane.Server/Repository/UrlMappingRepository.cs
@@ -14,7 +14,7 @@ namespace Oqtane.Repository
         UrlMapping GetUrlMapping(int urlMappingId);
         UrlMapping GetUrlMapping(int urlMappingId, bool tracking);
         UrlMapping GetUrlMapping(int siteId, string url);
-        UrlMapping GetUrlMapping(int siteId, string url, string referrer);
+        UrlMapping GetUrlMapping(int siteId, string url, string referrer, bool? captureBrokenUrls = null);
         void DeleteUrlMapping(int urlMappingId);
         int DeleteUrlMappings(int siteId, int age);
     }
@@ -83,25 +83,39 @@ namespace Oqtane.Repository
             return GetUrlMapping(siteId, url, "");
         }
 
-        public UrlMapping GetUrlMapping(int siteId, string url, string referrer)
+        public UrlMapping GetUrlMapping(int siteId, string url, string referrer, bool? captureBrokenUrl = null)
         {
             using var db = _dbContextFactory.CreateDbContext();
             url = (url.StartsWith("/")) ? url.Substring(1) : url;
             url = (url.Length > 750) ? url.Substring(0, 750) : url;
             var urlMapping = db.UrlMapping.Where(item => item.SiteId == siteId && item.Url == url).FirstOrDefault();
+
             if (urlMapping == null)
             {
-                var site = _sites.GetSite(siteId);
-                if (site.CaptureBrokenUrls)
+                bool capture;
+
+                if (captureBrokenUrl.HasValue)
                 {
-                    urlMapping = new UrlMapping();
-                    urlMapping.SiteId = siteId;
-                    urlMapping.Url = url;
-                    urlMapping.MappedUrl = "";
-                    urlMapping.Requests = 1;
-                    urlMapping.Referrer = referrer;
-                    urlMapping.CreatedOn = DateTime.UtcNow;
-                    urlMapping.RequestedOn = DateTime.UtcNow;
+                    capture = captureBrokenUrl.Value;
+                }
+                else
+                {
+                    var site = _sites.GetSite(siteId, false);
+                    capture = site.CaptureBrokenUrls;
+                }
+
+                if (capture)
+                {
+                    urlMapping = new UrlMapping
+                    {
+                        SiteId = siteId,
+                        Url = url,
+                        MappedUrl = "",
+                        Requests = 1,
+                        Referrer = referrer,
+                        CreatedOn = DateTime.UtcNow,
+                        RequestedOn = DateTime.UtcNow
+                    };
                     try
                     {
                         urlMapping = AddUrlMapping(urlMapping);


### PR DESCRIPTION
Issue described at #6222 

**URL Mapping Enhancements:**

* Updated the `GetUrlMapping` method in `IUrlMappingRepository` and its implementation to accept an optional `captureBrokenUrls` parameter, allowing explicit control over whether broken URLs should be captured when searching for a mapping

* Modified the logic in `GetUrlMapping` to use the provided `captureBrokenUrls` value if available, or fall back to the site's setting

* Changed the call to `UrlMappingRepository.GetUrlMapping` in `App.razor` to pass the site's `CaptureBrokenUrls` setting, avoiding the extra db call in this situation

* Incidentally, this gives more control to module developers, as they can use this parameter to explicitly override the site configuration when required for a specific functionality.

* This change does not affect url mappings retrieved from other places (PageController, UrlMappingController and Files server), which will still use the site's setting fallback.