### PR TITLE
include SQLitePCLRaw.bundle_e_sqlite3 directly

### DIFF
--- a/Oqtane.Package/Oqtane.Server.nuspec
+++ b/Oqtane.Package/Oqtane.Server.nuspec
@@ -37,7 +37,7 @@
         <dependency id="EFCore.NamingConventions" version="10.0.1" exclude="Build,Analyzers" />
         <dependency id="Npgsql.EntityFrameworkCore.PostgreSQL" version="10.0.2" exclude="Build,Analyzers" />
         <dependency id="Microsoft.EntityFrameworkCore.Sqlite" version="10.0.9" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Data.Sqlite.Core" version="10.0.9" exclude="Build,Analyzers" />
+        <dependency id="SQLitePCLRaw.bundle_e_sqlite3" version="3.0.3" exclude="Build,Analyzers" />
         <dependency id="Microsoft.EntityFrameworkCore.SqlServer" version="10.0.9" exclude="Build,Analyzers" />
       </group>
     </dependencies>

--- a/Oqtane.Server/Oqtane.Server.csproj
+++ b/Oqtane.Server/Oqtane.Server.csproj
@@ -52,7 +52,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <!-- SQLite Database Provider Dependencies -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.9" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <!-- SQL Server Database Provider Dependencies -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
   </ItemGroup>


### PR DESCRIPTION
include SQLitePCLRaw.bundle_e_sqlite3 directly rather than referencing Microsoft.Data.Sqlite.Core which has a critical CVE warning related to a transient dependency on the deprecated SQLitePCLRaw.lib.e_sqlite3 package