### PR TITLE
add defensive logic if user folder does not exist

### DIFF
--- a/Oqtane.Client/Modules/Controls/FileManager.razor
+++ b/Oqtane.Client/Modules/Controls/FileManager.razor
@@ -44,7 +44,7 @@
                     }
                     else
                     {
-                        if (FileId != -1 && _file != null && !UploadMultiple)
+                        if (ShowFile && FileId != -1 && _file != null && !UploadMultiple)
                         {
                             <input class="form-control" @bind="@_file.Name" disabled />
                         }
@@ -162,6 +162,9 @@
 
     [Parameter]
     public bool ShowFiles { get; set; } = true; // optional - for indicating whether a list of files should be displayed - default is true
+
+    [Parameter]
+    public bool ShowFile { get; set; } = true; // optional - for indicating whether a filename should be displayed when ShowFiles is false - default is true
 
     [Parameter]
     public bool ShowUpload { get; set; } = true; // optional - indicates if the file upload/delete and progress indicator section should be visible - default is true

--- a/Oqtane.Server/Managers/UserManager.cs
+++ b/Oqtane.Server/Managers/UserManager.cs
@@ -98,7 +98,8 @@ namespace Oqtane.Managers
                     }
                     user.Settings = _settings.GetSettings(EntityNames.User, user.UserId)
                         .ToDictionary(setting => setting.SettingName, setting => setting.SettingValue);
-                    user.FolderId = _folders.GetFolder(siteid, user.FolderPath).FolderId;
+                    var folder = _folders.GetFolder(siteid, user.FolderPath);
+                    user.FolderId = (folder != null) ? folder.FolderId : -1;
                 }
                 return user;
             });


### PR DESCRIPTION
in multi-site environments, some user accounts may not have a user folder for each site