### PR TITLE
allow Modules and Themes to access HttpContext when running in Static mode or Pre-rendering in Interactive mode

### DIFF
--- a/Oqtane.Client/Extensions/OqtaneServiceCollectionExtensions.cs
+++ b/Oqtane.Client/Extensions/OqtaneServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddOqtaneClientScopedServices(this IServiceCollection services)
         {
             services.AddScoped<SiteState>();
+            services.AddScoped<IHttpContext, ClientHttpContext>();
             services.AddScoped<IInstallationService, InstallationService>();
             services.AddScoped<IModuleDefinitionService, ModuleDefinitionService>();
             services.AddScoped<IThemeService, Oqtane.Services.ThemeService>();

--- a/Oqtane.Client/Modules/ModuleBase.cs
+++ b/Oqtane.Client/Modules/ModuleBase.cs
@@ -12,6 +12,7 @@ using Oqtane.Security;
 using Oqtane.Services;
 using Oqtane.Shared;
 using Oqtane.UI;
+using Oqtane.Interfaces;
 
 namespace Oqtane.Modules
 {
@@ -32,6 +33,9 @@ namespace Oqtane.Modules
 
         [Inject]
         protected SiteState SiteState { get; set; }
+
+        [Inject]
+        protected IHttpContext HttpContext { get; set; }
 
         [CascadingParameter]
         protected PageState PageState { get; set; }

--- a/Oqtane.Client/Providers/ClientHttpContext.cs
+++ b/Oqtane.Client/Providers/ClientHttpContext.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+using Oqtane.Interfaces;
+
+namespace Oqtane.Providers
+{
+    public class ClientHttpContext : IHttpContext
+    {
+        public HttpRequest Request { get; } = null;
+
+        public HttpResponse Response { get; } = null;
+
+        public ConnectionInfo Connection { get; } = null;
+
+        public WebSocketManager WebSockets { get; } = null;
+
+        public ClaimsPrincipal User { get; set; } = null;
+
+        public IDictionary<object, object> Items { get; } = null;
+
+        public string TraceIdentifier { get; } = null;
+
+        public ISession Session { get; } = null;
+    }
+}

--- a/Oqtane.Client/Themes/ThemeBase.cs
+++ b/Oqtane.Client/Themes/ThemeBase.cs
@@ -1,15 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using Oqtane.Enums;
+using Oqtane.Interfaces;
 using Oqtane.Models;
 using Oqtane.Modules;
 using Oqtane.Services;
 using Oqtane.Shared;
 using Oqtane.UI;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Oqtane.Themes
 {
@@ -25,6 +26,9 @@ namespace Oqtane.Themes
 
         [Inject]
         protected SiteState SiteState { get; set; }
+
+        [Inject]
+        protected IHttpContext HttpContext { get; set; }
 
         [CascadingParameter]
         protected PageState PageState { get; set; }

--- a/Oqtane.Package/Oqtane.Shared.nuspec
+++ b/Oqtane.Package/Oqtane.Shared.nuspec
@@ -20,6 +20,7 @@
       <group targetFramework="net10.0">
         <dependency id="Microsoft.EntityFrameworkCore" version="10.0.11" exclude="Build,Analyzers" />
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="10.0.11" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.AspNetCore.Http.Abstractions" version="2.2.0" exclude="Build,Analyzers" />
         <dependency id="NodaTime" version="3.3.3" exclude="Build,Analyzers" />
       </group>
     </dependencies>

--- a/Oqtane.Server/Extensions/OqtaneServiceCollectionExtensions.cs
+++ b/Oqtane.Server/Extensions/OqtaneServiceCollectionExtensions.cs
@@ -183,6 +183,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddOqtaneServerScopedServices(this IServiceCollection services)
         {
             services.AddScoped<Oqtane.Shared.SiteState>();
+            services.AddScoped<IHttpContext, ServerHttpContext>();
             services.AddScoped<IInstallationService, InstallationService>();
             services.AddScoped<IModuleDefinitionService, ModuleDefinitionService>();
             services.AddScoped<IThemeService, Oqtane.Services.ThemeService>();

--- a/Oqtane.Server/Providers/ServerHttpContext.cs
+++ b/Oqtane.Server/Providers/ServerHttpContext.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Oqtane.Interfaces;
+
+namespace Oqtane.Providers
+{
+    public class ServerHttpContext : IHttpContext
+    {
+        private readonly HttpContext _context;
+
+        public ServerHttpContext(IHttpContextAccessor httpContextAccessor)
+        {
+            _context = httpContextAccessor.HttpContext;
+        }
+
+        public HttpRequest Request
+        {
+            get
+            {
+                return (_context != null) ? _context.Request : null;
+            }
+        }
+
+        public HttpResponse Response
+        {
+            get
+            {
+                return (_context != null) ? _context.Response : null;
+            }
+        }
+
+        public ConnectionInfo Connection
+        {
+            get
+            {
+                return (_context != null) ? _context.Connection : null;
+            }
+        }
+
+        public WebSocketManager WebSockets
+        {
+            get
+            {
+                return (_context != null) ? _context.WebSockets : null;
+            }
+        }
+
+        public ClaimsPrincipal User
+        {
+            get
+            {
+                return (_context != null) ? _context.User : null;
+            }
+        }
+
+        public IDictionary<object, object> Items
+        {
+            get
+            {
+                return (_context != null) ? _context.Items : null;
+            }
+        }
+
+        public string TraceIdentifier
+        {
+            get
+            {
+                return (_context != null) ? _context.TraceIdentifier : null;
+            }
+        }
+
+        public ISession Session
+        {
+            get
+            {
+                return (_context != null) ? _context.Session : null;
+            }
+        }
+    }
+}

--- a/Oqtane.Shared/Interfaces/IHttpContext.cs
+++ b/Oqtane.Shared/Interfaces/IHttpContext.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Text;
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+
+namespace Oqtane.Interfaces
+{
+    public interface IHttpContext
+    {
+        public HttpRequest Request { get; }
+
+        public HttpResponse Response { get; }
+
+        public ConnectionInfo Connection { get; }
+
+        public WebSocketManager WebSockets { get; }
+
+        public ClaimsPrincipal User { get; }
+
+        public IDictionary<object, object> Items { get; }
+
+        public string TraceIdentifier { get; }
+
+        public ISession Session { get; }
+    }
+}

--- a/Oqtane.Shared/Oqtane.Shared.csproj
+++ b/Oqtane.Shared/Oqtane.Shared.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="NodaTime" Version="3.3.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Note that when running in Interactive mode and using Pre-rendering, Blazor does not allow you to modify the response (ie. set headers, cookies, etc..)