### PR TITLE
Remove System.ComponentModel.Annotations package ref

### DIFF
--- a/Oqtane.Application/Shared/Oqtane.Application.Shared.csproj
+++ b/Oqtane.Application/Shared/Oqtane.Application.Shared.csproj
@@ -7,10 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Oqtane.Shared" Version="10.2.1" />
   </ItemGroup>
 

--- a/Oqtane.Server/wwwroot/Modules/Templates/External/Shared/[Owner].Module.[Module].Shared.csproj
+++ b/Oqtane.Server/wwwroot/Modules/Templates/External/Shared/[Owner].Module.[Module].Shared.csproj
@@ -13,10 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     [SharedReference]
   </ItemGroup>
 


### PR DESCRIPTION
Remove explicit PackageReference to System.ComponentModel.Annotations (v5.0.0) from Oqtane.Application.Shared.csproj and the External Shared module template csproj. Cleans up redundant dependency declarations in shared project files so they rely on the consolidated/transitive dependency management. System.ComponentModel.DataAnnotations - the actual namespace. This is part of the .NET 10 framework runtime. Always available, no NuGet package needed.