### PR TITLE
Fusion Cache distributed stampede protection

### DIFF
--- a/Oqtane.Server/Extensions/OqtaneServiceCollectionExtensions.cs
+++ b/Oqtane.Server/Extensions/OqtaneServiceCollectionExtensions.cs
@@ -34,8 +34,10 @@ using Oqtane.Security;
 using Oqtane.Services;
 using Oqtane.Shared;
 using Radzen;
+using StackExchange.Redis;
 using ZiggyCreatures.Caching.Fusion;
 using ZiggyCreatures.Caching.Fusion.Backplane.StackExchangeRedis;
+using ZiggyCreatures.Caching.Fusion.Locking.Distributed.Redis;
 using ZiggyCreatures.Caching.Fusion.Serialization.SystemTextJson;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -603,12 +605,19 @@ namespace Microsoft.Extensions.DependencyInjection
             }
             else
             {
+                IConnectionMultiplexer muxer = ConnectionMultiplexer.Connect(configuration.GetConnectionString(SettingKeys.DistributedCacheKey));
+
+                services.AddStackExchangeRedisCache(options => {
+                    options.ConnectionMultiplexerFactory = () => Task.FromResult(muxer);
+                });
+
+                services.AddFusionCacheRedisDistributedLocker(options =>
+                {
+                    options.ConnectionMultiplexerFactory = () => Task.FromResult(muxer);
+                });
+
                 if (cacheSettings.GetValue<bool>("Distributed") && cacheSettings.GetValue<bool>("ScaleOut"))
                 {
-                    services.AddStackExchangeRedisCache(options => {
-                        options.Configuration = configuration.GetConnectionString(SettingKeys.DistributedCacheKey);
-                    });
-
                     // use memory cache (L1) with distributed cache (L2) and backplane for synchronization across instances
                     services.AddFusionCache()
                         .WithOptions(fusionCacheOptions)
@@ -617,15 +626,12 @@ namespace Microsoft.Extensions.DependencyInjection
                         .WithRegisteredDistributedCache()
                         .WithBackplane(new RedisBackplane(new RedisBackplaneOptions
                         {
-                            Configuration = configuration.GetConnectionString(SettingKeys.DistributedCacheKey)
-                        }));
+                            ConnectionMultiplexerFactory = () => Task.FromResult(muxer)
+                        }))
+                        .WithRegisteredDistributedLocker();
                 }
                 else
                 {
-                    services.AddStackExchangeRedisCache(options => {
-                        options.Configuration = configuration.GetConnectionString(SettingKeys.DistributedCacheKey);
-                    });
-
                     if (cacheSettings.GetValue<bool>("ScaleOut"))
                     {
                         // use memory cache (L1) with backplane for synchronization across instances
@@ -634,8 +640,9 @@ namespace Microsoft.Extensions.DependencyInjection
                             .WithDefaultEntryOptions(defaultCacheEntryOptions)
                             .WithBackplane(new RedisBackplane(new RedisBackplaneOptions
                             {
-                                Configuration = configuration.GetConnectionString(SettingKeys.DistributedCacheKey)
-                            }));
+                                ConnectionMultiplexerFactory = () => Task.FromResult(muxer)
+                            }))
+                            .WithRegisteredDistributedLocker();
                     }
                     else
                     {
@@ -644,7 +651,8 @@ namespace Microsoft.Extensions.DependencyInjection
                             .WithOptions(fusionCacheOptions)
                             .WithDefaultEntryOptions(defaultCacheEntryOptions)
                             .WithSerializer(new FusionCacheSystemTextJsonSerializer())
-                            .WithRegisteredDistributedCache();
+                            .WithRegisteredDistributedCache()
+                            .WithRegisteredDistributedLocker();
                     }
                 }
             }

--- a/Oqtane.Server/Infrastructure/DistributedLockManager.cs
+++ b/Oqtane.Server/Infrastructure/DistributedLockManager.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Caching.Distributed;
 using Oqtane.Shared;
+using ZiggyCreatures.Caching.Fusion;
 
 namespace Oqtane.Infrastructure
 {
@@ -14,10 +14,10 @@ namespace Oqtane.Infrastructure
 
     public class DistributedLockManager : IDistributedLockManager
     {
-        private readonly IDistributedCache _cache;
+        private readonly IFusionCache _cache;
         private readonly IConfigManager _config;
 
-        public DistributedLockManager(IDistributedCache cache, IConfigManager config)
+        public DistributedLockManager(IFusionCache cache, IConfigManager config)
         {
             _cache = cache;
             _config = config;
@@ -36,23 +36,31 @@ namespace Oqtane.Infrastructure
             Task.Delay(randomDelay);
 
             // attempt to get the distributed cache entry
-            var bytes = _cache.Get(key);
+            var cacheEntry = _cache.TryGet<string>(key, new()
+            {
+                SkipMemoryCacheRead = true,
+                SkipMemoryCacheWrite = true,
+                IsFailSafeEnabled = false
+            });
 
-            if (bytes != null)
+            if (cacheEntry.HasValue)
             {
                 // entry exists - an instance is executing
                 return false;
             }
 
             // entry does not exist - try to create it
-            bytes = Encoding.UTF8.GetBytes(value);
-            var options = new DistributedCacheEntryOptions
+            var options = new FusionCacheEntryOptions()
             {
-                AbsoluteExpirationRelativeToNow = expiration
+                SkipMemoryCacheRead = true,
+                SkipMemoryCacheWrite = true,
+                IsFailSafeEnabled = false,
+                Duration = expiration,
+                DistributedCacheDuration = expiration,
             };
             try
             {
-                _cache.Set(key, bytes, options);
+                _cache.Set(key, value, options);
                 return true;
             }
             catch

--- a/Oqtane.Server/Oqtane.Server.csproj
+++ b/Oqtane.Server/Oqtane.Server.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="ZiggyCreatures.FusionCache" Version="2.6.0" />
+    <PackageReference Include="ZiggyCreatures.FusionCache.Locking.Distributed.Redis" Version="2.6.0" />
     <PackageReference Include="ZiggyCreatures.FusionCache.Serialization.SystemTextJson" Version="2.6.0" />
     <PackageReference Include="ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis" Version="2.6.0" />
   </ItemGroup>


### PR DESCRIPTION
(Disclaimer: Only the PR summary was generated by AI)

This pull request enhances distributed caching and locking in the application by integrating FusionCache's distributed locker with Redis and refactoring the distributed lock manager to leverage FusionCache instead of the standard distributed cache. These changes improve reliability and consistency in distributed scenarios, especially for cache synchronization and distributed locking.

**Distributed Caching and Locking Improvements**

* Added `ZiggyCreatures.FusionCache.Locking.Distributed.Redis` as a dependency and integrated `FusionCacheRedisDistributedLocker` into the caching configuration, enabling distributed locking support via Redis.
* Updated the caching setup in `OqtaneServiceCollectionExtensions.cs` to register the distributed locker alongside the distributed cache and backplane, ensuring that distributed locking is available for both scale-out and non-scale-out configurations.

**Refactoring DistributedLockManager with FusionCache Integration**

* Refactored `DistributedLockManager` to use `IFusionCache` instead of `IDistributedCache`, updating lock acquisition logic to use FusionCache (L2 only), and consequently, the stampede protection from the DistributedLocker for enhanced safety

Docs at:

- https://github.com/ZiggyCreatures/FusionCache/issues/574
- https://github.com/ZiggyCreatures/FusionCache/blob/main/docs/StepByStep.md#10-distributed-stampede-protection-more
- https://github.com/ZiggyCreatures/FusionCache/blob/main/docs/StepByStep.md#11-optimize-redis-usage