### PR TITLE
Bump key NuGet dependencies

### DIFF
--- a/Oqtane.Client/Oqtane.Client.csproj
+++ b/Oqtane.Client/Oqtane.Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
     <RootNamespace>Oqtane</RootNamespace>
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Localization" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
-    <PackageReference Include="Radzen.Blazor" Version="10.4.9" />
+    <PackageReference Include="Radzen.Blazor" Version="11.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Oqtane.Package/Oqtane.Client.nuspec
+++ b/Oqtane.Package/Oqtane.Client.nuspec
@@ -23,7 +23,7 @@
         <dependency id="Microsoft.AspNetCore.Components.WebAssembly.Authentication" version="10.0.9" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Localization" version="10.0.9" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.Http" version="10.0.9" exclude="Build,Analyzers" />
-        <dependency id="Radzen.Blazor" version="10.4.9" exclude="Build,Analyzers" />
+        <dependency id="Radzen.Blazor" version="11.1.13" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>

--- a/Oqtane.Package/Oqtane.Server.nuspec
+++ b/Oqtane.Package/Oqtane.Server.nuspec
@@ -27,7 +27,7 @@
         <dependency id="Microsoft.Extensions.Caching.StackExchangeRedis" version="10.0.9" exclude="Build,Analyzers" />
         <dependency id="SixLabors.ImageSharp" version="3.1.12" exclude="Build,Analyzers" />
         <dependency id="HtmlAgilityPack" version="1.12.4" exclude="Build,Analyzers" />
-        <dependency id="Swashbuckle.AspNetCore" version="10.2.1" exclude="Build,Analyzers" />
+        <dependency id="Swashbuckle.AspNetCore" version="10.2.3" exclude="Build,Analyzers" />
         <dependency id="MailKit" version="4.17.0" exclude="Build,Analyzers" />
         <dependency id="ZiggyCreatures.FusionCache" version="2.6.0" exclude="Build,Analyzers" />
         <dependency id="ZiggyCreatures.FusionCache.Serialization.SystemTextJson" version="2.6.0" exclude="Build,Analyzers" />
@@ -35,7 +35,7 @@
         <dependency id="MySql.Data" version="9.7.0" exclude="Build,Analyzers" />
         <dependency id="MySql.EntityFrameworkCore" version="10.0.7" exclude="Build,Analyzers" />
         <dependency id="EFCore.NamingConventions" version="10.0.1" exclude="Build,Analyzers" />
-        <dependency id="Npgsql.EntityFrameworkCore.PostgreSQL" version="10.0.2" exclude="Build,Analyzers" />
+        <dependency id="Npgsql.EntityFrameworkCore.PostgreSQL" version="10.0.3" exclude="Build,Analyzers" />
         <dependency id="Microsoft.EntityFrameworkCore.Sqlite" version="10.0.9" exclude="Build,Analyzers" />
         <dependency id="SQLitePCLRaw.bundle_e_sqlite3" version="3.0.3" exclude="Build,Analyzers" />
         <dependency id="Microsoft.EntityFrameworkCore.SqlServer" version="10.0.9" exclude="Build,Analyzers" />

--- a/Oqtane.Package/Oqtane.Shared.nuspec
+++ b/Oqtane.Package/Oqtane.Shared.nuspec
@@ -20,7 +20,7 @@
       <group targetFramework="net10.0">
         <dependency id="Microsoft.EntityFrameworkCore" version="10.0.9" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.9" exclude="Build,Analyzers" />
-        <dependency id="NodaTime" version="3.3.2" exclude="Build,Analyzers" />
+        <dependency id="NodaTime" version="3.3.3" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>

--- a/Oqtane.Server/Oqtane.Server.csproj
+++ b/Oqtane.Server/Oqtane.Server.csproj
@@ -34,9 +34,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.9" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="[3.1.12]" /> <!-- ImageSharp 3.1.12 is pinned as to license compatibility -->
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="ZiggyCreatures.FusionCache" Version="2.6.0" />
     <PackageReference Include="ZiggyCreatures.FusionCache.Serialization.SystemTextJson" Version="2.6.0" />
@@ -49,7 +49,7 @@
     <PackageReference Include="MySql.EntityFrameworkCore" Version="10.0.7" />
     <!-- PostgreSQL Database Provider Dependencies -->
     <PackageReference Include="EFCore.NamingConventions" Version="10.0.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
     <!-- SQLite Database Provider Dependencies -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />

--- a/Oqtane.Shared/Oqtane.Shared.csproj
+++ b/Oqtane.Shared/Oqtane.Shared.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
-    <PackageReference Include="NodaTime" Version="3.3.2" />
+    <PackageReference Include="NodaTime" Version="3.3.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updates dependency versions across client, server, shared, and package specs to keep runtime and published package metadata aligned. This includes upgrading Radzen.Blazor, Swashbuckle.AspNetCore, Npgsql.EntityFrameworkCore.PostgreSQL, and NodaTime, and explicitly pinning SixLabors.ImageSharp to 3.1.12 for license compatibility.