### PR TITLE
Reset PermissionId before insert to allow auto-gen fix for #6335

### DIFF
--- a/Oqtane.Server/Repository/PermissionRepository.cs
+++ b/Oqtane.Server/Repository/PermissionRepository.cs
@@ -132,6 +132,7 @@ namespace Oqtane.Repository
                 }
                 else
                 {
+                    permission.PermissionId = 0; // allow identity column to auto-generate
                     db.Permission.Add(permission);
                     modified = true;
                 }


### PR DESCRIPTION
Set PermissionId to 0 before adding a new Permission entity so the identity column auto-generates the key, preventing potential conflicts with existing IDs.