### PR TITLE
Don't override Fusion Cache default entry options

### DIFF
--- a/Oqtane.Server/Infrastructure/CacheManager.cs
+++ b/Oqtane.Server/Infrastructure/CacheManager.cs
@@ -42,7 +42,7 @@ namespace Oqtane.Infrastructure
         {
             return _cache.GetOrSet(FormatKey(alias, key),
                 ct => factory(ct),
-                SetOptions(memoryCacheDuration, distributedCacheDuration));
+                options => SetOptions(options, memoryCacheDuration, distributedCacheDuration));
         }
 
         public void RemoveCache(Alias alias, string key)
@@ -77,7 +77,7 @@ namespace Oqtane.Infrastructure
         {
             return await _cache.GetOrSetAsync(FormatKey(alias, key),
                 async ct => await factory(ct),
-                SetOptions(memoryCacheDuration, distributedCacheDuration));
+                options => SetOptions(options, memoryCacheDuration, distributedCacheDuration));
         }
 
         public async Task RemoveCacheAsync(Alias alias, string key)
@@ -94,19 +94,17 @@ namespace Oqtane.Infrastructure
             return key;
         }
 
-        private FusionCacheEntryOptions SetOptions(TimeSpan? memoryCacheDuration, TimeSpan? distributedCacheDuration)
+        private void SetOptions(FusionCacheEntryOptions options, TimeSpan? memoryCacheDuration, TimeSpan? distributedCacheDuration)
         {
-            var options = new FusionCacheEntryOptions();
-            options.MemoryCacheDuration = memoryCacheDuration; // infinite = TimeSpan.MaxValue
+            options.SetMemoryCacheDuration(memoryCacheDuration); // infinite = TimeSpan.MaxValue
             if (distributedCacheDuration == TimeSpan.MinValue)
             {
                 options.SetSkipDistributedCache(true, true);
             }
             else
             {
-                options.DistributedCacheDuration = distributedCacheDuration;
+                options.SetDistributedCacheDuration(distributedCacheDuration);
             }
-            return options;
         }
     }
 }


### PR DESCRIPTION
According to Fusion Cache [docs ](https://github.com/ZiggyCreatures/FusionCache/blob/main/docs/Options.md#defaultentryoptions) for configuring the cache entry options, if you pass as a parameter a new FusionCacheEntryOptions object, this will completely override the default configured options.

To avoid this, you need to use the overload that allows configuring over the default options:
```c#
cache.Set<int>(
    "foo",
    42,
    // THIS DUPLICATES THE DEFAULT OPTIONS, SET A DIFFERENT DURATION AND ENABLES FAIL-SAFE
    options => options.SetDuration(TimeSpan.FromMinutes(2)).SetFailSafe(true)
);
```

This PR fixes this.