### PR TITLE
since there can be multple aliases for the same tenantid/siteid, return the default alias

### DIFF
--- a/Oqtane.Server/Repository/AliasRepository.cs
+++ b/Oqtane.Server/Repository/AliasRepository.cs
@@ -124,9 +124,15 @@ namespace Oqtane.Repository
 
         public Alias GetAlias(int tenantId, int siteId)
         {
-            return _db.Alias
-                .AsNoTracking()
-                .FirstOrDefault(item => item.TenantId == tenantId && item.SiteId == siteId);
+            var aliases = GetAliases().Where(item => item.TenantId == tenantId && item.SiteId == siteId).ToList();
+            if (aliases.Any(item => item.IsDefault))
+            {
+                return aliases.FirstOrDefault(item => item.IsDefault);
+            }
+            else
+            {
+                return aliases.FirstOrDefault();
+            }
         }
 
         public void DeleteAlias(int aliasId)


### PR DESCRIPTION
and use the cache