### PR TITLE
fix #6308 - localize page names in menu and breadcrumb theme controls

### DIFF
--- a/Oqtane.Client/Themes/Controls/Theme/Breadcrumbs.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/Breadcrumbs.razor
@@ -1,5 +1,7 @@
-﻿@namespace Oqtane.Themes.Controls
-@inherits ThemeControlBase       
+@namespace Oqtane.Themes.Controls
+@inherits ThemeControlBase
+@inject IStringLocalizerFactory LocalizerFactory
+@inject IStringLocalizer<SharedResources> SharedLocalizer
 
 @if (BreadCrumbPages.Any())
 {
@@ -10,7 +12,7 @@
                 if (p.PageId == PageState.Page.PageId)
                 {
                     <li class="breadcrumb-item active">
-                        <a href="@NavigateUrl(p.Path)">@p.Name</a>
+                        <a href="@NavigateUrl(p.Path)">@GetName(p)</a>
                     </li>
                 }
                 else
@@ -18,11 +20,11 @@
                     <li class="breadcrumb-item">
                         @if(p.IsClickable)
                         {
-                            <a href="@NavigateUrl(p.Path)">@p.Name</a>
+                            <a href="@NavigateUrl(p.Path)">@GetName(p)</a>
                         }
                         else
                         {
-                            @p.Name
+                            @GetName(p)
                         }
 
                     </li>
@@ -35,7 +37,41 @@
 @code {
 
     protected IEnumerable<Page> BreadCrumbPages => GetBreadCrumbPages().Reverse().ToList();
- 
+
+    private IStringLocalizer _themeLocalizer;
+    private string _themeType;
+
+    protected override void OnParametersSet()
+    {
+        if (_themeType != PageState.Page.ThemeType)
+        {
+            _themeType = PageState.Page.ThemeType;
+            try
+            {
+                _themeLocalizer = LocalizerFactory.Create(_themeType);
+            }
+            catch
+            {
+                _themeLocalizer = null; // theme type could not be resolved
+            }
+        }
+    }
+
+    private string GetName(Page page)
+    {
+        // page names are localized using the page name as the static resource key - the current theme's resources are searched first
+        // so that theme developers can provide their own translations, then shared resources (following the same convention as the Admin Dashboard)
+        if (_themeLocalizer != null)
+        {
+            var name = _themeLocalizer[page.Name];
+            if (!name.ResourceNotFound)
+            {
+                return name;
+            }
+        }
+        return SharedLocalizer[page.Name];
+    }
+
     private IEnumerable<Page> GetBreadCrumbPages()
     {
         var page = PageState.Page;

--- a/Oqtane.Client/Themes/Controls/Theme/MenuItemsBase.cs
+++ b/Oqtane.Client/Themes/Controls/Theme/MenuItemsBase.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 
 using Oqtane.Models;
 using Oqtane.UI;
@@ -10,11 +11,51 @@ namespace Oqtane.Themes.Controls
 {
     public abstract class MenuItemsBase : MenuBase
     {
+        [Inject]
+        protected IStringLocalizerFactory LocalizerFactory { get; set; }
+
+        [Inject]
+        protected IStringLocalizer<SharedResources> SharedLocalizer { get; set; }
+
         [Parameter()]
         public Page ParentPage { get; set; }
 
         [Parameter()]
         public IEnumerable<Page> Pages { get; set; }
+
+        private IStringLocalizer _themeLocalizer;
+        private string _themeType;
+
+        protected override void OnParametersSet()
+        {
+            if (_themeType != PageState.Page.ThemeType)
+            {
+                _themeType = PageState.Page.ThemeType;
+                try
+                {
+                    _themeLocalizer = LocalizerFactory.Create(_themeType);
+                }
+                catch
+                {
+                    _themeLocalizer = null; // theme type could not be resolved
+                }
+            }
+        }
+
+        protected virtual string GetName(Page page)
+        {
+            // page names are localized using the page name as the static resource key - the current theme's resources are searched first
+            // so that theme developers can provide their own translations, then shared resources (following the same convention as the Admin Dashboard)
+            if (_themeLocalizer != null)
+            {
+                var name = _themeLocalizer[page.Name];
+                if (!name.ResourceNotFound)
+                {
+                    return name;
+                }
+            }
+            return SharedLocalizer[page.Name];
+        }
 
         protected IEnumerable<Page> GetChildPages()
         {

--- a/Oqtane.Client/Themes/Controls/Theme/MenuItemsHorizontal.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/MenuItemsHorizontal.razor
@@ -18,7 +18,7 @@
                 <a class="nav-link active px-3" @attributes="_attributes">
                     <span class="w-100" data-bs-toggle="collapse" data-bs-target=".navbar-collapse.show">
                         <span class="@childPage.Icon" aria-hidden="true" />
-                        @childPage.Name <span class="visually-hidden-focusable">(current)</span>
+                        @GetName(childPage) <span class="visually-hidden-focusable">(current)</span>
                     </span>
                 </a>
             }
@@ -27,7 +27,7 @@
                 <a class="nav-link px-3" @attributes="_attributes">
                     <span class="w-100" data-bs-toggle="collapse" data-bs-target=".navbar-collapse.show">
                         <span class="@childPage.Icon" aria-hidden="true" />
-                        @childPage.Name
+                        @GetName(childPage)
                     </span>
                 </a>
             }
@@ -54,7 +54,7 @@ else
                         <a class="nav-link active" @attributes="_attributes">
                             <span class="w-100" data-bs-toggle="collapse" data-bs-target=".navbar-collapse.show">
                                 <span class="@childPage.Icon" aria-hidden="true" />
-                                @childPage.Name <span class="visually-hidden-focusable">(current)</span>
+                                @GetName(childPage) <span class="visually-hidden-focusable">(current)</span>
                             </span>
                         </a>
                     </li>
@@ -65,7 +65,7 @@ else
                         <a class="nav-link" @attributes="_attributes">
                             <span class="w-100" data-bs-toggle="collapse" data-bs-target=".navbar-collapse.show">
                                 <span class="@childPage.Icon" aria-hidden="true" />
-                                @childPage.Name
+                                @GetName(childPage)
                             </span>
                         </a>
                     </li>
@@ -78,7 +78,7 @@ else
                     <li class="nav-item dropdown active">
                         <a class="nav-link dropdown-toggle" id="@($"navbarDropdown{childPage.PageId}")" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" @attributes="_attributes">
                             <span class="@childPage.Icon" aria-hidden="true" />
-                            @childPage.Name <span class="visually-hidden-focusable">(current)</span>
+                            @GetName(childPage) <span class="visually-hidden-focusable">(current)</span>
                         </a>
                         <MenuItemsHorizontal ParentPage="childPage" Pages="Pages" />
                     </li>
@@ -88,7 +88,7 @@ else
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" id="@($"navbarDropdown{childPage.PageId}")" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" @attributes="_attributes">
                             <span class="@childPage.Icon" aria-hidden="true" />
-                            @childPage.Name
+                            @GetName(childPage)
                         </a>
                         <MenuItemsHorizontal ParentPage="childPage" Pages="Pages" />
                     </li>

--- a/Oqtane.Client/Themes/Controls/Theme/MenuItemsVertical.razor
+++ b/Oqtane.Client/Themes/Controls/Theme/MenuItemsVertical.razor
@@ -18,7 +18,7 @@
                 <a class="nav-link active" @attributes="_attributes">
                     <span class="w-100" data-bs-toggle="collapse" data-bs-target=".navbar-collapse.show">
                         <span class="@childPage.Icon" aria-hidden="true" />
-                        @childPage.Name <span class="visually-hidden-focusable">(current)</span>
+                        @GetName(childPage) <span class="visually-hidden-focusable">(current)</span>
                     </span>
                 </a>
             </li>
@@ -29,7 +29,7 @@
                 <a class="nav-link" @attributes="_attributes">
                     <span class="w-100" data-bs-toggle="collapse" data-bs-target=".navbar-collapse.show">
                         <span class="@childPage.Icon" aria-hidden="true" />
-                        @childPage.Name
+                        @GetName(childPage)
                     </span>
                 </a>
             </li>
@@ -58,7 +58,7 @@ else
                     <a class="nav-link active" @attributes="_attributes">
                         <span class="w-100" data-bs-toggle="collapse" data-bs-target=".navbar-collapse.show">
                             <span class="@childPage.Icon" aria-hidden="true" />
-                            @childPage.Name <span class="visually-hidden-focusable">(current)</span>
+                            @GetName(childPage) <span class="visually-hidden-focusable">(current)</span>
                         </span>
                     </a>
                 </li>
@@ -69,7 +69,7 @@ else
                     <a class="nav-link" @attributes="_attributes">
                         <span class="w-100" data-bs-toggle="collapse" data-bs-target=".navbar-collapse.show">
                             <span class="@childPage.Icon" aria-hidden="true" />
-                            @childPage.Name
+                            @GetName(childPage)
                         </span>
                     </a>
                 </li>


### PR DESCRIPTION
Resolves #6308

Localizes page names in the theme navigation controls (MenuItemsHorizontal, MenuItemsVertical, Breadcrumbs) using the page name as the static resource key. Resolution order:

1. **The current theme's resources** (via `LocalizerFactory.Create(PageState.Page.ThemeType)`, the same cross-assembly pattern used by `ModuleTitle`) - so theme developers can supply page name translations in the resx files they already own, without touching the framework.
2. **SharedResources** (the same convention the Admin Dashboard uses) - so admin page names and "Home" are localized immediately by existing language packs with no new strings.
3. **The raw page name** - pages without a matching resource render exactly as before, making this fully backward compatible.

`MenuItemsBase` gains a protected virtual `GetName(Page)` helper alongside the existing `GetUrl`/`GetTarget`; the menu item components render `@GetName(childPage)` instead of `@childPage.Name`, with no other markup changes (accessibility attributes preserved).

Tested on a fresh install: English rendering identical to before; a page-name key in the theme's resx takes precedence; a SharedResources value change is reflected in the menu; pages with no resource key fall back to their raw name.